### PR TITLE
Fix: autolink-headings anchors positioning

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -162,6 +162,17 @@ $pendIconMarg: #{$baseUnit}px;
   margin: 0 auto #{$baseUnit * 4}px;
   max-width: #{$baseUnit * 88}px;
 
+  // Fix autolink-headings anchors positioning
+  .anchor {
+    line-height: 1;
+    margin-left: -24px;
+    padding: 0;
+
+    svg {
+      vertical-align: middle;
+    }
+  }
+
   img {
     margin: 0 auto;
     display: block;


### PR DESCRIPTION
Heading anchor links are now vertically centered on the first line of the heading.

Its padding is converted to additional negative margin so that the headings are flush with the keyline.