### PR TITLE
Include our social media links. Rename "Learn more" to "About us"

### DIFF
--- a/content/site/about-us.md
+++ b/content/site/about-us.md
@@ -1,7 +1,7 @@
 ---
 {
-    title: "About Us",
-    description: 'About Unicorn Utterances - who we are, what our goals are, and how we want to help others learn',
+  title: "About Us",
+  description: "About Unicorn Utterances - who we are, what our goals are, and how we want to help others learn",
 }
 ---
 
@@ -12,12 +12,52 @@ Whether it's from how memory is allocated in assembly or how to do complex CSS a
 Our content will have a wide range of subject matters, difficulty curves, and (we hope) perspectives. We want to make resources for the seasoned full-time developer just as we would a newcomer hobbyist and everyone between the two.
 
 We know this is a lofty goal, though, and we don't want to do it alone. If you're interested in helping out, [open a pull request](https://github.com/unicorn-utterances/unicorn-utterances/pulls) and help us reach others by providing translations, [help the code maintenance on this site](https://github.com/unicorn-utterances/unicorn-utterances/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22), [write a post for us](https://github.com/unicorn-utterances/unicorn-utterances#blog-posts), or [jump in on discussions and help other readers on our Discord](https://discord.gg/FMcvc6T).
- 
-If you’d like to get in touch with us, [our Discord](https://discord.gg/FMcvc6T) is probably the best way to do so.
+
+## Where to Find Us
+
+We have various social media accounts where we share updates and new content with folks! We also have a YouTube channel where we host livestreams, recorded talks, and much more educational content on computer science related topics.
+
+<ul aria-label="Our social media" style="display: flex; align-items: center; list-style: none; padding: 0; margin: 0; flex-wrap: wrap; justify-content: center;" role="list"> 
+    <li>
+        <a aria-label="Our YouTube Channel" style="display: inline-block; margin-right: 1rem" href="https://www.youtube.com/channel/UCpHleOoeCdHNe_2k5nCbWOA/" target="_blank" rel="noopener noreferrer sponsored">
+            <svg width="100" aria-hidden="true" viewBox="0 0 71.41206 50"><defs/><style>.st1{fill:var(--backgroundColor);} .st2{fill:var(--highImpactBlack);}</style><g transform="scale(.58824)"><path class="st2" fill-opacity="1" d="M118.9 13.3c-1.4-5.2-5.5-9.3-10.7-10.7C98.7 0 60.7 0 60.7 0s-38 0-47.5 2.5C8.1 3.9 3.9 8.1 2.5 13.3 0 22.8 0 42.5 0 42.5s0 19.8 2.5 29.2C3.9 76.9 8 81 13.2 82.4 22.8 85 60.7 85 60.7 85s38 0 47.5-2.5c5.2-1.4 9.3-5.5 10.7-10.7 2.5-9.5 2.5-29.2 2.5-29.2s.1-19.8-2.5-29.3z"/><path class="st1" d="M80.2 42.5L48.6 24.3v36.4z"/></g></svg>
+        </a>
+    </li>
+    
+    <li>
+        <a aria-label="Our Discord Server" style="display: inline-block; margin-right: 1rem"  href="https://discord.gg/FMcvc6T"  target="_blank" rel="noopener noreferrer sponsored">
+            <svg height="100" aria-hidden="true" viewBox="30 15 180 210"><style>.st0{fill:var(--highImpactBlack);}</style><path class="st0" d="M104.4 103.9c-5.7 0-10.2 5-10.2 11.1s4.6 11.1 10.2 11.1c5.7 0 10.2-5 10.2-11.1.1-6.1-4.5-11.1-10.2-11.1zM140.9 103.9c-5.7 0-10.2 5-10.2 11.1s4.6 11.1 10.2 11.1c5.7 0 10.2-5 10.2-11.1s-4.5-11.1-10.2-11.1z"/><path class="st0" d="M189.5 20h-134C44.2 20 35 29.2 35 40.6v135.2c0 11.4 9.2 20.6 20.5 20.6h113.4l-5.3-18.5 12.8 11.9 12.1 11.2 21.5 19V40.6c0-11.4-9.2-20.6-20.5-20.6zm-38.6 130.6s-3.6-4.3-6.6-8.1c13.1-3.7 18.1-11.9 18.1-11.9-4.1 2.7-8 4.6-11.5 5.9-5 2.1-9.8 3.5-14.5 4.3-9.6 1.8-18.4 1.3-25.9-.1-5.7-1.1-10.6-2.7-14.7-4.3-2.3-.9-4.8-2-7.3-3.4-.3-.2-.6-.3-.9-.5-.2-.1-.3-.2-.4-.3-1.8-1-2.8-1.7-2.8-1.7s4.8 8 17.5 11.8c-3 3.8-6.7 8.3-6.7 8.3-22.1-.7-30.5-15.2-30.5-15.2 0-32.2 14.4-58.3 14.4-58.3 14.4-10.8 28.1-10.5 28.1-10.5l1 1.2c-18 5.2-26.3 13.1-26.3 13.1s2.2-1.2 5.9-2.9c10.7-4.7 19.2-6 22.7-6.3.6-.1 1.1-.2 1.7-.2 6.1-.8 13-1 20.2-.2 9.5 1.1 19.7 3.9 30.1 9.6 0 0-7.9-7.5-24.9-12.7l1.4-1.6s13.7-.3 28.1 10.5c0 0 14.4 26.1 14.4 58.3 0 0-8.5 14.5-30.6 15.2z"/></svg>
+        </a>
+    </li>
+    
+    <li>
+        <a aria-label="Our LinkedIn" style="display: inline-block; margin-right: 1rem" href="https://www.linkedin.com/company/unicorn-utterances"  target="_blank" rel="noopener noreferrer sponsored">
+            <svg xmlns="http://www.w3.org/2000/svg" height="100" viewBox="0 0 24 24"><style>.st0{fill:var(--highImpactBlack);}</style><path d="M19 0h-14c-2.761 0-5 2.239-5 5v14c0 2.761 2.239 5 5 5h14c2.762 0 5-2.239 5-5v-14c0-2.761-2.238-5-5-5zm-11 19h-3v-11h3v11zm-1.5-12.268c-.966 0-1.75-.79-1.75-1.764s.784-1.764 1.75-1.764 1.75.79 1.75 1.764-.783 1.764-1.75 1.764zm13.5 12.268h-3v-5.604c0-3.368-4-3.113-4 0v5.604h-3v-11h3v1.765c1.396-2.586 7-2.777 7 2.476v6.759z" class="st0"/></svg>
+        </a>
+    </li>
+    
+    <li>
+        <a aria-label="Our Twitter" style="display: inline-block; margin-right: 1rem" href="https://twitter.com/unicornuttrncs"  target="_blank" rel="noopener noreferrer sponsored">
+            <svg height="100" aria-hidden="true" viewBox="0 0 400 400" xml:space="preserve"><style type="text/css">.st0{fill:var(--highImpactBlack);}.st1{fill:var(--backgroundColor) !important;}</style><g><path class="st0" d="M350,400H50c-27.6,0-50-22.4-50-50V50C0,22.4,22.4,0,50,0h300c27.6,0,50,22.4,50,50v300 C400,377.6,377.6,400,350,400z"/></g><g><path class="st1" d="M153.6,301.6c94.3,0,145.9-78.2,145.9-145.9c0-2.2,0-4.4-0.1-6.6c10-7.2,18.7-16.3,25.6-26.6 c-9.2,4.1-19.1,6.8-29.5,8.1c10.6-6.3,18.7-16.4,22.6-28.4c-9.9,5.9-20.9,10.1-32.6,12.4c-9.4-10-22.7-16.2-37.4-16.2 c-28.3,0-51.3,23-51.3,51.3c0,4,0.5,7.9,1.3,11.7c-42.6-2.1-80.4-22.6-105.7-53.6c-4.4,7.6-6.9,16.4-6.9,25.8 c0,17.8,9.1,33.5,22.8,42.7c-8.4-0.3-16.3-2.6-23.2-6.4c0,0.2,0,0.4,0,0.7c0,24.8,17.7,45.6,41.1,50.3c-4.3,1.2-8.8,1.8-13.5,1.8 c-3.3,0-6.5-0.3-9.6-0.9c6.5,20.4,25.5,35.2,47.9,35.6c-17.6,13.8-39.7,22-63.7,22c-4.1,0-8.2-0.2-12.2-0.7 C97.7,293.1,124.7,301.6,153.6,301.6"/></g></svg>
+        </a>
+    </li>
+    
+    <li>
+        <a aria-label="Our RSS Feed" style="display: inline-block; margin-right: 1rem" href="https://unicorn-utterances.com/rss.xml"  target="_blank" rel="noopener noreferrer sponsored">
+            <svg height="100" aria-hidden="true" viewBox="0 0 8 8"><style>.b{var(--highImpactBlack)}.s{fill: var(--backgroundColor) !important;}</style><rect class="b" width="8" height="8" rx="1.5" /><circle class="s" cx="2" cy="6" r="1" /><path class="s" d="m 1,4 a 3,3 0 0 1 3,3 h 1 a 4,4 0 0 0 -4,-4 z" /><path class="s" d="m 1,2 a 5,5 0 0 1 5,5 h 1 a 6,6 0 0 0 -6,-6 z" /></svg>
+        </a>
+    </li>
+</ul>
+
+As mentioned previously, we also have a Discord where we chat tech, help out with CS related problems and questions, and generally have a good time. If you're looking to get in touch with us, this is probably the best way to do so.
 
 ## Sponsors
 
-<a href="https://www.thepolyglotdeveloper.com/" target="_blank" rel="noopener noreferrer sponsored"><img alt="The Polyglot Developer" src="/sponsors/the-polyglot-developer.svg" width="300"/></a>
+<ul aria-label="Our sponsors" role="list" style="list-style: none; padding: 0; margin: 0;">
+<li>
+<a href="https://www.thepolyglotdeveloper.com/" target="_blank" rel="noopener noreferrer sponsored"><img alt="The Polyglot Developer" src="/sponsors/the-polyglot-developer.svg" style="width: 300px; margin: 0"/></a>
+</li>
+</ul>
 
 ## Statement of Ethics {#ethics}
 

--- a/src/templates/post-list.test.tsx
+++ b/src/templates/post-list.test.tsx
@@ -73,7 +73,7 @@ test("Blog index page renders", async () => {
 	const { baseElement, findByText, findAllByTestId } = render(getElement());
 
 	expect(baseElement).toBeInTheDocument();
-	fireEvent.click(await findByText("Read More"));
+	fireEvent.click(await findByText("About Us"));
 	expect(onLinkClick).toHaveBeenCalledTimes(1);
 
 	// Post cards

--- a/src/templates/post-list.tsx
+++ b/src/templates/post-list.tsx
@@ -21,9 +21,7 @@ const BlogPostListTemplate = (props: BlogPostListTemplateProps) => {
 		<>
 			{data.site.siteMetadata.description}
 			<br />
-			<Link to={"/about"} aria-label={"The about us page"}>
-				<span aria-hidden={true}>Read More</span>
-			</Link>
+			<Link to={"/about"}>About Us</Link>
 		</>
 	);
 


### PR DESCRIPTION
We previously did not include mention of our LinkedIn, Twitter, YouTube, or other avenues in our about page. This not only adds that but renames the confusingly explained "Learn more" link for a more self-explanitory "about us"