### PR TITLE
Fix: Open Graph canonical URL is post, author, or page URL

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -75,6 +75,7 @@ interface SEOProps {
 	publishedTime?: string;
 	editedTime?: string;
 	type?: "article" | "profile";
+	canonicalPath?: string;
 }
 
 export const SEO = ({
@@ -86,7 +87,8 @@ export const SEO = ({
 	keywords,
 	publishedTime,
 	editedTime,
-	type
+	type,
+	canonicalPath
 }: SEOProps) => {
 	const { site } = useStaticQuery(
 		graphql`
@@ -135,7 +137,7 @@ export const SEO = ({
 			meta={[
 				{
 					property: `og:url`,
-					content: siteData.siteUrl
+					content: siteData.siteUrl + (canonicalPath || "")
 				},
 				{
 					property: `og:site_name`,

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -9,11 +9,12 @@ import { OutboundLink } from "gatsby-plugin-google-analytics";
 class NotFoundPage extends React.Component {
 	render() {
 		const { data } = this.props as any;
+		const location = (this.props as any).location;
 		const { repoPath } = data.site.siteMetadata;
 
 		return (
-			<Layout location={(this.props as any).location}>
-				<SEO title="404: Not Found" />
+			<Layout location={location}>
+				<SEO title="404: Not Found" canonicalPath={location.pathname} />
 				<Image
 					fixed={data.file.childImageSharp.fixed}
 					imgStyle={{ objectFit: "contain" }}

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -83,6 +83,7 @@ const AboutUs = (props: any) => {
 			<SEO
 				title={post.frontmatter.title}
 				description={post.frontmatter.description || post.excerpt}
+				canonicalPath={props.location.pathname}
 			/>
 			<div className={style.container}>
 				<div className={style.headerTitle}>

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -57,6 +57,7 @@ const BlogPostTemplateChild = (props: BlogPostTemplateProps) => {
 				editedTime={post.frontmatter.edited}
 				keywords={post.frontmatter.tags}
 				type="article"
+				canonicalPath={props.location.pathname}
 			/>
 			<article>
 				<header role="banner" className="marginZeroAutoChild">

--- a/src/templates/blog-profile.tsx
+++ b/src/templates/blog-profile.tsx
@@ -50,6 +50,7 @@ const BlogProfile = (props: BlogProfileProps) => {
 				description={unicornData.description}
 				unicornData={unicornData}
 				type="profile"
+				canonicalPath={props.location.pathname}
 			/>
 			<PostListLayout
 				pageContext={pageContext}


### PR DESCRIPTION
Fixes open graph metadata and social media engagement matching the homepage when sharing a post to Facebook, LinkedIn, etc.

# Examples
- Sharing `https://unicorn-utterances.com/posts/how-to-pick-tech-stacks-for-new-projects/` will show the metadata and social media metrics for the post even if it's not an exact match
- Sharing `https://unicorn-utterances.com/page/2` will show the homepage metadata

# Notes
This doesn't implement redirects/canonical URLs for renamed users or posts since we don't have any yet. [This is a future avenue to explore when needed](https://developers.facebook.com/docs/sharing/webmasters/getting-started/versioned-link/#preserve-engagement-metrics).