### PR TITLE
Small improvements to markdown styling

### DIFF
--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -29,7 +29,7 @@ export const COLORS = {
     dark: "0px 2px 4px rgba(0, 0, 0, 0.27), inset 0px 1px 0px #435e75",
   },
   codeBlockBackground: { light: "white", dark: "#202746" },
-  codeInlineBackground: { light: "#c6dbe5", dark: "#1d495e" },
+  codeInlineBackground: { light: "#cbe8fb", dark: "#1d495e" },
   //code styles
   codeBackgroundColor: { light: "#fff", dark: "#161b1d" },
   textColor: { light: "#5e6687", dark: "#7ea2b4" },

--- a/src/global.scss
+++ b/src/global.scss
@@ -237,18 +237,6 @@ $pendIconMarg: #{$baseUnit}px;
     margin-top: 0.75em;
   }
 
-  table tr:last-child th:first-child {
-    border-bottom-left-radius: 10px;
-  }
-
-  table tr:last-child td:first-child {
-    border-bottom-left-radius: 10px;
-  }
-
-  table tr:last-child td:last-child {
-    border-bottom-right-radius: 10px;
-  }
-
   .table-container {
     max-width: 100%;
     overflow: auto;
@@ -257,10 +245,27 @@ $pendIconMarg: #{$baseUnit}px;
   table {
     border: var(--cardOutlineStyle);
     border-radius: var(--cardRadius);
-    border-collapse: collapse;
-    // Border-collapse and border-radius don't mix. This is a workaround for that issue
-    box-shadow: 0 0 0 1px var(--primary);
+    border-spacing: 0;
+    // border-collapse: collapse;
     overflow: hidden;
+
+    thead th {
+      background-color: var(--codeInlineBackground);
+    }
+
+    tr > th, tr > td {
+      border: var(--cardOutlineStyle);
+      border-left: none;
+      border-top: none;
+
+      &:last-child {
+        border-right: none;
+      }
+    }
+
+    thead:last-child th, tr:last-child > td {
+      border-bottom: none;
+    }
 
     @include until($endSmallScreenSize) {
       ul {

--- a/src/global.scss
+++ b/src/global.scss
@@ -246,7 +246,6 @@ $pendIconMarg: #{$baseUnit}px;
     border: var(--cardOutlineStyle);
     border-radius: var(--cardRadius);
     border-spacing: 0;
-    // border-collapse: collapse;
     overflow: hidden;
 
     thead th {
@@ -307,6 +306,12 @@ $pendIconMarg: #{$baseUnit}px;
     color: var(--black);
     background-color: var(--codeInlineBackground);
     border-radius: 4px;
+  }
+
+  hr {
+    margin: 2rem 0;
+    border: 2px solid var(--darkPrimary);
+    border-radius: 2px;
   }
 
   details {

--- a/src/global.scss
+++ b/src/global.scss
@@ -300,9 +300,9 @@ $pendIconMarg: #{$baseUnit}px;
     overflow: hidden;
   }
 
-  p > code {
+  p > code, li > code {
     display: inline;
-    padding: 0 0.4em;
+    padding: 0.1em 0.4em;
     font-size: 85%;
     color: var(--black);
     background-color: var(--codeInlineBackground);


### PR DESCRIPTION
These changes focus on some existing styling behavior used in posts:

- The light mode background used for inline code has been improved to match the color scheme a bit better:
  | Before | After |
  | ------ | ----- |
  | ![2022-07-12-133928_805x212_scrot](https://user-images.githubusercontent.com/13000407/178557492-a2b03cb9-65fe-4e04-b7d2-5d5aae628b7b.png) | ![2022-07-12-133920_791x209_scrot](https://user-images.githubusercontent.com/13000407/178557541-07c4b8bd-2c79-467b-ac5a-07082cd9894b.png) |

- Inline code styles are now also applied when used inside of `<li>` elements
- Table borders are no longer clipped by the edge of the containing element:
  ![2022-07-12-134218_846x323_scrot](https://user-images.githubusercontent.com/13000407/178558149-56953acb-ffbf-466f-97fd-51c9335b8f68.png)
- `<hr>` elements have styling that matches the other border styles
  ![2022-07-12-134501_846x261_scrot](https://user-images.githubusercontent.com/13000407/178558747-691f0245-d8a4-4e17-8d23-82b546804dac.png)
