### PR TITLE
Post scrolling behavior

### DIFF
--- a/src/components/blog-post-layout/blog-post-layout.module.scss
+++ b/src/components/blog-post-layout/blog-post-layout.module.scss
@@ -22,20 +22,11 @@
 	min-width: 220px;
 }
 
-.leftContainer {
-	margin-right: 2rem;
-}
-
-.rightContainer {
-	margin-left: 2rem;
-	transition: 300ms opacity ease-in-out;
-}
-
 // This makes up ~80% of desktop users as-of Oct 2021 (past 3 months)
 // For reference, ~80% of desktop users had >750px height
 @media (max-width: 1270px) {
 	.rightContainer {
-		opacity: 0;
+		display: none;
 	}
 }
 
@@ -47,9 +38,20 @@
 	align-self: flex-start;
 	overflow: auto;
 
+	animation: fadeIn 300ms ease-in-out;
+
 	// Add 400px to the parent of the blog post, if it matches this, we want to hide the side elements from the browser
 	// This means no left and right containers on mobile
 	@include until(#{$baseUnit * (88 + 50)}px) {
 		display: none;
+	}
+}
+
+@keyframes fadeIn {
+	0% {
+		opacity: 0;
+	}
+	100% {
+		opacity: 1;
 	}
 }

--- a/src/components/table-of-contents/heading-intersection-observer-script.astro
+++ b/src/components/table-of-contents/heading-intersection-observer-script.astro
@@ -10,6 +10,10 @@ const { headingsToDisplaySlugs } = Astro.props as {
 
 <script>
 	window.onload = () => {
+		const prefersReducedMotion = window.matchMedia
+			? window.matchMedia("(prefers-reduced-motion: reduce)").matches
+			: false;
+
 		const tocListRef = document.querySelector("#tocList");
 
 		const linkRefs = [
@@ -17,6 +21,22 @@ const { headingsToDisplaySlugs } = Astro.props as {
 				'[data-headingitem="true"]'
 			) as never as HTMLElement[]),
 		];
+
+		// smooth-scroll to a heading when clicked
+		function handleAnchorClick(e: Event) {
+			e.preventDefault();
+			const anchor = e.target as HTMLAnchorElement;
+			document
+				.getElementById(anchor.getAttribute("href").slice(1))
+				?.scrollIntoView({
+					behavior: prefersReducedMotion ? "auto" : "smooth",
+				});
+			return false;
+		}
+
+		linkRefs.forEach((linkRef) => {
+			linkRef.firstElementChild.addEventListener("click", handleAnchorClick);
+		});
 
 		let previousSection = { current: "" };
 

--- a/src/components/table-of-contents/heading-intersection-observer-script.astro
+++ b/src/components/table-of-contents/heading-intersection-observer-script.astro
@@ -9,18 +9,30 @@ const { headingsToDisplaySlugs } = Astro.props as {
 </script>
 
 <script>
+	type LinkRef = {
+		li: HTMLLIElement;
+		anchor: HTMLAnchorElement;
+		id: string;
+	};
+
 	window.onload = () => {
 		const prefersReducedMotion = window.matchMedia
 			? window.matchMedia("(prefers-reduced-motion: reduce)").matches
 			: false;
 
-		const tocListRef = document.querySelector("#tocList");
+		const tocListRef: HTMLOListElement = document.querySelector("#tocList");
+		const tocListContainer =
+			tocListRef.parentElement?.parentElement?.parentElement;
 
-		const linkRefs = [
+		const linkRefs: LinkRef[] = [
 			...(document.querySelectorAll(
 				'[data-headingitem="true"]'
-			) as never as HTMLElement[]),
-		];
+			) as never as HTMLLIElement[]),
+		].map((li) => ({
+			li,
+			anchor: li.firstElementChild as HTMLAnchorElement,
+			id: li.firstElementChild.getAttribute("href").slice(1),
+		}));
 
 		// smooth-scroll to a heading when clicked
 		function handleAnchorClick(e: Event) {
@@ -34,49 +46,56 @@ const { headingsToDisplaySlugs } = Astro.props as {
 			return false;
 		}
 
-		linkRefs.forEach((linkRef) => {
-			linkRef.firstElementChild.addEventListener("click", handleAnchorClick);
-		});
+		for (const { anchor } of linkRefs) {
+			anchor.addEventListener("click", handleAnchorClick);
+		}
 
-		let previousSection = { current: "" };
+		let activeLinkId: string = linkRefs[0]?.id || "";
 
 		const handleObserver = (entries) => {
-			const highlightFirstActive = () => {
-				if (!tocListRef) return;
-				let firstVisibleLink = tocListRef.querySelector(".toc-is-visible");
+			// find the first link that matches a visible heading
+			for (const linkRef of linkRefs) {
+				// find any heading entry that corresponds to the linkRef
+				const entry = entries.find(
+					(entry) => entry.target.getAttribute("id") === linkRef.id
+				);
 
-				linkRefs.forEach((linkRef) => {
-					linkRef.classList.remove("toc-is-active");
-				});
+				// determine if the link should be active
+				if (entry && entry.isIntersecting && entry.intersectionRatio >= 1) {
+					linkRef.li.classList.add("toc-is-active");
+					activeLinkId = linkRef.id;
 
-				if (firstVisibleLink) {
-					firstVisibleLink.classList.add("toc-is-active");
+					// if the selected link is beyond the visible area of the container...
+					if (
+						// the user hasn't requested reduced motion...
+						!prefersReducedMotion &&
+						tocListContainer &&
+						// the link is below the lowest point of the container...
+						(tocListContainer.scrollTop + tocListContainer.offsetHeight <
+							linkRef.li.offsetTop + linkRef.li.offsetHeight ||
+							// the link is above the highest point of the container...
+							tocListContainer.scrollTop > linkRef.li.offsetTop)
+					) {
+						// ...then scroll to center the link in the container
+						tocListContainer.scrollTo({
+							top: Math.max(
+								0,
+								linkRef.li.offsetTop +
+									linkRef.li.offsetHeight -
+									tocListContainer.offsetHeight / 2
+							),
+							behavior: "smooth",
+						});
+					}
+					break;
 				}
+			}
 
-				if (!firstVisibleLink && previousSection.current) {
-					tocListRef
-						.querySelector(`a[href="#${previousSection.current}"]`)
-						.parentElement.classList.add("toc-is-active");
-				}
-			};
-
-			entries.forEach((entry) => {
-				let href = `#${entry.target.getAttribute("id")}`,
-					link = linkRefs.find(
-						(l) => l.firstElementChild.getAttribute("href") === href
-					);
-
-				if (!link) return;
-				if (entry.isIntersecting && entry.intersectionRatio >= 1) {
-					link.classList.add("toc-is-visible");
-					const newPreviousSection = entry.target.getAttribute("id");
-					previousSection.current = newPreviousSection;
-				} else {
-					link.classList.remove("toc-is-visible");
-				}
-
-				highlightFirstActive();
-			});
+			// remove visible class from any links that are *not* the most recently selected heading
+			for (const linkRef of linkRefs) {
+				if (linkRef.id != activeLinkId)
+					linkRef.li.classList.remove("toc-is-active");
+			}
 		};
 
 		const observer = new IntersectionObserver(handleObserver, {
@@ -84,11 +103,12 @@ const { headingsToDisplaySlugs } = Astro.props as {
 			threshold: 1,
 		});
 
-		const headingsEls = (window as any).headingsToDisplaySlugs.map(
-			(headingToDisplay) => {
-				return document.getElementById(headingToDisplay);
-			}
-		);
+		// use headingsToDisplaySlugs prop to observe all heading elements on the page
+		const headingsEls: HTMLElement[] = (
+			window as any
+		).headingsToDisplaySlugs.map((headingToDisplay: string) => {
+			return document.getElementById(headingToDisplay);
+		});
 
 		headingsEls
 			.filter((a) => a)

--- a/src/components/table-of-contents/table-of-contents.astro
+++ b/src/components/table-of-contents/table-of-contents.astro
@@ -35,7 +35,9 @@ const headingsToDisplaySlugs = headingsToDisplay.map((item) => item.slug);
 				});
 				return (
 					<li class={liClassNames} data-headingitem="true">
-						<a href={`#${headingInfo.slug}`}>{headingInfo.value}</a>
+						<a href={`#${headingInfo.slug}`} data-headinglink="true">
+							{headingInfo.value}
+						</a>
 					</li>
 				);
 			})

--- a/src/components/table-of-contents/table-of-contents.astro
+++ b/src/components/table-of-contents/table-of-contents.astro
@@ -32,6 +32,7 @@ const headingsToDisplaySlugs = headingsToDisplay.map((item) => item.slug);
 					[tableOfContentsStyle.tocH1]: headingInfo.depth === 1,
 					[tableOfContentsStyle.tocH2]: headingInfo.depth === 2,
 					[tableOfContentsStyle.tocH3]: headingInfo.depth === 3,
+					["toc-is-active"]: i === 0,
 				});
 				return (
 					<li class={liClassNames} data-headingitem="true">

--- a/src/global.scss
+++ b/src/global.scss
@@ -172,7 +172,7 @@ h6 {
 }
 
 .postViewContent {
-	padding: #{$baseUnit * 2.5}px;
+	padding: 0 #{$baseUnit * 2.5}px;
 	overflow-wrap: break-word;
 }
 


### PR DESCRIPTION
This PR aims to improve the scrolling behavior of the post pages:

- The table of contents should scroll when the active elements are not in view (unless the user has `prefers-reduced-motion`)
- Prevents a horizontal scroll bar from appearing in specific viewport sizes
- Removes the small sidebar scroll movement at the top of the page due to container padding
  (TBD whether this is actually an improvement)
- Changes opacity transition on right sidebar to one fade-in animation that applies to both
- Animates smooth scroll to heading on table of contents interaction (unless the user has `prefers-reduced-motion`)