### PR TITLE
[WIP] Various improvements to astro migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MPL-2.0",
 			"dependencies": {
 				"@astrojs/sitemap": "^1.0.0",
-				"medium-zoom": "^1.0.6",
+				"medium-zoom": "^1.0.7",
 				"preact": "^10.11.2",
 				"probe-image-size": "^7.2.3",
 				"vite-plugin-svgr": "^2.2.2"
@@ -20752,9 +20752,9 @@
 			}
 		},
 		"node_modules/medium-zoom": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.0.6.tgz",
-			"integrity": "sha512-UdiUWfvz9fZMg1pzf4dcuqA0W079o0mpqbTnOz5ip4VGYX96QjmbM+OgOU/0uOzAytxC0Ny4z+VcYQnhdifimg=="
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.0.7.tgz",
+			"integrity": "sha512-otDp0YidvLr6lAatPt6v3aEBxFE8YyWOksbCdfrR83KFY+8wluk7rblE6RKW18mY+FdBXhi9reVY0JTmoIt7SA=="
 		},
 		"node_modules/mem": {
 			"version": "8.1.1",
@@ -46314,9 +46314,9 @@
 			"peer": true
 		},
 		"medium-zoom": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.0.6.tgz",
-			"integrity": "sha512-UdiUWfvz9fZMg1pzf4dcuqA0W079o0mpqbTnOz5ip4VGYX96QjmbM+OgOU/0uOzAytxC0Ny4z+VcYQnhdifimg=="
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-1.0.7.tgz",
+			"integrity": "sha512-otDp0YidvLr6lAatPt6v3aEBxFE8YyWOksbCdfrR83KFY+8wluk7rblE6RKW18mY+FdBXhi9reVY0JTmoIt7SA=="
 		},
 		"mem": {
 			"version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 	},
 	"dependencies": {
 		"@astrojs/sitemap": "^1.0.0",
-		"medium-zoom": "^1.0.6",
+		"medium-zoom": "^1.0.7",
 		"preact": "^10.11.2",
 		"probe-image-size": "^7.2.3",
 		"vite-plugin-svgr": "^2.2.2"

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -38,47 +38,47 @@ export const Pagination = ({
 	return (
 		<>
 			{dontShowAnything ? null : (
-				<ul
-					id={id}
-					role="navigation"
-					aria-label="Pagination Navigation"
-					class={`${styles.pagination} ${className}`}
-				>
-					{!disablePrevious && (
-						<li class={`${styles.paginationItem} ${styles.previous}`}>
-							<a href={getPageHref(page.currentPage - 1)} aria-label="Previous">
-								{"<"}
-							</a>
-						</li>
-					)}
-
-					{paginationRange.map((pageItem) => {
-						const isSelected = pageItem.pageNumber === page.currentPage;
-						return (
-							<li
-								class={`${styles.paginationItem} ${
-									isSelected ? styles.active : ""
-								}`}
-							>
-								<a
-									href={getPageHref(pageItem.pageNumber)}
-									aria-label={pageItem.ariaLabel}
-									aria-current={isSelected || undefined}
-								>
-									{pageItem.display}
+				<div role="navigation" aria-label="Pagination Navigation">
+					<ul
+						id={id}
+						class={`${styles.pagination} ${className}`}
+					>
+						{!disablePrevious && (
+							<li class={`${styles.paginationItem} ${styles.previous}`}>
+								<a href={getPageHref(page.currentPage - 1)} aria-label="Previous">
+									{"<"}
 								</a>
 							</li>
-						);
-					})}
+						)}
 
-					{!disableNext && (
-						<li class={`${styles.paginationItem} ${styles.next}`}>
-							<a href={getPageHref(page.currentPage + 1)} aria-label="Next">
-								{">"}
-							</a>
-						</li>
-					)}
-				</ul>
+						{paginationRange.map((pageItem) => {
+							const isSelected = pageItem.pageNumber === page.currentPage;
+							return (
+								<li
+									class={`${styles.paginationItem} ${
+										isSelected ? styles.active : ""
+									}`}
+								>
+									<a
+										href={getPageHref(pageItem.pageNumber)}
+										aria-label={pageItem.ariaLabel}
+										aria-current={isSelected || undefined}
+									>
+										{pageItem.display}
+									</a>
+								</li>
+							);
+						})}
+
+						{!disableNext && (
+							<li class={`${styles.paginationItem} ${styles.next}`}>
+								<a href={getPageHref(page.currentPage + 1)} aria-label="Next">
+									{">"}
+								</a>
+							</li>
+						)}
+					</ul>
+				</div>
 			)}
 		</>
 	);

--- a/src/components/post-card/post-card.tsx
+++ b/src/components/post-card/post-card.tsx
@@ -34,7 +34,12 @@ export const PostCard = ({
 	} = post;
 
 	return (
-		<li class={`${cardStyles.card} ${className}`} role="listitem">
+		<li
+			class={`${cardStyles.card} ${className}`}
+			// @ts-ignore No, typescript, the onclick attr is perfectly fine and I'm sure that it works.
+			onclick={`location.href='/posts/${slug}'`}
+			role="listitem"
+		>
 			<div class={cardStyles.cardContents}>
 				<a href={`/posts/${slug}`} class="unlink">
 					<h2 class={cardStyles.header}>{title}</h2>

--- a/src/components/user-profile-pic/user-profile-pic.tsx
+++ b/src/components/user-profile-pic/user-profile-pic.tsx
@@ -22,24 +22,23 @@ export const UserProfilePic = ({
 				const classesToApply = hasTwoAuthors ? styles.twoAuthor : "";
 
 				return (
-					<a
-						aria-hidden={true}
-						href={`/unicorns/${unicorn.id}`}
+					<picture
+						// @ts-ignore No, typescript, the onclick attr is perfectly fine and I'm sure that it works.
+						onclick={`location.href='/unicorns/${unicorn.id}';`}
 						class={`pointer ${styles.profilePicContainer} ${classesToApply}`}
 						style={`border-color: ${unicorn.color};`}
 					>
-						<picture>
-							{imgAttrs.sources.map((attrs) => (
-								<source {...attrs} />
-							))}
-							<img
-								data-testid={`author-pic-${i}`}
-								{...(imgAttrs.image as any)}
-								alt={unicorn.name}
-								class={`circleImg ${styles.profilePicImage} ${styles.width50} ${classesToApply}`}
-							/>
-						</picture>
-					</a>
+						{imgAttrs.sources.map((attrs) => (
+							<source {...attrs} />
+						))}
+						<img
+							data-testid={`author-pic-${i}`}
+							{...(imgAttrs.image as any)}
+							alt={unicorn.name}
+							class={`circleImg ${styles.profilePicImage} ${styles.width50} ${classesToApply}`}
+							onclick
+						/>
+					</picture>
 				);
 			})}
 		</div>

--- a/src/global.scss
+++ b/src/global.scss
@@ -193,6 +193,11 @@ body {
 	background: var(--backgroundColor) !important;
 }
 
+.medium-zoom-image--opened:not(:last-child) {
+	/* TODO: This is a temporary fix to visually hide the cloned <img/> tag created by medium-zoom when a data-zoom-src is specified */
+	visibility: hidden;
+}
+
 /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
 .visually-hidden {
 	position: absolute !important;

--- a/src/layouts/document.astro
+++ b/src/layouts/document.astro
@@ -2,9 +2,12 @@
 import BlockingThemeChangerScript from "../page-components/layouts/blocking-theme-changer-script.astro";
 import Layout from "../components/layout/layout.astro";
 import "../global.scss";
+
+let { lang } = Astro.props;
+lang ??= "en";
 ---
 
-<html class="light">
+<html {lang} class="light">
 	<head>
 		<meta name="viewport" content="width=device-width" />
 		<meta charset="utf-8" />

--- a/src/pages/[locale]/about.astro
+++ b/src/pages/[locale]/about.astro
@@ -35,7 +35,7 @@ const { globResults, locale } = Astro.props as {
 };
 ---
 
-<Document>
+<Document lang={locale}>
 	<SEO title="About Us" />
 	<About globResults={globResults} locale={locale} />
 </Document>

--- a/src/pages/[locale]/posts/[postid].astro
+++ b/src/pages/[locale]/posts/[postid].astro
@@ -44,7 +44,7 @@ const otherLangs = translations
 	: [];
 ---
 
-<Document>
+<Document lang={locale}>
 	<SEO
 		slot="head"
 		title={post.title}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -8,7 +8,7 @@ const aboutUsLocales = await Astro.glob("../../content/site/about-us*.md");
 const locale = "en";
 ---
 
-<Document>
+<Document lang={locale}>
 	<SEO title="About Us" />
 	<About globResults={aboutUsLocales} locale={locale} />
 </Document>

--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -53,15 +53,15 @@
 		visibility: visible;
 	}
 
-	img {
+	picture, img {
 		margin: 0 auto;
 		display: block;
 		max-width: 100%;
+	}
 
-		&[src$=".svg"] {
-			width: 100%;
-			max-height: 50vh;
-		}
+	img[src$=".svg"] {
+		width: 100%;
+		max-height: 50vh;
 	}
 
 	h1,

--- a/src/utils/markdown/rehype-astro-image-md.ts
+++ b/src/utils/markdown/rehype-astro-image-md.ts
@@ -136,15 +136,21 @@ export const rehypeAstroImageMd: Plugin<
 
 				Object.assign(
 					node,
-					h("picture", [
-						...sources,
-						h("img", {
-							alt: node.properties.alt,
-							loading: "lazy",
-							decoding: "async",
-							"data-zoom-src": pngSource.src,
-						}),
-					])
+					h(
+						"picture",
+						{
+							style: `max-width: ${pngSource.size}px`,
+						},
+						[
+							...sources,
+							h("img", {
+								alt: node.properties.alt,
+								loading: "lazy",
+								decoding: "async",
+								"data-zoom-src": pngSource.src,
+							}),
+						]
+					)
 				);
 			})
 		);


### PR DESCRIPTION
This PR tracks some miscellaneous things I'm working on fixing:
- [x] Set the html `lang=` attribute to properly reflect the current article language
- [x] Wrap pagination in a div to preserve both `role="navigation"` and list behavior
- [x] Add onclick attributes for profile images & post cards (fixes "aria-hidden contains focusable descendents")
- [ ] Update `medium-zoom` for compatibility with the new `<picture/>` tags
  * While this is partially working, I might attempt to PR a more complete fix for this into `medium-zoom` (as it currently only clones the `img` tag, while the full structure is necessary for it to display correctly)