### PR TITLE
add avif format to Astro images

### DIFF
--- a/src/page-components/about/about.astro
+++ b/src/page-components/about/about.astro
@@ -47,6 +47,7 @@ const Content = matchedResult.Content;
 				loading={"eager"}
 				widths={[192]}
 				sizes={"192px"}
+				formats={["avif", "webp", "png"]}
 				alt={"Unicorn Utterances logo"}
 			/>
 		</div>
@@ -90,7 +91,7 @@ const Content = matchedResult.Content;
 								sizes="85px"
 								widths={[85]}
 								aspectRatio={1}
-								formats={["webp", "png"]}
+								formats={["avif", "webp", "png"]}
 								src={unicornInfo.profileImgMeta.relativeServerPath}
 							/>
 						</div>

--- a/src/page-components/collections/collection-header-default.astro
+++ b/src/page-components/collections/collection-header-default.astro
@@ -36,6 +36,7 @@ if (coverImgPath instanceof Promise && !coverImgAspectRatio) {
 				aspectRatio={coverImgAspectRatio}
 				sizes={`600`}
 				widths={[600]}
+				formats={["avif", "webp", "png"]}
 				loading="eager"
 			/>
 		</div>
@@ -48,6 +49,7 @@ if (coverImgPath instanceof Promise && !coverImgAspectRatio) {
 					aspectRatio={coverImgAspectRatio}
 					sizes={`600`}
 					widths={[600]}
+					formats={["avif", "webp", "png"]}
 					loading="eager"
 				/>
 			</div>

--- a/src/page-components/post-list/post-list-header/post-list-header.astro
+++ b/src/page-components/post-list/post-list-header/post-list-header.astro
@@ -17,7 +17,7 @@ const { siteDescription } = Astro.props as PostListHeaderProps;
 >
 	<div class={styles.headerPic}>
 		<Picture
-			formats={["webp", "png"]}
+			formats={["avif", "webp", "png"]}
 			loading={"eager"}
 			sizes={"300px"}
 			alt={`Smiling cartoon unicorn with a

--- a/src/page-components/unicorns/profile-header/profile-header.astro
+++ b/src/page-components/unicorns/profile-header/profile-header.astro
@@ -39,7 +39,7 @@ const possessiveName = getNamePossessive(unicornData.name);
 			sizes={"192px"}
 			loading={"eager"}
 			aspectRatio={1}
-			formats={["webp", "png"]}
+			formats={["avif", "webp", "png"]}
 			alt={`${possessiveName} profile picture`}
 		/>
 	</div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -17,6 +17,7 @@ const locale = "en";
 			loading="eager"
 			sizes="500px"
 			widths={[500]}
+			formats={["avif", "webp", "png"]}
 			width="500"
 			height="500"
 			alt="Unicorn Utterances 404 image"

--- a/src/pages/collections/framework-field-guide/index.mdx
+++ b/src/pages/collections/framework-field-guide/index.mdx
@@ -89,12 +89,12 @@ Don't want to learn all three? **That's okay.** You can easily select a single f
 </div>
 
 <div class="hide-for-mobile hide-on-dark">
-<Picture src={import('./hiker_with_bag.png')} class={styles.hikerPic} widths={[230]} formats={['webp', 'png']} alt="" />
+<Picture src={import('./hiker_with_bag.png')} class={styles.hikerPic} widths={[230]} formats={["avif", "webp", "png"]} alt="" />
 </div>
 
 
 <div class="hide-for-mobile show-on-dark">
-<Picture src={import('./hiker_with_bag_dark.png')} class={styles.hikerPic} widths={[230]} formats={['webp', 'png']} alt="" />
+<Picture src={import('./hiker_with_bag_dark.png')} class={styles.hikerPic} widths={[230]} formats={["avif", "webp", "png"]} alt="" />
 </div>
 
 
@@ -108,7 +108,7 @@ Don't want to learn all three? **That's okay.** You can easily select a single f
 
 <div style="display: flex; align-items: center; justify-content: center; flex-wrap: wrap">
 	<div style="margin: 1rem; width: 128px; flex-shrink: 0;">
-		<Picture class={styles.authorPic} src={import('./crutchcorn.png')} widths={[128]} formats={['webp', 'png']} alt="" />
+		<Picture class={styles.authorPic} src={import('./crutchcorn.png')} widths={[128]} formats={["avif", "webp", "png"]} alt="" />
 	</div>
 	<div style="width: 1px; flex-grow: 1; flex-shrink: 1; min-width: 350px; font-weight: bold;">
 		Hi! I'm <a href="https://crutchcorn.dev">Corbin Crutchley</a>, the author of

--- a/src/pages/confirm.astro
+++ b/src/pages/confirm.astro
@@ -17,6 +17,7 @@ const locale = "en";
 			loading="eager"
 			sizes="450px"
 			widths={[450]}
+			formats={["avif", "webp", "png"]}
 			width="450"
 			height="450"
 			alt="A happy unicorn"

--- a/src/pages/thanks.astro
+++ b/src/pages/thanks.astro
@@ -16,6 +16,7 @@ const locale = "en";
 			src={proudUnicorn}
 			sizes="450px"
 			widths={[450]}
+			formats={["avif", "webp", "png"]}
 			loading="eager"
 			width="450"
 			height="450"


### PR DESCRIPTION
- Specifically defines the formats array on any astro `<Picture/>` tags
- Adds the `avif` format to picture tags that did not previously use it