### PR TITLE
Fix windows build

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -186,7 +186,7 @@ module.exports = {
       resolve: "gatsby-plugin-react-svg",
       options: {
         rule: {
-          include: /\/src\/assets\/icons\/.*\.svg$/, // See below to configure properly
+          include: /(?:\/src\/assets\/icons\/|\\src\\assets\\icons\\).*\.svg$/,
         },
       },
     },


### PR DESCRIPTION
Previously, we had `\/` hardcoded in a regex to inline SVGs. This would cause our dev and prod builds to fail on windows machines. This PR fixes this by adding an `or` condition to that merge request