### PR TITLE
Added jest-axe and fixed a11y axe warnings

### DIFF
--- a/config/jest/setup-test-env.js
+++ b/config/jest/setup-test-env.js
@@ -1,4 +1,4 @@
 import React from "react"
 import "@testing-library/jest-dom/extend-expect"
+import 'jest-axe/extend-expect';
 import '../../__mocks__/modules';
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -5005,6 +5005,12 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
+    "axe-core": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.3.1.tgz",
+      "integrity": "sha512-gw1T0JptHPF4AdLLqE8yQq3Z7YvsYkpFmFWd84r6hnq/QoKRr8icYHFumhE7wYl5TVIHgVlchMyJsAYh0CfwCQ==",
+      "dev": true
+    },
     "axios": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
@@ -10761,7 +10767,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10779,11 +10786,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10796,15 +10805,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10907,7 +10919,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10917,6 +10930,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10929,17 +10943,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10956,6 +10973,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11028,7 +11046,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11038,6 +11057,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11113,7 +11133,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11143,6 +11164,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11160,6 +11182,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11198,11 +11221,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -14308,12 +14333,14 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true
         },
         "slice-ansi": {
           "version": "1.0.0",
@@ -14339,6 +14366,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -15273,6 +15301,18 @@
             "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "jest-axe": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-3.2.0.tgz",
+      "integrity": "sha512-QSQwSwG72/cpmhJU0fBsaUUvu9mb2uAqhccGQVG6JbIV8sK+aIXh8hYl7vxraMF/I6soQod1aqSdD/j7LjpVFQ==",
+      "dev": true,
+      "requires": {
+        "axe-core": "3.3.1",
+        "chalk": "2.4.2",
+        "jest-matcher-utils": "24.8.0",
+        "lodash.merge": "4.6.2"
       }
     },
     "jest-changed-files": {
@@ -17224,7 +17264,8 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -17247,6 +17288,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -22175,6 +22217,7 @@
       "version": "0.13.6",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
       "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "optional": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "babel-preset-gatsby": "^0.2.10",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
+    "jest-axe": "^3.2.0",
     "jest-dom": "^4.0.0",
     "jest-watch-typeahead": "^0.4.0",
     "prettier": "^1.18.2"

--- a/src/components/dark-light-button/dark-light-button.js
+++ b/src/components/dark-light-button/dark-light-button.js
@@ -8,10 +8,15 @@ export const DarkLightButton = () => {
   const {currentTheme, setTheme} = useContext(ThemeContext);
 
   return (
-    <button className={`${btnStyles.darkLightBtn} baseBtn`} onClick={() => {
-      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-      setTheme(newTheme);
-    }}>
+    <button
+      className={`${btnStyles.darkLightBtn} baseBtn`}
+      onClick={() => {
+        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+        setTheme(newTheme);
+      }}
+      aria-pressed={currentTheme === 'light'}
+      aria-label={"Dark mode"}
+    >
       {currentTheme === 'dark' ? <DarkIcon/> :  <LightIcon/>}
     </button>
   )

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -41,7 +41,16 @@ export const Layout = ({ location, children }) => {
       }}
     >
       <header className={layoutStyles.header}>
-        {!isBase && <Link className={`${layoutStyles.backBtn} baseBtn`} to={`/`}><BackIcon/></Link>}
+        {
+          !isBase &&
+          <Link
+            className={`${layoutStyles.backBtn} baseBtn`}
+            to={`/`}
+            aria-label="Go back"
+          >
+            <BackIcon/>
+          </Link>
+        }
         <DarkLightButton/>
       </header>
       <main className={!isBlogPost ? "listViewContent" : "postViewContent"}>{children}</main>

--- a/src/components/pic-title-header/pic-title-header.js
+++ b/src/components/pic-title-header/pic-title-header.js
@@ -38,6 +38,7 @@ export const PicTitleHeader = ({ image, socials, title, description, profile = f
         style={profile ? { borderRadius: "50%" } : {}}
         fixed={image}
         loading={"eager"}
+        alt={`${title} ${profile ? 'profile picture' : 'header image'}`}
       />
       <div className={styles.noMgContainer}>
         <h1 className={styles.title}>{title}</h1>

--- a/src/components/post-view/post-metadata/post-metadata.js
+++ b/src/components/post-view/post-metadata/post-metadata.js
@@ -14,6 +14,7 @@ export const PostMetadata = ({ post }) => {
           className="circleImg"
           fixed={author.profileImg.childImageSharp.mediumPic}
           data-testid="post-meta-author-pic"
+          alt={`Profile pic for ${author.name}`}
         />
       </div>
       <div className={styles.textDiv}>

--- a/src/pages/__tests__/index.test.js
+++ b/src/pages/__tests__/index.test.js
@@ -3,11 +3,12 @@
  */
 import React from "react"
 import { fireEvent, render } from "@testing-library/react"
+import ReactDOMServer from 'react-dom/server';
+import { axe } from 'jest-axe';
+import {onLinkClick, useStaticQuery} from 'gatsby';
 import { siteMetadata } from "../../../__mocks__/data/mock-site-metadata"
 import { MockPost } from "../../../__mocks__/data/mock-post"
-import { useStaticQuery } from "gatsby"
 import { MockUnicorn } from "../../../__mocks__/data/mock-unicorn"
-import {onLinkClick} from 'gatsby';
 import BlogIndex from "../index"
 
 beforeAll(() => {
@@ -22,8 +23,7 @@ afterAll(() => {
   useStaticQuery.mockImplementation(jest.fn())
 })
 
-test("Blog profile page renders", async () => {
-  const { baseElement, findByText, findByTestId } = render(
+const getElement = () => (
   <BlogIndex
     data={{
       site: {
@@ -47,7 +47,11 @@ test("Blog profile page renders", async () => {
     location={{
       pathname: '/post/this-post-name-here'
     }}
-  />)
+  />
+);
+
+test("Blog index page renders", async () => {
+  const { baseElement, findByText, findByTestId } = render(getElement());
 
   expect(baseElement).toBeInTheDocument();
   fireEvent.click(await findByText('Read More'));
@@ -63,4 +67,10 @@ test("Blog profile page renders", async () => {
 
   fireEvent.click(await findByTestId("authorPic"));
   expect(onLinkClick).toHaveBeenCalledTimes(5);
-})
+});
+
+test("Blog index page should not have axe errors", async () => {
+  const html = ReactDOMServer.renderToString(getElement());
+  const results = await axe(html);
+  expect(results).toHaveNoViolations();
+});

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -62,7 +62,7 @@ const BlogPostTemplateChild = (props) => {
           >
             <img
               src={post.frontmatter.license.footerImg}
-              alt={post.frontmatter.license.licenseType}
+              alt={post.frontmatter.license.licenceType}
             />
           </a>
         </div>

--- a/src/templates/blog-post.test.js
+++ b/src/templates/blog-post.test.js
@@ -4,6 +4,8 @@ import { siteMetadata } from "../../__mocks__/data/mock-site-metadata"
 import { MockPost } from "../../__mocks__/data/mock-post"
 import BlogPostTemplate from "./blog-post"
 import { onLinkClick, useStaticQuery } from "gatsby"
+import ReactDOMServer from 'react-dom/server';
+import { axe } from 'jest-axe';
 
 beforeAll(() => {
   useStaticQuery.mockImplementation(() => ({
@@ -17,8 +19,7 @@ afterAll(() => {
   useStaticQuery.mockImplementation(jest.fn())
 })
 
-test("Blog post page renders", async () => {
-  const { baseElement, findByText, findByTestId } = render(
+const getElement = () => (
   <BlogPostTemplate
     data={{
       site: {
@@ -29,7 +30,11 @@ test("Blog post page renders", async () => {
     location={{
       pathname: '/post/this-post-name-here'
     }}
-  />)
+  />
+)
+
+test("Blog post page renders", async () => {
+  const { baseElement, findByText, findByTestId } = render(getElement())
 
   expect(baseElement).toBeInTheDocument();
 
@@ -53,3 +58,10 @@ test("Blog post page renders", async () => {
 
 test.todo("SEO should apply");
 test.todo("Shows post footer image")
+
+
+test("Blog post page should not have axe errors", async () => {
+  const html = ReactDOMServer.renderToString(getElement());
+  const results = await axe(html);
+  expect(results).toHaveNoViolations();
+});

--- a/src/templates/blog-profile.test.js
+++ b/src/templates/blog-profile.test.js
@@ -7,6 +7,8 @@ import { MockUnicorn } from "../../__mocks__/data/mock-unicorn"
 import BlogProfile from "./blog-profile"
 import {onLinkClick as onAnalyticsLinkClick} from 'gatsby-plugin-google-analytics';
 import {onLinkClick as onGarsbyLinkClick} from 'gatsby';
+import ReactDOMServer from "react-dom/server"
+import { axe } from "jest-axe"
 
 beforeAll(() => {
   useStaticQuery.mockImplementation(() => ({
@@ -20,8 +22,7 @@ afterAll(() => {
   useStaticQuery.mockImplementation(jest.fn())
 })
 
-test("Blog profile page renders", async () => {
-  const { baseElement, findByText, findByTestId } = render(
+const getElement = () => (
   <BlogProfile
     data={{
       site: {
@@ -38,7 +39,11 @@ test("Blog profile page renders", async () => {
     location={{
       pathname: '/post/this-post-name-here'
     }}
-  />)
+  />
+)
+
+test("Blog profile page renders", async () => {
+  const { baseElement, findByText, findByTestId } = render(getElement());
 
   expect(baseElement).toBeInTheDocument();
   expect(await findByText('Joe')).toBeInTheDocument();
@@ -68,6 +73,10 @@ test("Blog profile page renders", async () => {
 
   fireEvent.click(await findByTestId("authorPic"));
   expect(onGarsbyLinkClick).toHaveBeenCalledTimes(4);
-
 })
 
+test("Blog profile page should not have axe errors", async () => {
+  const html = ReactDOMServer.renderToString(getElement());
+  const results = await axe(html);
+  expect(results).toHaveNoViolations();
+});


### PR DESCRIPTION
This PR adds the axe-jest automated A11Y best-practices toolset. Now, when tests are ran, we can ensure that we're catching _some_ of the A11Y errors that might be introduced into a PR

This PR also fixes some of the axe errors that were present in our codebase

Keep in mind: These tests do not find all errors, just the best practices. Manually QA is still needed