### PR TITLE
Table of contents styling improvements

### DIFF
--- a/src/components/table-of-contents/table-of-contents.module.scss
+++ b/src/components/table-of-contents/table-of-contents.module.scss
@@ -46,7 +46,8 @@
 
 .tocH1 {
 	padding-top: 0;
-	margin-top: 12px;
+	margin-top: 16px;
+	border-left: none;
 }
 
 .tocH1,
@@ -67,6 +68,6 @@
 
 @for $i from 1 through 4 {
 	.tocH#{$i} {
-		padding-left: $i * 10px;
+		padding-left: ($i - 1) * 10px;
 	}
 }

--- a/src/components/table-of-contents/table-of-contents.module.scss
+++ b/src/components/table-of-contents/table-of-contents.module.scss
@@ -13,31 +13,39 @@
 
 .tocLi a {
 	text-decoration: none;
+
+	&:hover {
+		text-decoration: underline;
+	}
+}
+
+.tocLi:global(.toc-is-active) a {
+	font-weight: 700;
+	color: var(--darkPrimary) !important;
+}
+
+.tocH1 a {
+	color: var(--midImpactBlack);
 }
 
 .tocH2 {
 	@extend %body-1;
-	font-style: italic;
-	a {
-		color: var(--midImpactBlack);
-	}
 }
 
 .tocH3,
 .tocH4 {
-	// This should be body2
-	line-height: 135%;
+	@extend %body-2;
 }
 
-.tocH3 a {
-	color: var(--midImpactBlack);
-	font-style: italic;
-	font-size: 1rem;
+.tocH2, .tocH3, .tocH4 {
+	a {
+		color: var(--midImpactBlack);
+		font-style: italic;
+	}
 }
 
-.tocH4 a {
-	color: var(--midImpactBlack);
-	font-style: italic;
-	line-height: 135%;
-	font-size: 1rem;
+@for $i from 1 through 4 {
+	.tocH#{$i} {
+		margin-left: $i * 10px;
+	}
 }

--- a/src/components/table-of-contents/table-of-contents.module.scss
+++ b/src/components/table-of-contents/table-of-contents.module.scss
@@ -10,15 +10,22 @@
 .tocLi {
 	margin-top: 12px;
 	margin-right: 3px;
-
-	&:focus-within {
-		outline: 3px solid var(--primary);
-	}
 }
 
 .tocLi a {
+	display: block;
 	text-decoration: none;
 	outline: none;
+
+	@supports not selector(:focus-visible) {
+		&:focus {
+			outline: 3px solid var(--black);
+		}
+	}
+
+	&:focus-visible {
+		outline: 3px solid var(--black);
+	}
 
 	&:hover {
 		text-decoration: underline;

--- a/src/components/table-of-contents/table-of-contents.module.scss
+++ b/src/components/table-of-contents/table-of-contents.module.scss
@@ -41,13 +41,14 @@
 	color: var(--midImpactBlack);
 }
 
+.tocH1,
 .tocH2 {
-	@extend %body-1;
+	@extend %headline-uniwidth-1;
 }
 
 .tocH3,
 .tocH4 {
-	@extend %body-2;
+	@extend %headline-uniwidth-2;
 }
 
 .tocH2, .tocH3, .tocH4 {

--- a/src/components/table-of-contents/table-of-contents.module.scss
+++ b/src/components/table-of-contents/table-of-contents.module.scss
@@ -11,7 +11,7 @@
 	padding: 6px 0;
 	margin-right: 3px;
 
-	border-left: 3px solid rgba(0, 0, 0, 0.2);
+	border-left: 3px solid var(--minImpactBlack);
 }
 
 .tocLi a {

--- a/src/components/table-of-contents/table-of-contents.module.scss
+++ b/src/components/table-of-contents/table-of-contents.module.scss
@@ -8,11 +8,14 @@
 }
 
 .tocLi {
-	margin-top: 12px;
+	padding: 6px 0;
 	margin-right: 3px;
+
+	border-left: 3px solid rgba(0, 0, 0, 0.2);
 }
 
 .tocLi a {
+	color: var(--midImpactBlack);
 	display: block;
 	text-decoration: none;
 	outline: none;
@@ -32,13 +35,18 @@
 	}
 }
 
-.tocLi:global(.toc-is-active) a {
-	font-weight: 700;
-	color: var(--darkPrimary) !important;
+.tocLi:global(.toc-is-active) {
+	border-color: var(--darkPrimary);
+
+	a {
+		font-weight: 700;
+		color: var(--darkPrimary) !important;
+	}
 }
 
-.tocH1 a {
-	color: var(--midImpactBlack);
+.tocH1 {
+	padding-top: 0;
+	margin-top: 12px;
 }
 
 .tocH1,
@@ -53,13 +61,12 @@
 
 .tocH2, .tocH3, .tocH4 {
 	a {
-		color: var(--midImpactBlack);
 		font-style: italic;
 	}
 }
 
 @for $i from 1 through 4 {
 	.tocH#{$i} {
-		margin-left: $i * 10px;
+		padding-left: $i * 10px;
 	}
 }

--- a/src/components/table-of-contents/table-of-contents.module.scss
+++ b/src/components/table-of-contents/table-of-contents.module.scss
@@ -9,10 +9,16 @@
 
 .tocLi {
 	margin-top: 12px;
+	margin-right: 3px;
+
+	&:focus-within {
+		outline: 3px solid var(--primary);
+	}
 }
 
 .tocLi a {
 	text-decoration: none;
+	outline: none;
 
 	&:hover {
 		text-decoration: underline;

--- a/src/components/table-of-contents/table-of-contents.tsx
+++ b/src/components/table-of-contents/table-of-contents.tsx
@@ -10,13 +10,19 @@ interface TableOfContentsProps {
 }
 
 export const TableOfContents = ({ headingsWithId }: TableOfContentsProps) => {
-  const headingsToDisplay = React.useMemo(
-    () =>
-      headingsWithId?.length
-        ? headingsWithId.filter((headingInfo) => headingInfo.depth <= 3)
-        : [],
-    [headingsWithId]
-  );
+  const headingsToDisplay = React.useMemo(() => {
+    const headings = headingsWithId?.length
+      ? headingsWithId.filter((headingInfo) => headingInfo.depth <= 3)
+      : [];
+
+    // get the "minimum" depth of heading used in the post (e.g. if the post only uses h2 and h3 -> minDepth=1)
+    const minDepth = Math.min(...headings.map((h) => h.depth));
+
+    // offset the heading depths by minDepth, so they always start at 1
+    return headings.map((h) =>
+      Object.assign({}, h, { depth: h.depth - minDepth + 1 })
+    );
+  }, [headingsWithId]);
 
   const tocListRef = React.createRef<HTMLOListElement>();
 
@@ -56,7 +62,6 @@ export const TableOfContents = ({ headingsWithId }: TableOfContentsProps) => {
           return (
             <li
               key={headingInfo.slug}
-              style={{ marginLeft: `${10 * (headingInfo.depth - 1)}px` }}
               ref={linkRefs[i]}
               className={liClassNames}
             >

--- a/src/components/table-of-contents/table-of-contents.tsx
+++ b/src/components/table-of-contents/table-of-contents.tsx
@@ -11,17 +11,15 @@ interface TableOfContentsProps {
 
 export const TableOfContents = ({ headingsWithId }: TableOfContentsProps) => {
   const headingsToDisplay = React.useMemo(() => {
-    const headings = headingsWithId?.length
-      ? headingsWithId.filter((headingInfo) => headingInfo.depth <= 3)
-      : [];
+    const headings = headingsWithId?.length ? headingsWithId : [];
 
     // get the "minimum" depth of heading used in the post (e.g. if the post only uses h2 and h3 -> minDepth=1)
     const minDepth = Math.min(...headings.map((h) => h.depth));
 
     // offset the heading depths by minDepth, so they always start at 1
-    return headings.map((h) =>
-      Object.assign({}, h, { depth: h.depth - minDepth + 1 })
-    );
+    return headings
+      .map((h) => Object.assign({}, h, { depth: h.depth - minDepth + 1 }))
+      .filter((headingInfo) => headingInfo.depth <= 3);
   }, [headingsWithId]);
 
   const tocListRef = React.createRef<HTMLOListElement>();

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -18,6 +18,10 @@ export const COLORS = {
     light: "rgba(0, 0, 0, 0.58)",
     dark: "rgba(255, 255, 255, .58)",
   },
+  minImpactBlack: {
+    light: "rgba(0, 0, 0, 0.2)",
+    dark: "rgba(255, 255, 255, .2)",
+  },
   backgroundColor: { light: "#E4F4FF", dark: "#072a41" },
   cardActiveBackground: { light: "#EBF6FC", dark: "#163954" },
   cardActiveBoxShadow: {

--- a/src/global.scss
+++ b/src/global.scss
@@ -403,14 +403,6 @@ li > ul > li {
   margin: 1rem 0;
 }
 
-.toc-is-active {
-  font-weight: bold;
-
-  a {
-    color: var(--darkPrimary) !important;
-  }
-}
-
 kbd {
   background-color: #eee;
   border-radius: 3px;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -7,7 +7,7 @@ export default class MyDocument extends Document {
       <Html lang="en">
         <Head>
           <link
-            href="https://fonts.googleapis.com/css?family=Work+Sans:400,500,600,700%7CArchivo:400,500,600%7CRoboto+Mono:400&display=swap"
+            href="https://fonts.googleapis.com/css?family=Asap:400,700%7CWork+Sans:400,500,600,700%7CArchivo:400,500,600%7CRoboto+Mono:400&display=swap"
             rel="stylesheet"
           />
           <link rel="icon" href="/favicon.ico" />

--- a/src/styles/_text_styles.scss
+++ b/src/styles/_text_styles.scss
@@ -1,5 +1,6 @@
 @import "./utils";
 
+$asap: "Asap", "Archivo", sans-serif;
 $workSans: "Work Sans", "Archivo", sans-serif;
 $archivo: "Archivo", sans-serif;
 $robotoMono: "Roboto Mono", monospace;
@@ -116,6 +117,31 @@ $robotoMono: "Roboto Mono", monospace;
 	@include from($endSmallScreenSize) {
 		font-size: 1.375rem;
 		line-height: 130%;
+	}
+}
+
+%headline-uniwidth-1 {
+	font-family: $asap;
+	font-weight: 400;
+	font-size: 1rem;
+	letter-spacing: 0em;
+	line-height: 150%;
+	@include from($endSmallScreenSize) {
+		font-size: 1.125rem;
+		line-height: 140%;
+	}
+}
+
+
+%headline-uniwidth-2 {
+	font-family: $asap;
+	font-weight: 400;
+	font-size: 0.875rem;
+	letter-spacing: 0em;
+	line-height: 145%;
+	@include from($endSmallScreenSize) {
+		font-size: 1rem;
+		line-height: 135%;
 	}
 }
 

--- a/src/utils/markdown/markdownToHtml.ts
+++ b/src/utils/markdown/markdownToHtml.ts
@@ -32,7 +32,7 @@ export default async function markdownToHtml(
       // Remove complaining about "div cannot be in p element"
       remarkUnwrapImages,
       /* start remark plugins here */
-      [behead, { after: 0, depth: 1 }],
+      [behead, { depth: 1 }],
       [
         remarkEmbedder as any,
         {


### PR DESCRIPTION
- Offsets all heading depths within the table of contents by the minimum level used in a blog post
  e.g. even if a post only uses `<h3>` and `<h4>`, the table of contents will still start at depth 1 instead of depth 3 (as it does now)
- Adds distinct `:hover` and `:focus` styles to the heading links
- Consolidates styling in the module SCSS (moved from global.scss)