### PR TITLE
Made filter dropdown scroll, fix cut off text, fix text alignment

### DIFF
--- a/src/components/filter-search-bar/filter-listbox/filter-listbox.module.scss
+++ b/src/components/filter-search-bar/filter-listbox/filter-listbox.module.scss
@@ -29,7 +29,7 @@ $btnPadding: 8px 16px 8px 15px;
 	appearance: none;
 	max-width: 100%;
 	display: flex;
-	justify-content: center;
+	align-items: center;
 	height: 100%;
 	padding: $btnPadding;
 	font-size: var(--filterBarFontSize);
@@ -65,7 +65,6 @@ $btnPadding: 8px 16px 8px 15px;
 .appliedTags {
 	white-space: nowrap;
 	text-overflow: ellipsis;
-	overflow: hidden;
 }
 
 .placeholder:not(.show) {
@@ -93,6 +92,7 @@ $btnPadding: 8px 16px 8px 15px;
 	z-index: 1;
 	margin: 0;
 	padding: 0;
+	overflow: hidden;
 	border: 1px solid transparent;
 	transition: background var(--animSpeed) var(--animStyle),
 		box-shadow var(--animSpeed) var(--animStyle),
@@ -112,7 +112,7 @@ $btnPadding: 8px 16px 8px 15px;
 }
 
 .listbox .spacer {
-	height: 48px;
+	height: 8px;
 }
 
 .option:first-of-type {
@@ -172,8 +172,9 @@ $btnPadding: 8px 16px 8px 15px;
 	color: var(--black);
 }
 
-.maxHeightHideContainer {
-	overflow: hidden;
-	max-height: 100%;
+.filterListHideContainer {
+	margin-top: 48px;
 	padding: $btnPadding;
+	max-height: 50vh;
+	overflow: auto;
 }

--- a/src/components/filter-search-bar/filter-listbox/filter-listbox.tsx
+++ b/src/components/filter-search-bar/filter-listbox/filter-listbox.tsx
@@ -278,7 +278,7 @@ export const FilterListbox = ({ tags = [], className }: FilterListboxProps) => {
 					poseKey={buttonHeight}
 					pose={expanded ? "expanded" : "hidden"}
 				>
-					<div className={filterStyles.maxHeightHideContainer}>
+					<div className={filterStyles.filterListHideContainer}>
 						<div className={filterStyles.spacer} />
 						{values.map((tag, index) => (
 							<FilterListItem


### PR DESCRIPTION
This PR addresses three issues with the filter dropdown:

1) The text was previously not vertically centered

|Before|After|
|---|---|
|![The text is not aligned vertically](https://user-images.githubusercontent.com/9100169/78744102-86bc8f80-7915-11ea-830e-09dc4e5daa5c.png)|![The text is now aligned](https://user-images.githubusercontent.com/9100169/78744110-91772480-7915-11ea-872b-10e4e28931b1.png)|

2) Anything with a lower-hanging letter (g, y, j, etc) was being cut off

|Before|After|
|---|---|
|![The lower-hanging letters are cut off](https://user-images.githubusercontent.com/9100169/78744155-b23f7a00-7915-11ea-898d-5ae0de11efa0.png)|![The letters are now displaying properly!](https://user-images.githubusercontent.com/9100169/78744179-c1262c80-7915-11ea-9977-fcfa91e9c021.png)|

3) The filter dropdown now scrolls

![A scrollbar is now present on the side to enable for more filters in the future](https://user-images.githubusercontent.com/9100169/78744217-dc913780-7915-11ea-9ca8-7b806a88b33f.png)
