### PR TITLE
Properly fix header logo

### DIFF
--- a/src/components/pic-title-header/pic-title-header.module.scss
+++ b/src/components/pic-title-header/pic-title-header.module.scss
@@ -22,12 +22,14 @@
 	$desktopImgSize: 300px;
 	max-width: $desktopImgSize;
 	max-height: $desktopImgSize;
+	margin-right: 48px;
 	margin-bottom: 16px;
 
 	@include until($endSmallScreenSize) {
 		$mobileImgSize: 150px;
 		max-width: $mobileImgSize;
 		max-height: $mobileImgSize;
+		margin-right: 0;
 	}
 }
 


### PR DESCRIPTION
Includes `margin-right` in all screen size but not in small breakpoint.