### PR TITLE
feat: make styling more consistent

### DIFF
--- a/src/components/blog-post-layout/blog-post-layout.module.scss
+++ b/src/components/blog-post-layout/blog-post-layout.module.scss
@@ -11,14 +11,14 @@
 .centerContainer {
 	margin: 0 auto;
 	max-width: 100%;
+	flex-basis: 100%;
 }
 
 .rightContainer,
 .leftContainer {
-	top: 3rem;
+	top: 4rem;
 	overflow: auto;
-	height: calc(100vh - 10rem);
-	margin-top: 4rem;
+	height: calc(100vh - 6rem);
 	min-width: 220px;
 }
 

--- a/src/global.scss
+++ b/src/global.scss
@@ -157,7 +157,7 @@ $pendIconMarg: #{$baseUnit}px;
 
 .post-body {
   margin: 0 auto #{$baseUnit * 4}px;
-  max-width: #{$baseUnit * 88}px;
+  max-width: 768px;
   line-height: 1.7;
 
   // Fix autolink-headings anchors positioning

--- a/src/page-components/blog-post/suggested-articles/suggested-articles.module.scss
+++ b/src/page-components/blog-post/suggested-articles/suggested-articles.module.scss
@@ -5,6 +5,7 @@
 .list {
   list-style: none;
   margin: 0;
+  padding: 0;
 }
 
 .localCard {


### PR DESCRIPTION
Right now, if you move between pages there's a few problems with our styling:

1) The blog post width isn't consistent and can lead to weird content shifts
2) The header doesn't align with the body contents
3) The sidebars don't have enough spacing when scrolled, but too much by default

This PR makes our styling more consistent between pages

# Before

![image](https://user-images.githubusercontent.com/9100169/153357504-faab5f8a-78cd-4900-afaf-af5a2f6cb671.png)

# After

![image](https://user-images.githubusercontent.com/9100169/153357546-5d3df941-c9a8-4a7f-a4e5-17718de73553.png)

