### PR TITLE
Next built in i18n

### DIFF
--- a/content/data/languages.json
+++ b/content/data/languages.json
@@ -1,5 +1,4 @@
 {
   "en": "English",
-  "es": "Español",
-  "es-es": "Spain Spanish"
+  "es": "Español"
 }

--- a/next.config.js
+++ b/next.config.js
@@ -2,12 +2,18 @@ const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
 const withPlugins = require("next-compose-plugins");
 const webpack = require("webpack");
+const languagesObj = require("./content/data/languages.json");
 
 const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true",
 });
 
 module.exports = withPlugins([withBundleAnalyzer], {
+  i18n: {
+    locales: Object.keys(languagesObj),
+    defaultLocale: "en",
+    localeDetection: false,
+  },
   webpack: (config) => {
     config.plugins.push(
       new CopyPlugin({

--- a/src/page-components/blog-post/blog-post.test.tsx
+++ b/src/page-components/blog-post/blog-post.test.tsx
@@ -6,7 +6,7 @@ import {
   MockMultiAuthorPost,
   MockPost,
 } from "__mocks__/data/mock-post";
-import BlogPostTemplate from "../../pages/[...postInfo]";
+import BlogPostTemplate from "../../pages/posts/[...postInfo]";
 import { RouterContext } from "next/dist/shared/lib/router-context";
 import { Languages } from "types/index";
 import { getAllByRel, getByProperty, getByRel } from "utils/tests";

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -2,9 +2,9 @@ import React from "react";
 import Link from "next/link";
 import Image from "next/image";
 import style from "../page-components/about/about.module.scss";
-import { UnicornInfo } from "uu-types";
+import { Languages, UnicornInfo } from "uu-types";
 import { siteDirectory, sponsorsDirectory, unicorns } from "utils/fs/get-datas";
-import unicornLogo from "../assets/unicorn_head_1024.png";
+import unicornLogo from "assets/unicorn_head_1024.png";
 import { useRouter } from "next/router";
 import { readMarkdownFile } from "utils/fs/api";
 import { join, resolve } from "path";
@@ -106,7 +106,13 @@ interface AboutUsMarkdownData {
   description: string;
 }
 
-export async function getStaticProps() {
+export async function getStaticProps({ locale }: { locale: Languages }) {
+  if (locale !== "en") {
+    return {
+      notFound: true,
+    };
+  }
+
   const { pickedData, frontmatterData } = readMarkdownFile<AboutUsMarkdownData>(
     join(siteDirectory, "about-us.md"),
     {

--- a/src/pages/collections/[slug].tsx
+++ b/src/pages/collections/[slug].tsx
@@ -19,6 +19,7 @@ import Link from "next/link";
 import { ThemeContext } from "constants/theme-context";
 import { SEO } from "components/seo";
 import { useRouter } from "next/router";
+import { Languages } from "types/index";
 
 const collectionQuery = {
   associatedSeries: true,
@@ -193,7 +194,15 @@ type Params = {
 
 const seriesPostCacheKey = {};
 
-export async function getStaticProps({ params }: Params) {
+export async function getStaticProps({
+  params,
+  locale,
+}: Params & { locale: Languages }) {
+  if (locale !== "en") {
+    return {
+      notFound: true,
+    };
+  }
   const collection = getCollectionBySlug(params.slug, collectionQuery);
 
   const { html: markdownHTML } = await markdownToHtml(

--- a/src/pages/confirm.tsx
+++ b/src/pages/confirm.tsx
@@ -55,4 +55,6 @@ export async function getStaticProps({ locale }: { locale: Languages }) {
       notFound: true,
     };
   }
+
+  return { props: {} };
 }

--- a/src/pages/confirm.tsx
+++ b/src/pages/confirm.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { SEO } from "components/seo";
 import helloUnicorn from "assets/hello_2048.png";
 import { useRouter } from "next/router";
+import { Languages } from "types/index";
 
 const ConfirmPage = () => {
   const router = useRouter();
@@ -47,3 +48,11 @@ const ConfirmPage = () => {
 };
 
 export default ConfirmPage;
+
+export async function getStaticProps({ locale }: { locale: Languages }) {
+  if (locale !== "en") {
+    return {
+      notFound: true,
+    };
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import { getAllPostsForListView, ListViewPosts } from "utils/fs/api";
 import React from "react";
 import { postsPerPage } from "constants/pagination";
 import { PostListTemplate } from "../page-components/post-list/PostList";
+import { Languages } from "types/index";
 
 type Props = {
   posts: ListViewPosts;
@@ -23,7 +24,13 @@ const Index = (props: Props) => {
 
 export default Index;
 
-export const getStaticProps = async () => {
+export async function getStaticProps({ locale }: { locale: Languages }) {
+  if (locale !== "en") {
+    return {
+      notFound: true,
+    };
+  }
+
   const posts = getAllPostsForListView();
 
   const numberOfPages = Math.ceil(posts.length / postsPerPage);
@@ -38,4 +45,4 @@ export const getStaticProps = async () => {
       numberOfPages,
     },
   };
-};
+}

--- a/src/pages/page/[pageNum].tsx
+++ b/src/pages/page/[pageNum].tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 
 import { postsPerPage } from "constants/pagination";
 import { PostListTemplate } from "../../page-components/post-list/PostList";
+import { Languages } from "types/index";
 
 type Props = {
   posts: ListViewPosts;
@@ -34,7 +35,15 @@ type Params = {
 
 const postListContentsCache = {};
 
-export async function getStaticProps({ params }: Params) {
+export async function getStaticProps({
+  params,
+  locale,
+}: Params & { locale: Languages }) {
+  if (locale !== "en") {
+    return {
+      notFound: true,
+    };
+  }
   const posts = getAllPostsForListView();
 
   const numberOfPages = Math.ceil(posts.length / postsPerPage);

--- a/src/pages/posts/[...postInfo].tsx
+++ b/src/pages/posts/[...postInfo].tsx
@@ -16,8 +16,8 @@ import {
 import { useRouter } from "next/router";
 
 import { SEO } from "components/seo";
-import { PostMetadata } from "../page-components/blog-post/post-metadata";
-import { PostTitleHeader } from "../page-components/blog-post/post-title-header";
+import { PostMetadata } from "../../page-components/blog-post/post-metadata";
+import { PostTitleHeader } from "../../page-components/blog-post/post-title-header";
 import { TableOfContents } from "components/table-of-contents";
 import { BlogPostLayout } from "components/blog-post-layout";
 import { MailingList } from "components/mailing-list";
@@ -34,7 +34,7 @@ import {
   getSuggestedArticles,
   OrderSuggestPosts,
 } from "utils/useGetSuggestedArticles";
-import { SuggestedArticles } from "../page-components/blog-post/suggested-articles";
+import { SuggestedArticles } from "../../page-components/blog-post/suggested-articles";
 import { PrivacyErrorBoundary } from "components/privacy-error-boundary";
 import { AnalyticsLink } from "components/analytics-link";
 import { languages } from "constants/index";
@@ -42,7 +42,7 @@ import { Languages } from "types/index";
 import { objectFromKeys } from "utils/objects";
 import { objectMap } from "ts-util-helpers";
 import { Lang } from "shiki";
-import { TranslationsHeader } from "components/../page-components/blog-post/translations-header";
+import { TranslationsHeader } from "../../page-components/blog-post/translations-header";
 
 type Props = {
   markdownHTML: string;
@@ -210,16 +210,16 @@ export default Post;
 
 type Params = {
   params: {
-    postInfo: [Languages, string] | [string];
+    postInfo: [string];
   };
+  locale: Languages;
 };
 
 const seriesPostCacheKey = {};
 
-export async function getStaticProps({ params }: Params) {
+export async function getStaticProps({ params, locale }: Params) {
   const slugParam = params.postInfo.pop() || "";
-  params.postInfo.pop(); // Remove `"posts"`
-  const lang = (params.postInfo.pop() as Languages) || "en";
+  const lang = locale;
   const post = getPostBySlug(slugParam, lang, postBySlug);
 
   const isStr = (val: any): val is string => typeof val === "string";
@@ -267,15 +267,11 @@ export async function getStaticPaths() {
   const paths = (Object.keys(postsLangArr) as Array<Languages>)
     .map((lang) =>
       postsLangArr[lang].map((post) => {
-        const postInfo = [];
-        if (lang !== "en") postInfo.push(lang);
-        postInfo.push("posts");
-        postInfo.push(post.slug);
-
         return {
           params: {
-            postInfo,
+            postInfo: [post.slug],
           },
+          locale: lang,
         };
       })
     )

--- a/src/pages/thanks.tsx
+++ b/src/pages/thanks.tsx
@@ -55,4 +55,6 @@ export async function getStaticProps({ locale }: { locale: Languages }) {
       notFound: true,
     };
   }
+
+  return { props: {} };
 }

--- a/src/pages/thanks.tsx
+++ b/src/pages/thanks.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { SEO } from "components/seo";
 import proudUnicorn from "assets/proud_2048.png";
 import { useRouter } from "next/router";
+import { Languages } from "types/index";
 
 const ThanksPage = () => {
   const router = useRouter();
@@ -47,3 +48,11 @@ const ThanksPage = () => {
 };
 
 export default ThanksPage;
+
+export async function getStaticProps({ locale }: { locale: Languages }) {
+  if (locale !== "en") {
+    return {
+      notFound: true,
+    };
+  }
+}

--- a/src/pages/unicorns/[...pageInfo].tsx
+++ b/src/pages/unicorns/[...pageInfo].tsx
@@ -1,7 +1,7 @@
 import { getAllPostsForListView, ListViewPosts, unicorns } from "utils/fs/api";
 import * as React from "react";
 
-import { UnicornInfo } from "../../types";
+import { Languages, UnicornInfo } from "../../types";
 import { postsPerPage } from "constants/pagination";
 import { SEO } from "components/seo";
 import { PostListProvider } from "constants/post-list-context";
@@ -73,7 +73,15 @@ type Params = {
   };
 };
 
-export async function getStaticProps({ params }: Params) {
+export async function getStaticProps({
+  params,
+  locale,
+}: Params & { locale: Languages }) {
+  if (locale !== "en") {
+    return {
+      notFound: true,
+    };
+  }
   const allPosts = getAllPostsForListView();
 
   const [unicornId, _, paramsPageNum] = params.pageInfo;


### PR DESCRIPTION
Currently, we're using our own implementation of i18n sub-routing which requires us to have dynamic paths for each page.

Here's a problem though: you can only have one dynamic path component per route, meaning that we could not port `about` or other pages with that method.

Because of this, we can utilize NextJS's default i18n routing logic