### PR TITLE
Improved title splitting in social/preview image generation

### DIFF
--- a/src/build-scripts/social-previews/twitter-large-card.test.tsx
+++ b/src/build-scripts/social-previews/twitter-large-card.test.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MockPost } from "__mocks__/data/mock-post";
+import TwitterLargeCard, { splitSentence } from './twitter-large-card';
+
+test("Social previews splitSentence", () => {
+	// doesn't split at start/end of short titles
+	expect(splitSentence(
+		"Topic: Topic"
+	)).toStrictEqual(
+		["Topic: Topic", ""]
+	);
+
+	// splits by colon (including the colon char)
+	expect(splitSentence(
+		"A Topic: an Attribute"
+	)).toStrictEqual(
+		["A Topic", ": an Attribute"]
+	);
+
+	// splits by commas
+	expect(splitSentence(
+		"An Attribute of Topic, Topic, and Topic"
+	)).toStrictEqual(
+		["An Attribute of ", "Topic, Topic, and Topic"]
+	);
+
+	// splits by apostrophe
+	expect(splitSentence(
+		"A Topic's Attribute"
+	)).toStrictEqual(
+		["A Topic's", " Attribute"]
+	);
+
+	// splits by apostrophe (plural)
+	expect(splitSentence(
+		"Some Topics' Attributes"
+	)).toStrictEqual(
+		["Some Topics'", " Attributes"]
+	);
+
+	// splits by lowercase words
+	expect(splitSentence(
+		"An Attribute in a Topic"
+	)).toStrictEqual(
+		["An Attribute in ", "a Topic"]
+	);
+});
+
+test("Social preview renders", async () => {
+	const post = MockPost;
+	const { baseElement, findByText } = render(
+		<TwitterLargeCard
+			post={post}
+			postHtml="<code>test();</code>"
+			width={1280}
+			height={640}
+			authorImagesStrs={["test.jpg"]}
+			unicornUtterancesHead="uu.jpg" />
+	);
+
+	expect(baseElement).toBeInTheDocument();
+	expect(await findByText(post.title)).toBeInTheDocument();
+});

--- a/src/build-scripts/social-previews/twitter-large-card.tsx
+++ b/src/build-scripts/social-previews/twitter-large-card.tsx
@@ -4,7 +4,7 @@ import { readFileAsBase64 } from "./read-file-as-base64";
 import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 
-function splitSentence(str: string): [string, string] {
+export function splitSentence(str: string): [string, string] {
   const splitStr = str.split(" ");
   const splitBy = (regex: RegExp, matchLast: boolean = true): [string, string]|null => {
     const matches = splitStr.map((word, i) => ({ reg: regex.exec(word), i }));
@@ -28,7 +28,7 @@ function splitSentence(str: string): [string, string] {
   // try to split by "Topic['s Attribute]" (apostrophe)
   if (ret = splitBy(/(?<=^\w+\'s?)$/)) return ret;
   // try to split by "Attribute [in Topic]" (lowercase words)
-  if (ret = splitBy(/^[a-z]\w+$/)) return ret;
+  if (ret = splitBy(/^[a-z][A-Za-z]*$/)) return ret;
   // otherwise, don't split the string
   return [str, ""];
 }

--- a/src/build-scripts/social-previews/twitter-large-card.tsx
+++ b/src/build-scripts/social-previews/twitter-large-card.tsx
@@ -6,11 +6,31 @@ import { fileURLToPath } from "url";
 
 function splitSentence(str: string): [string, string] {
   const splitStr = str.split(" ");
-  const isEven = splitStr.length % 2 === 0;
-  const firstHalfEnd = (isEven ? splitStr.length : splitStr.length - 1) / 2;
-  const firstHalf = splitStr.splice(0, firstHalfEnd);
-  // Splice mutates, so we can just return the rest
-  return [firstHalf.join(" "), splitStr.join(" ")];
+  const splitBy = (regex: RegExp, matchLast: boolean = true): [string, string]|null => {
+    const matches = splitStr.map((word, i) => ({ reg: regex.exec(word), i }));
+    const match = (matchLast ? matches.reverse() : matches)
+      .slice(1, -1)
+      .find(({reg}) => !!reg);
+
+    // if match is not found, fail
+    if (!match || !match.reg) return null;
+
+    const firstHalf = [...splitStr.slice(0, match.i), match.reg.input.substring(0, match.reg.index)].join(" ");
+    const secondHalf = [match.reg[0], ...splitStr.slice(match.i+1)].join(" ");
+    return [firstHalf, secondHalf];
+  };
+
+  let ret;
+  // try to split by "Topic[: Attribute]" or "Topic [- Attribute]" (hyphens/colons)
+  if (ret = splitBy(/(?<=^\w+):$|^[-—]$/)) return ret;
+  // try to split by "Attribute in [Topic, Topic, and Topic]" (commas)
+  if (ret = splitBy(/^\w+,$/, false)) return ret;
+  // try to split by "Topic['s Attribute]" (apostrophe)
+  if (ret = splitBy(/(?<=^\w+\'s?)$/)) return ret;
+  // try to split by "Attribute [in Topic]" (lowercase words)
+  if (ret = splitBy(/^[a-z]\w+$/)) return ret;
+  // otherwise, don't split the string
+  return [str, ""];
 }
 
 interface TwitterLargeCardProps {
@@ -50,7 +70,7 @@ const TwitterLargeCard = ({
             }px)`,
           }}
         >
-          {firstHalfTitle}{" "}
+          {firstHalfTitle}
           <span className="secondHalfTitle">{secondHalfTitle}</span>
         </h1>
       </div>


### PR DESCRIPTION
This attempts to improve upon the title splitting for accented text in articles' social media previews. Rather than picking an arbitrary point to split at, the proposed change searches for specific casing or punctuation to act as a delimiter. This makes its behavior more predictable and prevents the split from being placed in an undesirable location, such as the middle of a sentence or term.

The RegEx splits look for these details (in order of priority): colons/hyphens, comma-separated items, apostrophes, and lowercase words. Any matches directly at the start or end of the text will not be selected. If a title does not contain any of these, it will not be given an accent.

There are also two new test cases for this functionality; one for verifying the expected splitting behavior, and one for checking the overall social preview render with test data.