### PR TITLE
fix: tabs no longer jump between large blocks of content

### DIFF
--- a/src/utils/markdown/MarkdownRenderer/tabs.tsx
+++ b/src/utils/markdown/MarkdownRenderer/tabs.tsx
@@ -56,12 +56,21 @@ const Tabs: React.FC<React.PropsWithChildren<unknown>> = ({ children }) => {
   }, [state.selectedTabText]);
 
   const onSelect = React.useCallback(
-    (index: number) => {
+    (index: number, _: number, event: Event) => {
+      const target = event.target as HTMLElement;
       setSelectedIndex(index);
       dispatch({
         type: "SET_SELECTED_TAB_TEXT",
         payload: tabsHeadingText[index],
       });
+      // Scroll onto screen in order to avoid jumping page locations
+      setTimeout(() => {
+        target.scrollIntoView({
+          behavior: "auto",
+          block: "center",
+          inline: "center",
+        });
+      }, 0);
     },
     [dispatch, tabsHeadingText]
   );


### PR DESCRIPTION
Currently when clicking between tabs in certain circumstances, it causes the following behavior of page jumping:

https://user-images.githubusercontent.com/9100169/175764283-88875ca2-a6f2-45b4-b1cc-fb961c6211a2.mp4

This is caused by a difference in content length between tabs

This PR looks to fix that.