### PR TITLE
A11y fixes for filter, subheader, profile social links, and card list, etc

### DIFF
--- a/src/components/filter-search-bar/filter-listbox/filter-listbox.js
+++ b/src/components/filter-search-bar/filter-listbox/filter-listbox.js
@@ -124,6 +124,17 @@ export const FilterListbox = ({ tags = [], className, onFilter }) => {
   const windowSize = useWindowSize(150)
 
   /**
+   * Effects
+   */
+  useEffect(() => {
+    // When user escapes using "Esc" key, refocus on btn
+    if (!expanded && usedKeyboardLast && btnRef.current) {
+      btnRef.current.focus();
+    }
+  }, [expanded, usedKeyboardLast, btnRef])
+
+
+  /**
    * Value calcs
    */
   const appliedTagsStr = useMemo(() => {
@@ -236,7 +247,9 @@ export const FilterListbox = ({ tags = [], className, onFilter }) => {
           ref={btnRef}
           className={filterStyles.filterButton}
           aria-haspopup="listbox"
+          aria-expanded={expanded}
           aria-labelledby="exp_elem filter-button"
+          aria-owns="listBoxID"
           id="filter-button"
           {...buttonProps}
         >

--- a/src/components/layout/layout.js
+++ b/src/components/layout/layout.js
@@ -40,7 +40,7 @@ export const Layout = ({ location, children }) => {
         marginRight: `auto`,
       }}
     >
-      <header className={layoutStyles.header}>
+      <header className={layoutStyles.header} aria-label={"Toolbar for primary action buttons"}>
         {
           !isBase &&
           <Link
@@ -53,10 +53,7 @@ export const Layout = ({ location, children }) => {
         }
         <DarkLightButton/>
       </header>
-      <main className={!isBlogPost ? "listViewContent" : "postViewContent"}>{children}</main>
-      <footer>
-        {''}
-      </footer>
+      <div className={!isBlogPost ? "listViewContent" : "postViewContent"}>{children}</div>
     </div>
     </ThemeContext.Provider>
   )

--- a/src/components/pic-title-header/pic-title-header.js
+++ b/src/components/pic-title-header/pic-title-header.js
@@ -13,7 +13,7 @@ const getNamePossessive = (name) => {
 
 const SocialBtn = ({ icon, text, url }) => {
 
-  return <li className={`baseBtn lowercase prependIcon ${styles.socialBtnLink}`}>
+  return <li className={`baseBtn lowercase prependIcon ${styles.socialBtnLink}`} role="listitem">
     <OutboundLink className='unlink' target="_blank" rel="noopener" href={url}>
       <span className={styles.svgContainer} aria-hidden={true}>{icon}</span>
       <span>
@@ -57,7 +57,7 @@ export const PicTitleHeader = ({ image, socials, title, description, profile = f
         <div className={styles.subheader} aria-label={subHeaderAria}>
           {description}
         </div>
-        {socials && <ul className={styles.socialsContainer} aria-label={socialsAria}>
+        {socials && <ul className={styles.socialsContainer} aria-label={socialsAria} role="list">
           {
             socials.twitter &&
             <SocialBtn

--- a/src/components/pic-title-header/pic-title-header.js
+++ b/src/components/pic-title-header/pic-title-header.js
@@ -1,24 +1,26 @@
-import React, { useMemo } from "react"
+import React, { useCallback, useMemo } from "react"
 import Image from "gatsby-image"
 import styles from "./pic-title-header.module.scss"
-import GitHubIcon from '../../assets/icons/github.svg'
-import SiteIcon from '../../assets/icons/site.svg'
-import TwitterIcon from '../../assets/icons/twitter.svg'
+import GitHubIcon from "../../assets/icons/github.svg"
+import SiteIcon from "../../assets/icons/site.svg"
+import TwitterIcon from "../../assets/icons/twitter.svg"
 import { OutboundLink } from "gatsby-plugin-google-analytics"
 
-const SocialBtn = ({icon, text, url, name}) => {
-  const nameS = useMemo(() => {
-    if (name.endsWith('s')) return `${name}'`;
-    return `${name}'s`;
-  }, [name])
-  return <OutboundLink className='unlink baseBtn lowercase prependIcon' target="_blank" rel="noopener" href={url}>
-    <span className={styles.svgContainer} aria-hidden={true}>{icon}</span>
-    <span className='visually-hidden'>Link to {nameS}</span>
-    <span>
+const getNamePossessive = (name) => {
+  if (name.endsWith("s")) return `${name}'`
+  return `${name}'s`
+}
+
+const SocialBtn = ({ icon, text, url }) => {
+
+  return <li className={`baseBtn lowercase prependIcon ${styles.socialBtnLink}`}>
+    <OutboundLink className='unlink' target="_blank" rel="noopener" href={url}>
+      <span className={styles.svgContainer} aria-hidden={true}>{icon}</span>
+      <span>
       {text}
     </span>
-    <span className='visually-hidden'>account</span>
-  </OutboundLink>
+    </OutboundLink>
+  </li>
 }
 
 /**
@@ -31,23 +33,59 @@ const SocialBtn = ({icon, text, url, name}) => {
  * @constructor
  */
 export const PicTitleHeader = ({ image, socials, title, description, profile = false }) => {
+  const subHeaderAria = profile ? `A description of ${title}` :
+    "The site's about snippet"
+
+  const imgAlt = `${title} ${profile ? "profile picture" : "header image"}`
+  const imgStyle = profile ? { borderRadius: "50%" } : {}
+
+  const possessiveName = useMemo(() => profile && getNamePossessive(title), [title])
+
+  const socialsAria = profile && `${possessiveName} social media links`;
+
   return (
     <div className={styles.container}>
       <Image
         className={styles.headerPic}
-        style={profile ? { borderRadius: "50%" } : {}}
+        style={imgStyle}
         fixed={image}
         loading={"eager"}
-        alt={`${title} ${profile ? 'profile picture' : 'header image'}`}
+        alt={imgAlt}
       />
       <div className={styles.noMgContainer}>
         <h1 className={styles.title}>{title}</h1>
-        <h2 className={styles.subheader}>{description}</h2>
-        {socials && <div className={styles.socialsContainer}>
-          {socials.twitter && <SocialBtn icon={<TwitterIcon/>} text={'Twitter'} name={title} url={`https://twitter.com/${socials.twitter}`}/>}
-          {socials.github && <SocialBtn icon={<GitHubIcon/>} text={'GitHub'} name={title} url={`https://github.com/${socials.github}`}/>}
-          {socials.website && <SocialBtn icon={<SiteIcon/>} text={'Website'} name={title} url={socials.website}/>}
-        </div>}
+        <aside className={styles.subheader} aria-label={subHeaderAria}>
+          {description}
+        </aside>
+        {socials && <ul className={styles.socialsContainer} aria-label={socialsAria}>
+          {
+            socials.twitter &&
+            <SocialBtn
+              icon={<TwitterIcon/>}
+              text={"Twitter"}
+              name={title}
+              url={`https://twitter.com/${socials.twitter}`}
+            />
+          }
+          {
+            socials.github &&
+            <SocialBtn
+              icon={<GitHubIcon/>}
+              text={"GitHub"}
+              name={title}
+              url={`https://github.com/${socials.github}`}
+            />
+          }
+          {
+            socials.website &&
+            <SocialBtn
+              icon={<SiteIcon/>}
+              text={"Website"}
+              name={title}
+              url={socials.website}
+            />
+          }
+        </ul>}
       </div>
     </div>
   )

--- a/src/components/pic-title-header/pic-title-header.js
+++ b/src/components/pic-title-header/pic-title-header.js
@@ -44,7 +44,7 @@ export const PicTitleHeader = ({ image, socials, title, description, profile = f
   const socialsAria = profile && `${possessiveName} social media links`;
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} role="banner" aria-label={`Banner for ${title}`}>
       <Image
         className={styles.headerPic}
         style={imgStyle}
@@ -54,9 +54,9 @@ export const PicTitleHeader = ({ image, socials, title, description, profile = f
       />
       <div className={styles.noMgContainer}>
         <h1 className={styles.title}>{title}</h1>
-        <aside className={styles.subheader} aria-label={subHeaderAria}>
+        <div className={styles.subheader} aria-label={subHeaderAria}>
           {description}
-        </aside>
+        </div>
         {socials && <ul className={styles.socialsContainer} aria-label={socialsAria}>
           {
             socials.twitter &&

--- a/src/components/pic-title-header/pic-title-header.module.scss
+++ b/src/components/pic-title-header/pic-title-header.module.scss
@@ -73,6 +73,9 @@
   font-size: $baseUnit * 5px;
   color: var(--darkPrimary);
   flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }
 
 @media screen and (max-width: $endSmallScreenSize) {
@@ -114,5 +117,12 @@
     $mobileSvgSize: $baseUnit * 4px;
     height: $mobileSvgSize;
     width: $mobileSvgSize;
+  }
+}
+
+.socialBtnLink {
+  & > a {
+    display: flex;
+    flex-wrap: nowrap;
   }
 }

--- a/src/components/pic-title-header/pic-title-header.test.js
+++ b/src/components/pic-title-header/pic-title-header.test.js
@@ -17,6 +17,5 @@ test("Renders with the expected text", async () => {
   expect(baseElement).toBeInTheDocument();
   expect(await findByText("User")).toBeInTheDocument();
   expect(await findByText('Description')).toBeInTheDocument();
-  expect(await findByText('Link to User\'s')).toBeInTheDocument();
   expect(await findByText('Website')).toBeInTheDocument();
 })

--- a/src/components/post-card-list/post-card-list.js
+++ b/src/components/post-card-list/post-card-list.js
@@ -26,7 +26,7 @@ export const PostList = ({ posts = [], showWordCount = false, numberOfArticles, 
                        numberOfArticles={numberOfArticles}
                        onFilter={val => setFiltered(val && val.map(v => v.slug))}
       onSearch={val => setSearched(val && val.map(v => v.slug))}/>
-      <ul className={listStyle.postsListContainer} aria-label={listAria}>
+      <ul className={listStyle.postsListContainer} aria-label={listAria} role="list">
         {posts.map(({ node }) => {
           const slug = node.fields.slug;
           if (

--- a/src/components/post-card-list/post-card-list.js
+++ b/src/components/post-card-list/post-card-list.js
@@ -19,7 +19,7 @@ export const PostList = ({ posts = [], showWordCount = false, numberOfArticles, 
   const listAria = unicornData ? `List of posts written by ${unicornData.name}` : `List of posts`;
 
   return (
-    <div>
+    <main>
       <FilterSearchBar tags={tags}
                        showWordCount={showWordCount}
                        wordCount={wordCount}
@@ -52,7 +52,7 @@ export const PostList = ({ posts = [], showWordCount = false, numberOfArticles, 
           )
         })}
       </ul>
-    </div>
+    </main>
   )
 }
 

--- a/src/components/post-card-list/post-card-list.js
+++ b/src/components/post-card-list/post-card-list.js
@@ -3,10 +3,20 @@ import listStyle from "./post-card-list.module.scss"
 import { PostCard } from "../post-card"
 import { FilterSearchBar } from "../filter-search-bar"
 
-export const PostList = ({ posts = [], showWordCount = false, numberOfArticles, wordCount, tags }) => {
+/**
+ * @param posts
+ * @param showWordCount
+ * @param numberOfArticles
+ * @param wordCount
+ * @param tags
+ * @param unicornData - The data with the associated post. If present - you're on profile page
+ */
+export const PostList = ({ posts = [], showWordCount = false, numberOfArticles, wordCount, tags, unicornData }) => {
   // FIXME: This will not suffice with pagination added
   const [filtered, setFiltered] = useState(null)
   const [searched, setSearched] = useState(null)
+
+  const listAria = unicornData ? `List of posts written by ${unicornData.name}` : `List of posts`;
 
   return (
     <div>
@@ -16,7 +26,7 @@ export const PostList = ({ posts = [], showWordCount = false, numberOfArticles, 
                        numberOfArticles={numberOfArticles}
                        onFilter={val => setFiltered(val && val.map(v => v.slug))}
       onSearch={val => setSearched(val && val.map(v => v.slug))}/>
-      <div className={listStyle.postsListContainer}>
+      <ul className={listStyle.postsListContainer} aria-label={listAria}>
         {posts.map(({ node }) => {
           const slug = node.fields.slug;
           if (
@@ -41,7 +51,7 @@ export const PostList = ({ posts = [], showWordCount = false, numberOfArticles, 
             />
           )
         })}
-      </div>
+      </ul>
     </div>
   )
 }

--- a/src/components/post-card-list/post-card-list.module.scss
+++ b/src/components/post-card-list/post-card-list.module.scss
@@ -4,6 +4,9 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 
   &:empty::after {
     content: 'No results could be found, you might try making your search or filter less restrictive';

--- a/src/components/post-card/post-card.js
+++ b/src/components/post-card/post-card.js
@@ -19,7 +19,7 @@ export const PostCard = ({ title, author, published, tags, excerpt, description,
   const authorLink = useRef()
 
   return (
-    <li className={`${cardStyles.card} ${className}`} onClick={() => headerLink.current.click()}>
+    <li className={`${cardStyles.card} ${className}`} onClick={() => headerLink.current.click()} role="listitem">
       <div className={cardStyles.cardContents}>
         <Link
           to={`/posts${slug}`}

--- a/src/components/post-card/post-card.js
+++ b/src/components/post-card/post-card.js
@@ -19,7 +19,7 @@ export const PostCard = ({ title, author, published, tags, excerpt, description,
   const authorLink = useRef()
 
   return (
-    <div className={`${cardStyles.card} ${className}`} onClick={() => headerLink.current.click()}>
+    <li className={`${cardStyles.card} ${className}`} onClick={() => headerLink.current.click()}>
       <div className={cardStyles.cardContents}>
         <Link
           to={`/posts${slug}`}
@@ -80,7 +80,7 @@ export const PostCard = ({ title, author, published, tags, excerpt, description,
           }}
         />
       </Link>
-    </div>
+    </li>
   )
 }
 

--- a/src/components/post-view/post-title-header/post-title-header.js
+++ b/src/components/post-view/post-title-header/post-title-header.js
@@ -6,8 +6,12 @@ export const PostTitleHeader = ({ post }) => {
 
   return (
     <div className={styles.container}>
-      <div className={styles.tags}>{tags.map(tag => <p key={tag}>{tag}</p>)}</div>
       <h1 className={styles.title}>{title}</h1>
+      <ul aria-label="Post tags" role="list" className={styles.tags}>
+        {tags.map(tag =>
+          <li key={tag} role="listitem">{tag}</li>
+        )}
+      </ul>
       {subtitle && <h2 className={styles.subtitle}>{subtitle}</h2>}
     </div>
   )

--- a/src/components/post-view/post-title-header/post-title-header.module.scss
+++ b/src/components/post-view/post-title-header/post-title-header.module.scss
@@ -2,6 +2,15 @@
 
 .container {
   max-width: 768px;
+  display: flex;
+  flex-direction: column;
+}
+
+.tags {
+  order: -1;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .tags > * {

--- a/src/global.scss
+++ b/src/global.scss
@@ -210,3 +210,9 @@ svg:not(.strokeicon) {
     fill: var(--darkPrimary);
   }
 }
+
+.marginZeroAutoChild {
+  & > * {
+    margin: 0 auto;
+  }
+}

--- a/src/global.scss
+++ b/src/global.scss
@@ -152,7 +152,7 @@ $pendIconMarg: #{$baseUnit}px;
 }
 
 .post-body {
-  margin-bottom: #{$baseUnit * 4}px;
+  margin: 0 auto #{$baseUnit * 4}px;
   max-width: #{$baseUnit * 88}px;
 
   img {
@@ -163,6 +163,7 @@ $pendIconMarg: #{$baseUnit}px;
 }
 
 .post-lower-area {
+  margin: 0 auto;
   max-width: #{$baseUnit * 115}px;
 }
 

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -20,7 +20,7 @@ const getUnicornRoleListItems = (unicornInfo) => {
     // If there is an item ahead
     const shouldShowComma = arr[i + 1];
     return (
-      <li key={role.id}>
+      <li key={role.id} role="listitem">
         {role.prettyname}
         {
           shouldShowComma &&
@@ -101,7 +101,7 @@ const AboutUs = (props) => {
                   </div>
                   <div className={style.nameRoleDiv}>
                     <Link to={`/unicorns/${unicornInfo.id}`}>{unicornInfo.name}</Link>
-                    <ul aria-label="Roles assigned to this user" className={style.rolesList}>
+                    <ul aria-label="Roles assigned to this user" className={style.rolesList} role="list">
                       {roleListItems}
                     </ul>
                   </div>

--- a/src/pages/about.js
+++ b/src/pages/about.js
@@ -6,6 +6,31 @@ import Image from "gatsby-image"
 import style from "./about.module.scss"
 import { navigate } from "@reach/router"
 
+const getUnicornRoleListItems = (unicornInfo) => {
+  const unicornRoles = unicornInfo.roles;
+
+  if (unicornInfo.fields.isAuthor) {
+    unicornRoles.push({
+      id: 'author',
+      prettyname: 'Author'
+    })
+  }
+
+  return unicornInfo.roles.map((role, i, arr) => {
+    // If there is an item ahead
+    const shouldShowComma = arr[i + 1];
+    return (
+      <li key={role.id}>
+        {role.prettyname}
+        {
+          shouldShowComma &&
+          <span aria-hidden={true}>,&nbsp;</span>
+        }
+      </li>
+    )
+  });
+}
+
 const AboutUs = (props) => {
   const { data: { markdownRemark } } = props
 
@@ -56,41 +81,35 @@ const AboutUs = (props) => {
                  loading={"eager"}/>
           <h1>About Us</h1>
         </div>
-        <div
+        <main
           className={`${style.aboutBody} post-body`}
         >
           <div dangerouslySetInnerHTML={{ __html: markdownRemark.html }}/>
           {
-            unicornArr.map(unicornInfo => (
-              <div key={unicornInfo.id} className={style.contributorContainer}>
-                <div className='pointer' onClick={() => navigate(`/unicorns/${unicornInfo.id}`)}>
-                  <Image className="circleImg" fixed={unicornInfo.profileImg.childImageSharp.mediumPic}/>
+            unicornArr.map(unicornInfo => {
+              const roleListItems = getUnicornRoleListItems(unicornInfo);
+
+              const navigateToUni = () => navigate(`/unicorns/${unicornInfo.id}`);
+
+              return (
+                <div key={unicornInfo.id} className={style.contributorContainer}>
+                  <div className='pointer' onClick={navigateToUni}>
+                    <Image
+                      className="circleImg"
+                      fixed={unicornInfo.profileImg.childImageSharp.mediumPic}
+                    />
+                  </div>
+                  <div className={style.nameRoleDiv}>
+                    <Link to={`/unicorns/${unicornInfo.id}`}>{unicornInfo.name}</Link>
+                    <ul aria-label="Roles assigned to this user" className={style.rolesList}>
+                      {roleListItems}
+                    </ul>
+                  </div>
                 </div>
-                <div className={style.nameRoleDiv}>
-                  <Link to={`/unicorns/${unicornInfo.id}`}>{unicornInfo.name}</Link>
-                  <ul aria-label="Roles assigned to this user" className={style.rolesList}>
-                    {unicornInfo.roles.map((role, i, arr) => (
-                      <li key={role.id}>
-                        {role.prettyname}
-                        {
-                          (arr[i + 1] || (
-                            unicornInfo.fields.isAuthor &&
-                            i === arr.length - 1
-                          )) &&
-                            <span aria-hidden={true}>,&nbsp;</span>
-                        }
-                      </li>
-                    ))}
-                    {
-                      unicornInfo.fields.isAuthor &&
-                      <li>Author</li>
-                    }
-                  </ul>
-                </div>
-              </div>
-            ))
+              )
+            })
           }
-        </div>
+        </main>
       </div>
     </Layout>
   )

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,7 +21,7 @@ const BlogIndex = (props) => {
     const Description = <>
       {data.site.siteMetadata.description}
       <br/>
-      <Link to={"/about"} aria-label={"A link to the about us page"}><span aria-hidden={true}>Read More</span></Link>
+      <Link to={"/about"} aria-label={"The about us page"}><span aria-hidden={true}>Read More</span></Link>
     </>
 
     return (

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,7 +21,7 @@ const BlogIndex = (props) => {
     const Description = <>
       {data.site.siteMetadata.description}
       <br/>
-      <Link to={"/about"}>Read More</Link>
+      <Link to={"/about"} aria-label={"A link to the about us page"}><span aria-hidden={true}>Read More</span></Link>
     </>
 
     return (

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -1,8 +1,8 @@
-import React, {useContext, useState, useEffect} from "react"
+import React, { useContext, useState, useEffect } from "react"
 import { graphql } from "gatsby"
 import GitHubIcon from "../assets/icons/github.svg"
 import CommentsIcon from "../assets/icons/message.svg"
-import {DiscussionEmbed} from "disqus-react"
+import { DiscussionEmbed } from "disqus-react"
 
 import { Layout } from "../components/layout"
 import { SEO } from "../components/seo"
@@ -17,7 +17,7 @@ const BlogPostTemplateChild = (props) => {
 
   const { currentTheme } = useContext(ThemeContext)
 
-  const [disqusConfig, setDisqusConfig] = useState(currentTheme);
+  const [disqusConfig, setDisqusConfig] = useState(currentTheme)
 
   /**
    * Toggle the Disqus theme
@@ -27,7 +27,7 @@ const BlogPostTemplateChild = (props) => {
    */
   useEffect(() => {
     setTimeout(() => {
-      if (!setDisqusConfig || !currentTheme) return;
+      if (!setDisqusConfig || !currentTheme) return
       setDisqusConfig({
         url: `${siteData.siteUrl}posts${slug}`,
         // TODO: Fix this, this is causing comments to not apply to the correct
@@ -37,7 +37,7 @@ const BlogPostTemplateChild = (props) => {
         title: post.frontmatter.title,
       })
       // Must use a `useTimeout` so that this reloads AFTER the background animation
-    }, 600);
+    }, 600)
   }, [currentTheme])
 
   const GHLink = `https://github.com/${siteData.repoPath}/tree/master${
@@ -55,55 +55,57 @@ const BlogPostTemplateChild = (props) => {
         keywords={post.frontmatter.tags}
         type="article"
       />
-      <div role="banner" aria-label="Banner for the post" className="marginZeroAutoChild">
-        <PostTitleHeader post={post}/>
-        <PostMetadata post={post}/>
-      </div>
-      <main
-        className="post-body"
-        data-testid={"post-body-div"}
-        dangerouslySetInnerHTML={{ __html: post.html }}
-      />
-      <footer className="post-lower-area">
-        <div>
-          <a
-            aria-label={`Post licensed with ${post.frontmatter.license.displayName}`}
-            href={post.frontmatter.license.explainLink}
-            style={{ display: "table", margin: "0 auto" }}
-          >
-            <img
-              src={post.frontmatter.license.footerImg}
-              alt={post.frontmatter.license.licenceType}
-            />
-          </a>
-        </div>
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-          }}
-        >
-          <div className="btnLike prependIcon">
-            <CommentsIcon/>
-            <p>Comments</p>
-          </div>
-
-          <OutboundLink className="baseBtn prependIcon" href={GHLink}>
-            <GitHubIcon/>
-            View this Post on GitHub
-          </OutboundLink>
-
-          {/*<button className="baseBtn appendIcon" type="button">*/}
-          {/*  Share this Post*/}
-          {/*  <ShareIcon/>*/}
-          {/*</button>*/}
-        </div>
-        <DiscussionEmbed
-          shortname={siteData.disqusShortname}
-          config={disqusConfig}
-          key={currentTheme}
+      <article>
+        <header role="banner" className="marginZeroAutoChild">
+          <PostTitleHeader post={post}/>
+          <PostMetadata post={post}/>
+        </header>
+        <main
+          className="post-body"
+          data-testid={"post-body-div"}
+          dangerouslySetInnerHTML={{ __html: post.html }}
         />
-      </footer>
+        <footer role="contentinfo" className="post-lower-area">
+          <div>
+            <a
+              aria-label={`Post licensed with ${post.frontmatter.license.displayName}`}
+              href={post.frontmatter.license.explainLink}
+              style={{ display: "table", margin: "0 auto" }}
+            >
+              <img
+                src={post.frontmatter.license.footerImg}
+                alt={post.frontmatter.license.licenceType}
+              />
+            </a>
+          </div>
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+            }}
+          >
+            <div className="btnLike prependIcon">
+              <CommentsIcon/>
+              <p>Comments</p>
+            </div>
+
+            <OutboundLink className="baseBtn prependIcon" href={GHLink}>
+              <GitHubIcon/>
+              View this Post on GitHub
+            </OutboundLink>
+
+            {/*<button className="baseBtn appendIcon" type="button">*/}
+            {/*  Share this Post*/}
+            {/*  <ShareIcon/>*/}
+            {/*</button>*/}
+          </div>
+          <DiscussionEmbed
+            shortname={siteData.disqusShortname}
+            config={disqusConfig}
+            key={currentTheme}
+          />
+        </footer>
+      </article>
     </>
   )
 }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -55,7 +55,7 @@ const BlogPostTemplateChild = (props) => {
         keywords={post.frontmatter.tags}
         type="article"
       />
-      <div role="banner" aria-label="Banner for the post">
+      <div role="banner" aria-label="Banner for the post" className="marginZeroAutoChild">
         <PostTitleHeader post={post}/>
         <PostMetadata post={post}/>
       </div>

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -19,11 +19,20 @@ const BlogPostTemplateChild = (props) => {
 
   const [disqusConfig, setDisqusConfig] = useState(currentTheme);
 
+  /**
+   * Toggle the Disqus theme
+   * Disqus will by default try to guess what theme to pick based on the
+   * color of the background. As a result, we don't have to do much other than
+   * reload it after the page theme change is finished
+   */
   useEffect(() => {
     setTimeout(() => {
       if (!setDisqusConfig || !currentTheme) return;
       setDisqusConfig({
         url: `${siteData.siteUrl}posts${slug}`,
+        // TODO: Fix this, this is causing comments to not apply to the correct
+        //   post. This identifier should NEVER change and should ALWAYS match
+        //   `slug` only
         identifier: `${slug}${currentTheme}`,
         title: post.frontmatter.title,
       })
@@ -46,14 +55,16 @@ const BlogPostTemplateChild = (props) => {
         keywords={post.frontmatter.tags}
         type="article"
       />
-      <PostTitleHeader post={post}/>
-      <PostMetadata post={post}/>
-      <div
+      <div role="banner" aria-label="Banner for the post">
+        <PostTitleHeader post={post}/>
+        <PostMetadata post={post}/>
+      </div>
+      <main
         className="post-body"
         data-testid={"post-body-div"}
         dangerouslySetInnerHTML={{ __html: post.html }}
       />
-      <div className="post-lower-area">
+      <footer className="post-lower-area">
         <div>
           <a
             aria-label={`Post licensed with ${post.frontmatter.license.displayName}`}
@@ -92,7 +103,7 @@ const BlogPostTemplateChild = (props) => {
           config={disqusConfig}
           key={currentTheme}
         />
-      </div>
+      </footer>
     </>
   )
 }

--- a/src/templates/blog-profile.js
+++ b/src/templates/blog-profile.js
@@ -45,6 +45,7 @@ const BlogProfile = (props) => {
         posts={posts}
         tags={postTags}
         showWordCount={true}
+        unicornData={unicornData}
       />
     </Layout>
   )

--- a/src/utils/useOutsideClick.js
+++ b/src/utils/useOutsideClick.js
@@ -1,10 +1,10 @@
 import { useCallback, useEffect, useRef } from "react"
 
 export const useOutsideClick = (enable, onOutsideClick, parentRef) => {
-  const elRef = useRef()
+  const localElRef = useRef()
+  const elRef = parentRef || localElRef;
   const handleClickOutside = useCallback(e => {
-    const currElRef = parentRef || elRef;
-    if (currElRef.current.contains(e.target)) {
+    if (elRef.current.contains(e.target)) {
       // inside click
       return
     }


### PR DESCRIPTION
This PR provides some fixes for A11Y on the site that does the following:

- Focuses the button on the listbox after escape is pressed
- Adds missing aria attributes for the filter listbox
- Change subheader on profile and about page from h2 to `aside` (which fits MUCH better for the UX of the page)
- Move profile social links to a `ul`
- Move the cards list to a `ul`