### PR TITLE
Fix undefined license information in posts

### DIFF
--- a/content/data/licenses.json
+++ b/content/data/licenses.json
@@ -33,7 +33,7 @@
   },
   {
     "id": "coderpad",
-    "footerImg": "/coderpad.png",
+    "footerImg": "/sponsors/coderpad.svg",
     "licenceType": "Owned by CoderPad",
     "explainLink": "https://coderpad.io/about-us/",
     "name": "Written for CoderPad, reposted to Unicorn Utterances",

--- a/src/utils/fs/posts-and-collections-api.ts
+++ b/src/utils/fs/posts-and-collections-api.ts
@@ -4,6 +4,7 @@ import {
   collectionsDirectory,
   postsDirectory,
   unicorns,
+  licenses,
 } from "utils/fs/get-datas";
 import { isNotJunk } from "junk";
 import { DeepPartial, DeepReplaceKeys, PickDeep } from "ts-util-helpers";
@@ -167,6 +168,13 @@ export function getPostBySlug<ToPick extends PostKeysToPick>(
     pickedData.authors = (frontmatterData.authors as string[]).map(
       (author) => unicorns.find((unicorn) => unicorn.id === author)!
     );
+  }
+
+  if (fields.license) {
+    if (frontmatterData.license) {
+      pickedData.license = licenses.find((l) => l.id === frontmatterData.license);
+    }
+    if (!pickedData.license) pickedData.license = null;
   }
 
   if (fields.excerpt) {


### PR DESCRIPTION
At some point, this functionality was removed from the posts api - causing the site to generate an `<a aria-label="Post licensed with undefined">` instead of the correct license info for each post.

This PR fixes that behavior, and corrects one of the licenses' image paths.