### PR TITLE
Add mention of the recorded talk on Angular templates

### DIFF
--- a/content/blog/angular-templates-start-to-source/index.md
+++ b/content/blog/angular-templates-start-to-source/index.md
@@ -37,7 +37,7 @@ It's going to be a long article, so please feel free to take breaks, grab a drin
 
 Sound like a fun time? Let's goooo! 🏃🌈
 
-> The contents of this post was also presented in a talk under the same name. You can [find the slides here](./slides.pptx).
+> The contents of this post was also presented in a talk under the same name. You can [find the slides here](./slides.pptx) or a live recording of that talk given by the post's author [on our YouTube channel](https://www.youtube.com/watch?v=7AilTMFPxqQ).
 
 # Introduction To Templates {#intro}
 


### PR DESCRIPTION
Now that we have our YouTube channel up-and-running with the edited video uploaded, I've added a link to the YouTube video inside of the post's aside at the top of the article alongside mention of the slides