### PR TITLE
fix: adds in privacy error detection and handling

### DIFF
--- a/src/components/privacy-error-boundary.tsx
+++ b/src/components/privacy-error-boundary.tsx
@@ -1,0 +1,43 @@
+import { Component, ErrorInfo } from "react";
+
+export class PrivacyErrorBoundary extends Component<{}, { hasError: boolean }> {
+  constructor(props: {}) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(error: unknown) {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.warn(error);
+    console.warn(errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return (
+        <p>
+          Something went wrong. This is where our Disqus comments should be. If
+          you&apos;re using privacy tools, they may be blocking this comment
+          system due to tracking concerns with the platform.
+          <br />
+          If that&apos;s the case, we&apos;d{" "}
+          <a
+            rel="nofollow noopener noreferrer"
+            target="_blank"
+            href="https://github.com/unicorn-utterances/unicorn-utterances/issues/24"
+          >
+            love to hear from you
+          </a>{" "}
+          about what type of comment system you&apos;d like to see implemented
+          instead.
+        </p>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/src/pages/posts/[slug].tsx
+++ b/src/pages/posts/[slug].tsx
@@ -30,6 +30,7 @@ import { siteMetadata } from "constants/site-config";
 import "react-medium-image-zoom/dist/styles.css";
 import path from "path";
 import { SeriesToC } from "components/series-toc";
+import { PrivacyErrorBoundary } from "components/privacy-error-boundary";
 
 type Props = {
   markdownHTML: string;
@@ -150,11 +151,13 @@ const Post = ({
             {/*  <ShareIcon/>*/}
             {/*</button>*/}
           </div>
-          <DiscussionEmbed
-            shortname={siteMetadata.disqusShortname}
-            config={disqusConfig}
-            key={colorMode}
-          />
+          <PrivacyErrorBoundary>
+            <DiscussionEmbed
+              shortname={siteMetadata.disqusShortname}
+              config={disqusConfig}
+              key={colorMode}
+            />
+          </PrivacyErrorBoundary>
         </footer>
       </article>
     </>


### PR DESCRIPTION
I use a privacy browser plugin called "[Privacy Badger](https://privacybadger.org/)" from the EFF. It's fairly popular and it's a suggested Firefox plugin.

When changing the theme on UU where Disqus is loaded (like a blog post), it will crash the entire page and leave it blank and unresponsive due to it never actually being loaded and the React component trying to do some cleanup.

This PR adds in an intermediary step and handles the error that occurs during this step, replacing it with a message encouraging the user to take a look at #24

Admittedly, this acts as a bit of fuel to the #24 fire, but this is a short-term solution

Closes #287

