### PR TITLE
Adds styling to `kbd` elements

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -411,3 +411,18 @@ li > ul > li {
 		color: var(--darkPrimary) !important;
 	}
 }
+
+kbd {
+	background-color: #eee;
+	border-radius: 3px;
+	border: 1px solid #b4b4b4;
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2),
+		0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
+	color: #333;
+	display: inline-block;
+	font-size: 0.85em;
+	font-weight: 700;
+	line-height: 1;
+	padding: 2px 4px;
+	white-space: nowrap;
+}


### PR DESCRIPTION
This adds styling of `kbd` elements to match some default styling:

![image](https://user-images.githubusercontent.com/9100169/80837862-875ee380-8bac-11ea-8429-b75147e22f5c.png)
