### PR TITLE
Create distinct styles for collapsible <details> elements

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -294,6 +294,24 @@ $pendIconMarg: #{$baseUnit}px;
     border-radius: 8px;
     overflow: hidden;
   }
+
+  details {
+    border: 2px solid var(--darkPrimary);
+    border-radius: 0.5rem;
+    margin-bottom: 1em;
+
+    summary {
+      padding: .5rem 1.5rem;
+      background: var(--darkPrimary);
+      color: var(--backgroundColor);
+      cursor: pointer;
+    }
+
+    summary ~ * {
+      margin-left: 1.5rem;
+      margin-right: 1.5rem;
+    }
+  }
 }
 
 .post-lower-area {


### PR DESCRIPTION
I'm not aware of any posts currently using this element, but it could be useful for e.g. providing a problem/challenge with a hidden "solution" that shouldn't be immediately available to the reader.

This PR adds a border to show a clear separation between text in expanded details and the rest of the page. This matches the styling currently used in the tabs component.

![2022-06-16-095031_822x333_scrot](https://user-images.githubusercontent.com/13000407/174086329-ca2219aa-d59f-482d-bcde-39b5ce9705c1.png)

The touch target for the `<summary>` element is also expanded by the padding on this element (i.e. it extends to the borders of the page) making it somewhat easier to press.