### PR TITLE
Create distinct styles for in-text code snippets

### DIFF
--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -25,6 +25,7 @@ export const COLORS = {
     dark: "0px 2px 4px rgba(0, 0, 0, 0.27), inset 0px 1px 0px #435e75",
   },
   codeBlockBackground: { light: "white", dark: "#202746" },
+  codeInlineBackground: { light: "#c6dbe5", dark: "#1d495e" },
   //code styles
   codeBackgroundColor: { light: "#fff", dark: "#161b1d" },
   textColor: { light: "#5e6687", dark: "#7ea2b4" },

--- a/src/global.scss
+++ b/src/global.scss
@@ -294,6 +294,14 @@ $pendIconMarg: #{$baseUnit}px;
     border-radius: 8px;
     overflow: hidden;
   }
+
+  p > code {
+    display: inline;
+    padding: 0 0.4em;
+    font-size: 85%;
+    background-color: var(--codeInlineBackground);
+    border-radius: 4px;
+  }
 }
 
 .post-lower-area {


### PR DESCRIPTION
Currently, inline code snippets are a bit hard to separate from the rest of the text in a post. This isn't much of an issue in cases where the syntax is easily recognizable, but it can create confusion when the code snippets start to blend in with a larger paragraph.

For example, the WIP "Minecraft Data Pack Programming" series includes the following sentence:
> If you try to flip the order those two subcommands, `at @a as @s` won't actually select the right entity.

Here's how that looks on the site:
![2022-06-15-181046_781x64_scrot](https://user-images.githubusercontent.com/13000407/173940886-4b33d1e1-74cf-418c-945e-c9de0bc48069.png)

In comparison, this is how it looks with the suggested styling in this PR:
![2022-06-15-181313_768x70_scrot](https://user-images.githubusercontent.com/13000407/173941199-baa812b8-d7e8-45d3-a64f-db5f01706175.png)
