### PR TITLE
feat: improve tab styling

### DIFF
--- a/src/shiki.scss
+++ b/src/shiki.scss
@@ -33,11 +33,18 @@ pre {
 	border-left: 1px solid #999;
 	border-bottom: 1px solid #999;
 
-	margin-bottom: 3rem;
-
 	/* Important to allow the code to move horizontally; */
 	overflow-x: auto;
 	position: relative;
+}
+pre:not(:last-child) {
+	margin-bottom: 3rem;
+}
+pre:first-child {
+	margin-top: 0;
+}
+pre:last-child {
+	margin-top: 0;
 }
 pre .code-container {
 	/* Give it some space to breathe */

--- a/src/tabs.scss
+++ b/src/tabs.scss
@@ -2,26 +2,31 @@
   -webkit-tap-highlight-color: transparent;
 
   &__tab-list {
-    border-bottom: 1px solid #aaa;
-    margin: 0 0 10px;
     padding: 0;
+    margin: 0 1rem -2px;
   }
 
   &__tab {
     display: inline-block;
     border: 1px solid transparent;
     border-bottom: none;
-    bottom: -1px;
+    bottom: -2px;
     position: relative;
     list-style: none;
     padding: 6px 12px;
     cursor: pointer;
 
+    background: #153E67;
+    color: var(--backgroundColor);
+    border-radius: 0.5rem 0.5rem 0 0;
+    margin-right: 4px;
+
     &--selected {
-      background: #fff;
-      border-color: #aaa;
-      color: black;
-      border-radius: 5px 5px 0 0;
+      background: var(--backgroundColor);
+      border: 2px solid #153E67;
+      border-bottom: 0px;
+      margin-bottom: 2px;
+      color: #153E67;
     }
 
     &--disabled {
@@ -48,6 +53,9 @@
 
   &__tab-panel {
     display: none;
+    border: 2px solid #153E67;
+    border-radius: 0.5rem;
+    padding: 1.5rem;
 
     &--selected {
       display: block;


### PR DESCRIPTION
This PR improves the (currently unused) tab styling to go from this style:

![image](https://user-images.githubusercontent.com/9100169/158014952-eb2ed1b1-a984-4ec7-81fe-3bef95ad5223.png)

To this one:

![image](https://user-images.githubusercontent.com/9100169/158014961-9c56fab2-15cc-4094-a31e-5289b633c01c.png)
