### PR TITLE
Fix: Use NetworkFirst strategy for "non-cachable" page-data

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -233,7 +233,42 @@ module.exports = {
 				icon: `src/assets/unicorn_utterances_logo_512.png`
 			}
 		},
-		`gatsby-plugin-offline`,
+		{
+			resolve: `gatsby-plugin-offline`,
+			options: {
+				workboxConfig: {
+					runtimeCaching: [
+						// Some as-is options from default config, explictly stated to avoid regressions from issues with `_.merge`ing into the default
+						{
+							// DEFAULT - Use cacheFirst since these don't need to be revalidated (same RegExp
+							// and same reason as above)
+							urlPattern: /(\.js$|\.css$|static\/)/,
+							handler: `CacheFirst`
+						},
+						{
+							// MODIFIED - page-data.json files are not content hashed
+							urlPattern: /^https?:.*\/page-data\/.*\/page-data\.json/,
+							handler: `NetworkFirst`
+						},
+						{
+							// MODIFIED - app-data.json is not content hashed
+							urlPattern: /^https?:.*\/page-data\/app-data\.json/,
+							handler: `NetworkFirst`
+						},
+						{
+							// DEFAULT - Add runtime caching of various other page resources
+							urlPattern: /^https?:.*\.(png|jpg|jpeg|webp|svg|gif|tiff|js|woff|woff2|json|css)$/,
+							handler: `StaleWhileRevalidate`
+						},
+						{
+							// DEFAULT - Google Fonts CSS (doesn't end in .css so we need to specify it)
+							urlPattern: /^https?:\/\/fonts\.googleapis\.com\/css/,
+							handler: `StaleWhileRevalidate`
+						}
+					]
+				}
+			}
+		},
 		`gatsby-plugin-react-helmet`,
 		{
 			resolve: "gatsby-plugin-react-svg",


### PR DESCRIPTION
Since we are a blog site, seeing a cached version of the homepage can lead to unintended side effects.

Switching from [`StaleWhileRevalidate`](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#stale-while-revalidate) to [`NetworkFirst`](https://developers.google.com/web/tools/workbox/modules/workbox-strategies#network_first_network_falling_back_to_cache) will add a small blocking round-trip to fetch the latest version of the page. While this makes browsing slightly slower, if it doesn't match the version from the disk cache (if any), it will also download it from the server. If the network fails (e.g. offline) it will still fall back to the cached version from the service worker cache.

I'd like to test this in integration before making it into release since it will depend on our caching policies too.

Related discussion: https://github.com/gatsbyjs/gatsby/pull/24940

Fixes: Issues discussed with @crutchcorn directly about the latest post not being available. 