### PR TITLE
Fix `confirm` and `thanks` page image

### DIFF
--- a/src/pages/confirm.tsx
+++ b/src/pages/confirm.tsx
@@ -13,9 +13,12 @@ const Confirm = (props: any) => {
 				style={{
 					margin: "0 auto",
 					display: "block",
-					width: "500px",
+					width: "calc(100vw - 40px)",
+					height: "calc(100vw - 40px)",
+					maxWidth: "450px",
+					maxHeight: "450px",
 					background: "var(--primary)",
-					borderRadius: "50%"
+					borderRadius: "100%"
 				}}
 				loading={"eager"}
 			/>

--- a/src/pages/thanks.tsx
+++ b/src/pages/thanks.tsx
@@ -13,9 +13,12 @@ const Thanks = (props: any) => {
 				style={{
 					margin: "0 auto",
 					display: "block",
-					width: "500px",
+					width: "calc(100vw - 40px)",
+					height: "calc(100vw - 40px)",
+					maxWidth: "450px",
+					maxHeight: "450px",
 					background: "var(--primary)",
-					borderRadius: "50%"
+					borderRadius: "100%"
 				}}
 				loading={"eager"}
 			/>


### PR DESCRIPTION
Fix image overflowing of confirm page
### Before
![Confirm page old](https://user-images.githubusercontent.com/44255990/76516871-3b33d480-6482-11ea-914a-470a051a1653.png)
### After
![Confirm page new](https://user-images.githubusercontent.com/44255990/76516901-48e95a00-6482-11ea-8767-41cc4fd3be48.png)
