### PR TITLE
Fix: Change open graph image meta tag to property from name

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -178,7 +178,7 @@ export const SEO = ({
 					content: `summary_large_image`
 				},
 				{
-					name: "og:image",
+					property: "og:image",
 					content: "https://unicorn-utterances.com/share-banner.png"
 				},
 				{


### PR DESCRIPTION
This will fix the `og:img` issue for sites that do not infer the image from other meta tags or allow `name=` instead of `property`.

This patch will appear not to work on `beta.unicorn-utterances.com` before it goes live in prod because it uses the canonical URL of production.