### PR TITLE
Align post tags to be more inline with other posts

### DIFF
--- a/content/blog/intro-to-html-css-and-javascript/index.md
+++ b/content/blog/intro-to-html-css-and-javascript/index.md
@@ -4,7 +4,7 @@
 	description: 'Introduction to the underlying concepts of HTML, CSS, and JavaScript and how they work together.',
 	published: '2019-12-16T13:45:00.284Z',
 	authors: ['MDutro'],
-	tags: ['HTML', 'CSS', 'JavaScript', 'Beginner'],
+	tags: ['html', 'css', 'javascript'],
 	attached: [],
 	license: 'publicdomain-zero-1'
 }


### PR DESCRIPTION
For all of our other posts, we have lowercase tags. Because of this post's deviance from that pattern, it was listing some of the values twice. 

Additionally, this removes one of the tags as it didn't seem to match up to an actual skillset someone might be searching for via tag search