### PR TITLE
Make sure focus ring has good contrast

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -32,6 +32,16 @@
   }
 }
 
+:focus {
+  outline-color: var(--darkPrimary);
+}
+
+//without this all <button>s have bad outline colors in firefox
+:focus::-moz-focus-inner {
+  padding: 0; //prevent weirdness just in case
+  border-color: var(--darkPrimary);
+}
+
 .listViewContent {
   margin: 0 auto;
   max-width: #{67318 * $baseUnit}px;


### PR DESCRIPTION
For some reason Firefox has a somewhat different thing going on with the focus ring. This solution works fine on both Linux and Windows so far, which matters due to the fact that Firefox attempts to use native OS UI styles for things such as buttons.