### PR TITLE
Use font-face "f-mods" to minimize layout shift

### DIFF
--- a/src/styles/_text_styles.scss
+++ b/src/styles/_text_styles.scss
@@ -72,9 +72,25 @@
 		url("/fonts/Roboto_Mono/RobotoMono-Regular.ttf") format("truetype");
 }
 
-$asap: "Asap", "Archivo", sans-serif;
-$workSans: "Work Sans", "Archivo", sans-serif;
-$archivo: "Archivo", sans-serif;
+// Fallback fonts for minimal CLS
+// see: https://simonhearne.com/2021/layout-shifts-webfonts/#reduce-layout-shift-with-f-mods
+@font-face {
+	font-family: "Work Sans-fallback";
+	size-adjust: 111.87%;
+	ascent-override: 80%;
+	src: local("Arial");
+}
+
+@font-face {
+	font-family: "Archivo-fallback";
+	size-adjust: 98.5%;
+	ascent-override: 85%;
+	src: local("Arial");
+}
+
+$asap: "Asap", "Archivo", "Archivo-fallback", sans-serif;
+$workSans: "Work Sans", "Work Sans-fallback", sans-serif;
+$archivo: "Archivo", "Archivo-fallback", sans-serif;
 $robotoMono: "Roboto Mono", monospace;
 
 %beeg {

--- a/src/styles/_text_styles.scss
+++ b/src/styles/_text_styles.scss
@@ -82,15 +82,27 @@
 }
 
 @font-face {
+	font-family: "Work Sans-fallback2";
+	size-adjust: 111.9%;
+	src: local("Roboto");
+}
+
+@font-face {
 	font-family: "Archivo-fallback";
 	size-adjust: 98.5%;
 	ascent-override: 85%;
 	src: local("Arial");
 }
 
-$asap: "Asap", "Archivo", "Archivo-fallback", sans-serif;
-$workSans: "Work Sans", "Work Sans-fallback", sans-serif;
-$archivo: "Archivo", "Archivo-fallback", sans-serif;
+@font-face {
+	font-family: "Archivo-fallback2";
+	size-adjust: 97.5%;
+	src: local("Roboto");
+}
+
+$asap: "Asap", "Archivo", "Archivo-fallback", "Archivo-fallback2", sans-serif;
+$workSans: "Work Sans", "Work Sans-fallback", "Work Sans-fallback2", sans-serif;
+$archivo: "Archivo", "Archivo-fallback", "Archivo-fallback2", sans-serif;
 $robotoMono: "Roboto Mono", monospace;
 
 %beeg {


### PR DESCRIPTION
This PR adds two fallback font faces based on the "Arial" and "Roboto" fonts, which should minimize layout shift when custom fonts are swapped (assuming they are available as local fonts on the device).

These fonts override the size and ascent of the local font to closely(ish) match the expected size of the custom font. This can still cause layout shift when the viewport size causes some lines to wrap differently, but the differences are much less common.

See also:
- https://deploy-preview-15--upbeat-shirley-608546.netlify.app/posts/high-performance-web-font-loading/
- https://simonhearne.com/2021/layout-shifts-webfonts/#reduce-layout-shift-with-f-mods