### PR TITLE
Center the logo on mobile properly

### DIFF
--- a/src/components/pic-title-header/pic-title-header.module.scss
+++ b/src/components/pic-title-header/pic-title-header.module.scss
@@ -19,16 +19,16 @@
 }
 
 .headerPic {
-  $desktopImgSize: 300px;
-  max-width: $desktopImgSize;
-  max-height: $desktopImgSize;
-  margin-right: 48px;
+  $mobileImgSize: 150px;
+  max-width: $mobileImgSize;
+  max-height: $mobileImgSize;
   margin-bottom: 16px;
 
-  @include until($endSmallScreenSize) {
-    $mobileImgSize: 150px;
-    max-width: $mobileImgSize;
-    max-height: $mobileImgSize;
+  @include from($startMediumScreenSize) {
+    $desktopImgSize: 300px;
+    max-width: $desktopImgSize;
+    max-height: $desktopImgSize;
+    margin-right: 48px;
   }
 }
 


### PR DESCRIPTION
Previously, the logo on the mainpage was centered to the left

![Logo offset to the left](https://user-images.githubusercontent.com/9100169/66933068-5ee71180-efed-11e9-80ed-55fd4a6d2422.png)

With this PR, we've fixed centering the logo

![Logo properly centered](https://user-images.githubusercontent.com/9100169/66933048-57c00380-efed-11e9-874b-2042007b29e1.png)
