### PR TITLE
Sort and cull tags for blog posts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,7 @@ Now that we've placed the file in the correct location, we need to add metadata 
     published: '2019-10-07T22:07:09.945Z',
     edited: '2020-02-02T22:07:09.945Z',
     authors: ['edpratti'],
-    tags: ['android', 'design', 'figma'],
+    tags: ['android', 'design'],
     attached: [],
     license: 'cc-by-nc-nd-4'
 }

--- a/content/blog/android-studio-setup-for-ryzen-cpus/index.md
+++ b/content/blog/android-studio-setup-for-ryzen-cpus/index.md
@@ -4,7 +4,7 @@
 	description: "Historically, the Android Emulator has only run on Intel CPUs. While that's no longer the case, it can be tricky to setup. Let's walk through how to do so!",
 	published: '2020-05-05T13:45:00.284Z',
 	authors: ['crutchcorn'],
-	tags: ['tooling', 'windows'],
+	tags: ['tools', 'windows'],
 	attached: [],
 	license: 'cc-by-nc-sa-4'
 }

--- a/content/blog/angular-templates-start-to-source/index.md
+++ b/content/blog/angular-templates-start-to-source/index.md
@@ -4,7 +4,7 @@
 	description: 'Learn how templates work in Angular. From the basics to being able to read Angular source code and write your own structural directives',
 	published: '2019-07-11T22:12:03.284Z',
 	authors: ['crutchcorn'],
-	tags: ['angular', 'templates'],
+	tags: ['angular', 'webdev'],
 	attached: [],
 	license: 'cc-by-nc-sa-4'
 }

--- a/content/blog/basic-overview-of-packets-and-osi/index.md
+++ b/content/blog/basic-overview-of-packets-and-osi/index.md
@@ -4,7 +4,7 @@
 	description: 'You use networking every day - even to read this text! Join us as we dive into explaining how we send data across a network and what the OSI model is.',
 	published: '2020-03-11T13:45:00.284Z',
 	authors: ['reikaze', 'crutchcorn'],
-	tags: ['networking', 'osi model'],
+	tags: ['networking'],
 	attached: [],
 	license: 'cc-by-nc-sa-4',
     series: "Networking 101",

--- a/content/blog/chess-knight-problem/index.md
+++ b/content/blog/chess-knight-problem/index.md
@@ -4,7 +4,7 @@
   description: "Here I present a quick and dirty solution to a common interview question where the solution is not nearly as complex as it may first appear.",
   published: "2020-04-29T12:27:06.284Z",
   authors: ["thodges314"],
-  tags: ["javascript", "computer science", "interview"],
+  tags: ["javascript", "computer science", "interviewing"],
   attached: [],
   license: "cc-by-4",
 }

--- a/content/blog/corbin-advice-to-technical-interviewers/index.md
+++ b/content/blog/corbin-advice-to-technical-interviewers/index.md
@@ -4,7 +4,7 @@
     description: "",
     published: '2021-05-03T22:12:03.284Z',
     authors: ['crutchcorn'],
-    tags: ['interviews'],
+    tags: ['interviewing'],
     attached: [],
     license: 'coderpad',
     originalLink: 'https://coderpad.io/blog/5-tips-for-tech-recruiting/'

--- a/content/blog/css-fundamentals/index.md
+++ b/content/blog/css-fundamentals/index.md
@@ -4,7 +4,7 @@
   description: "A beginners course for CSS box model, HTML defaults, flexible box layout, grid box layout, responsive design, selectors, units, and variables.",
   published: "2022-01-18T20:08:26.988Z",
   authors: ["ljtech"],
-  tags: ["CSS", "design"],
+  tags: ["css", "design"],
   attached: [],
   license: "cc-by-4",
   originalLink: "https://ljtech.ca/posts/css-fundamentals"

--- a/content/blog/debugging-nodejs-programs-using-chrome/index.md
+++ b/content/blog/debugging-nodejs-programs-using-chrome/index.md
@@ -4,7 +4,7 @@
 	description: 'Learn how to interactively debug your NodeJS applications using a GUI-based debugger built into Chrome.',
 	published: '2020-01-21T05:12:03.284Z',
 	authors: ['crutchcorn'],
-	tags: ['nodejs', 'debugging', 'chrome'],
+	tags: ['node', 'chrome'],
 	attached: [],
 	license: 'cc-by-nc-sa-4'
 }

--- a/content/blog/documentation-driven-development/index.md
+++ b/content/blog/documentation-driven-development/index.md
@@ -4,7 +4,7 @@ title: "A Better Way To Code: Documentation Driven Development",
 description: "",
 published: '2022-01-18T22:12:03.284Z',
 authors: ['crutchcorn'],
-tags: ['documentation', 'tdd', 'ddd'],
+tags: ['documentation', 'testing', 'opinion'],
 attached: [],
 license: 'cc-by-nc-sa-4',
 }

--- a/content/blog/five-suggestions-for-simpler-tests/index.md
+++ b/content/blog/five-suggestions-for-simpler-tests/index.md
@@ -4,7 +4,7 @@
   description: "Writing tests is an integral skill for any engineer to take on. Unfortunately, we often tend to over complicate our tests. Let's take a look at how we can simplify them for better tests overall",
   published: '2020-05-26T05:12:03.284Z',
   authors: ['crutchcorn', 'skatcat31'],
-  tags: ['testing', 'testing library', 'jest'],
+  tags: ['testing', 'jest'],
   attached: [],
   license: 'cc-by-nc-sa-4'
 }

--- a/content/blog/github-copilot-breaks-bad-interviews/index.md
+++ b/content/blog/github-copilot-breaks-bad-interviews/index.md
@@ -4,7 +4,7 @@
     description: "",
     published: '2021-07-22T22:12:03.284Z',
     authors: ['crutchcorn'],
-    tags: ['interviews', 'github copilot'],
+    tags: ['interviewing', 'opinion', 'copilot'],
     attached: [],
     license: 'coderpad',
     originalLink: 'https://coderpad.io/blog/github-copilot-breaks-bad-interviews/'

--- a/content/blog/github-copilot-wont-replace-devs/index.md
+++ b/content/blog/github-copilot-wont-replace-devs/index.md
@@ -4,7 +4,7 @@
     description: "",
     published: '2021-10-04T22:12:03.284Z',
     authors: ['crutchcorn'],
-    tags: ['github copilot', 'tools'],
+    tags: ['opinion', 'tools', 'copilot'],
     attached: [],
     license: 'cc-by-nc-sa-4'
 }

--- a/content/blog/hard-grids-and-baselines-android-design-fidelity/index.md
+++ b/content/blog/hard-grids-and-baselines-android-design-fidelity/index.md
@@ -5,7 +5,7 @@
     published: '2019-10-07T22:07:09.945Z',
     edited: '2020-02-02T22:07:09.945Z',
     authors: ['edpratti'],
-    tags: ['android', 'design', 'figma'],
+    tags: ['android', 'design'],
     attached: [],
     license: 'cc-by-nc-nd-4'
 }

--- a/content/blog/how-computers-speak/index.md
+++ b/content/blog/how-computers-speak/index.md
@@ -5,7 +5,7 @@
 	published: "2020-08-25T04:45:30.247Z",
 	edited: "2020-08-25T04:45:30.247Z",
 	authors: ["crutchcorn", "reikaze"],
-	tags: ["hardware", "javascript", "ast"],
+	tags: ["hardware", "javascript", "computer science"],
 	attached: [],
 	license: "cc-by-nc-sa-4"
 }

--- a/content/blog/how-to-get-started-with-net/index.md
+++ b/content/blog/how-to-get-started-with-net/index.md
@@ -4,7 +4,7 @@
     description: "Did you know that 35% of developers are using .NET? This is a great article to read to get started with .NET.",
     published: '2022-01-18T19:20:19.000Z',
     authors: ['bobrossrtx'],
-    tags: ['dotnet', 'c#'],
+    tags: ['dotnet', 'csharp'],
     attached: [],
     license: 'cc-by-4',
     originalLink: 'https://dev.to/bobrossrtx/how-to-get-started-with-net-50bh'

--- a/content/blog/how-to-pick-tech-stacks-for-new-projects/index.md
+++ b/content/blog/how-to-pick-tech-stacks-for-new-projects/index.md
@@ -4,7 +4,7 @@
 	description: 'I often get asked: "How do you pick a tech stack for your projects?". This article answers that by outlining what questions you should be asking early on',
 	published: '2020-03-02T05:12:03.284Z',
 	authors: ['crutchcorn'],
-	tags: ['engineering', 'advice'],
+	tags: ['opinion'],
 	attached: [],
 	license: 'cc-by-nc-sa-4'
 }

--- a/content/blog/integrating-android-code-in-unity/index.md
+++ b/content/blog/integrating-android-code-in-unity/index.md
@@ -4,7 +4,7 @@
 	description: 'Have you ever wanted to run native Java and Kotlin code from your mobile game written in Unity? Well you can! This article outlines how to set that up!',
 	published: '2020-01-04T05:12:03.284Z',
 	authors: ['crutchcorn'],
-	tags: ['unity', 'android', 'c#', 'java', 'kotlin'],
+	tags: ['unity', 'android', 'csharp', 'java'],
 	attached: [],
 	license: 'cc-by-nc-sa-4'
 }

--- a/content/blog/intro-to-web-accessability/index.md
+++ b/content/blog/intro-to-web-accessability/index.md
@@ -4,7 +4,7 @@
     description: "",
     published: '2021-05-30T22:12:03.284Z',
     authors: ['crutchcorn'],
-    tags: ['a11y', 'accessibility', 'web'],
+    tags: ['accessibility', 'webdev'],
     attached: [],
     license: 'coderpad',
     originalLink: 'https://coderpad.io/blog/introduction-to-web-accessibility-a11y/'

--- a/content/blog/intro-to-web-components-vanilla-js/index.md
+++ b/content/blog/intro-to-web-components-vanilla-js/index.md
@@ -4,7 +4,7 @@
     description: "",
     published: '2021-07-15T22:12:03.284Z',
     authors: ['crutchcorn'],
-    tags: ['javascript', 'html', 'web'],
+    tags: ['javascript', 'html', 'webdev'],
     attached: [],
     license: 'coderpad',
     originalLink: 'https://coderpad.io/blog/intro-to-web-components-vanilla-js/',

--- a/content/blog/joining-freenode-irc/index.md
+++ b/content/blog/joining-freenode-irc/index.md
@@ -4,7 +4,7 @@
     description: 'Basic (but detailed) instructions for setting up a Freenode IRC account through various clients',
     published: '2019-08-22T05:12:03.284Z',
     authors: ['fennifith'],
-    tags: ['irc'],
+    tags: ['tools'],
     attached: [],
     license: 'publicdomain-zero-1'
 }

--- a/content/blog/living-off-the-ipad-as-an-engineer/index.md
+++ b/content/blog/living-off-the-ipad-as-an-engineer/index.md
@@ -5,7 +5,7 @@
     published: '2021-02-11T00:00:00.000Z',
     edited: '2021-02-12T00:00:00.000Z',
     authors: ['pierremtb'],
-    tags: ['tooling', 'ipad'],
+    tags: ['tools', 'opinion'],
     attached: [],
     license: 'cc-by-nc-nd-4'
 }

--- a/content/blog/networking-101-udp-and-tcp/index.md
+++ b/content/blog/networking-101-udp-and-tcp/index.md
@@ -4,7 +4,7 @@
 	description: "If networking is analogous to physical mail, then let's take a look at the letters being sent themselves. Let's dive into UDP and TCP",
 	published: '2020-03-31T05:12:03.284Z',
 	authors: ['crutchcorn'],
-	tags: ['udp', 'networking'],
+	tags: ['networking'],
 	attached: [],
 	license: 'cc-by-nc-sa-4',
 	series: "Networking 101",

--- a/content/blog/non-decimal-numbers-in-tech/index.md
+++ b/content/blog/non-decimal-numbers-in-tech/index.md
@@ -4,7 +4,7 @@
   description: "Learn how to convert decimal to binary and hexadecimal, how CSS colors are calculated, and how your computer interprets letters into binary",
   published: "2019-11-07T05:12:03.284Z",
   authors: ["crutchcorn"],
-  tags: ["binary", "hexadecimal"],
+  tags: ["computer science"],
   attached: [],
   license: "cc-by-nc-sa-4",
 }

--- a/content/blog/pointers-and-references-cpp/index.md
+++ b/content/blog/pointers-and-references-cpp/index.md
@@ -4,7 +4,7 @@
     description: 'An overview of how pointers and references function in C/C++',
     published: '2020-06-02T09:40:00.000Z',
     authors: ['seanmiller'],
-    tags: ['computer science', 'c++'],
+    tags: ['computer science', 'cpp'],
     attached: [],
     license: 'cc-by-nc-nd-4'
 }

--- a/content/blog/pointers-and-references-cpp/index.md
+++ b/content/blog/pointers-and-references-cpp/index.md
@@ -4,7 +4,7 @@
     description: 'An overview of how pointers and references function in C/C++',
     published: '2020-06-02T09:40:00.000Z',
     authors: ['seanmiller'],
-    tags: ['computer science', 'cpp'],
+    tags: ['computer science', 'c++'],
     attached: [],
     license: 'cc-by-nc-nd-4'
 }

--- a/content/blog/setup-standard-version/index.md
+++ b/content/blog/setup-standard-version/index.md
@@ -4,7 +4,7 @@
 	description: "Whether creating comprehensive changelogs or just keeping track of git tags, releases matter. Learn how to automate your release process with conventional-commits!",
 	published: '2020-06-23T05:12:03.284Z',
 	authors: ['crutchcorn'],
-	tags: ['packaging', 'engineering', 'javascript'],
+	tags: ['npm', 'javascript'],
 	attached: [],
 	license: 'cc-by-nc-sa-4'
 }

--- a/content/blog/typescript-type-generics/index.md
+++ b/content/blog/typescript-type-generics/index.md
@@ -4,7 +4,7 @@
 	description: 'An introduction to the type generic functionality in TypeScript',
 	published: '2019-09-26T05:12:03.284Z',
 	authors: ['crutchcorn'],
-	tags: ['typescript', 'polymorphic functions', 'functional programming'],
+	tags: ['typescript'],
 	attached: [],
 	license: 'cc-by-nc-sa-4'
 }

--- a/content/blog/ultimate-windows-development-environment-guide/index.md
+++ b/content/blog/ultimate-windows-development-environment-guide/index.md
@@ -5,7 +5,7 @@
 	published: '2020-04-07T05:12:03.284Z',
 	edited: "2022-01-05T04:45:30.247Z",
 	authors: ['crutchcorn'],
-	tags: ['tooling', 'windows'],
+	tags: ['tools', 'windows'],
 	attached: [],
 	license: 'cc-by-nc-sa-4'
 }

--- a/content/blog/understanding-the-dom/index.md
+++ b/content/blog/understanding-the-dom/index.md
@@ -4,7 +4,7 @@
 	description: 'Learn how the browser internally handles HTML and CSS to show the user webpages on-screen',
 	published: '2019-11-26T22:12:03.284Z',
 	authors: ['crutchcorn'],
-	tags: ['dom', 'css', 'javascript', 'html'],
+	tags: ['webdev', 'css', 'javascript', 'html'],
 	attached: [],
 	license: 'cc-by-nc-sa-4'
 }

--- a/content/blog/uttering-hello-introduction-post/index.md
+++ b/content/blog/uttering-hello-introduction-post/index.md
@@ -4,7 +4,7 @@
     description: 'An introduction to Unicorn Utterances, including a mission statement and general roadmap',
     published: '2019-06-29T22:12:03.284Z',
     authors: ['crutchcorn'],
-    tags: ['community', 'announcements'],
+    tags: ['announcements'],
     attached: [],
     license: 'cc-by-4'
 }

--- a/content/blog/virtual-memory-overview/index.md
+++ b/content/blog/virtual-memory-overview/index.md
@@ -4,7 +4,7 @@
     description: 'An overview of how operating systems give processes their own address space.',
     published: '2020-05-19T12:45:00.000Z',
     authors: ['seanmiller'],
-    tags: ['computer science', 'c++'],
+    tags: ['computer science', 'cpp'],
     attached: [],
     license: 'cc-by-nc-nd-4'
 }

--- a/content/blog/virtual-memory-overview/index.md
+++ b/content/blog/virtual-memory-overview/index.md
@@ -4,7 +4,7 @@
     description: 'An overview of how operating systems give processes their own address space.',
     published: '2020-05-19T12:45:00.000Z',
     authors: ['seanmiller'],
-    tags: ['computer science', 'cpp'],
+    tags: ['computer science', 'c++'],
     attached: [],
     license: 'cc-by-nc-nd-4'
 }

--- a/content/blog/web-components-101-history/index.md
+++ b/content/blog/web-components-101-history/index.md
@@ -4,7 +4,7 @@
     description: "",
     published: '2021-12-21T22:12:03.284Z',
     authors: ['crutchcorn'],
-    tags: ['web components', 'history'],
+    tags: ['webdev', 'history'],
     attached: [],
     license: 'coderpad',
     originalLink: 'https://coderpad.io/blog/web-components-101-history/',

--- a/content/blog/web-components-101-lit-framework/index.md
+++ b/content/blog/web-components-101-lit-framework/index.md
@@ -4,7 +4,7 @@
     description: "",
     published: '2021-11-04T22:12:03.284Z',
     authors: ['crutchcorn'],
-    tags: ['web components', 'lit'],
+    tags: ['webdev', 'lit'],
     attached: [],
     license: 'coderpad',
     originalLink: 'https://coderpad.io/blog/web-components-101-lit-framework/',

--- a/content/blog/what-do-files-extensions-do/index.md
+++ b/content/blog/what-do-files-extensions-do/index.md
@@ -5,7 +5,7 @@
 	published: "2020-07-11T20:58:16.292Z",
 	edited: "2020-07-11T20:58:16.292Z",
 	authors: ["skatcat31"],
-	tags: ["files","extensions", "magic numbers"],
+	tags: ["computer science"],
 	attached: [],
 	license: "cc-by-nc-sa-4"
 }

--- a/content/blog/writing-better-angular-tests/index.md
+++ b/content/blog/writing-better-angular-tests/index.md
@@ -5,7 +5,7 @@
 	published: "2020-05-12T04:45:30.247Z",
 	edited: "2020-06-09T04:45:30.247Z",
 	authors: ["skatcat31"],
-	tags: ["testing", "unit tests", "angular"],
+	tags: ["testing", "angular"],
 	attached: [],
 	license: "cc-by-nc-sa-4"
 }

--- a/src/constants/search-and-filter-context/search-and-filter-context.ts
+++ b/src/constants/search-and-filter-context/search-and-filter-context.ts
@@ -37,7 +37,7 @@ export const usePostTagsFromNodes = <T extends { tags: PostInfo["tags"] }>(
     );
   }, [posts]);
 
-  return postTags;
+  return postTags.sort();
 };
 
 /**


### PR DESCRIPTION
@evelynhathaway pointed out to me how chaotic our tags list are on our homepage

![image](https://user-images.githubusercontent.com/9100169/149709160-f70f7a70-9aa5-4eb3-8984-cbeb1ae1b86a.png)

They're not sorted, there are weird tags that don't have any other content in them, and are generally not that helpful

I think a good way to fix that would be to keep our list as reasonably small as possible and simply monitor the list going forward.

After this was done, the list seems much more manageable

![image](https://user-images.githubusercontent.com/9100169/149709270-32d54a8f-6342-4b60-9bd6-bcd06f127034.png)
