### PR TITLE
Fix disqus slug

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -33,7 +33,7 @@ const BlogPostTemplateChild = props => {
 				// TODO: Fix this, this is causing comments to not apply to the correct
 				//   post. This identifier should NEVER change and should ALWAYS match
 				//   `slug` only
-				identifier: `${slug}${currentTheme}`,
+				identifier: slug,
 				title: post.frontmatter.title
 			});
 			// Must use a `useTimeout` so that this reloads AFTER the background animation


### PR DESCRIPTION
I'll have to migrate the Disqus posts, but we were resetting the disqus identifier by the theme that was used to load it

https://sporadicallyyours.com/techbytes/2013/5/19/change-url-without-losing-comments