### PR TITLE
Static tab heights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
 				"@lesjoursfr/html-to-epub": "^3.1.0",
 				"@remark-embedder/core": "^3.0.1",
 				"@remark-embedder/transformer-oembed": "^3.0.0",
+				"@testing-library/dom": "^8.20.0",
 				"@testing-library/jest-dom": "^5.16.5",
 				"@testing-library/preact": "^3.2.2",
 				"@types/classnames": "^2.3.1",
@@ -7717,14 +7718,14 @@
 			}
 		},
 		"node_modules/@testing-library/dom": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.0.tgz",
-			"integrity": "sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.0.tgz",
+			"integrity": "sha512-d9ULIT+a4EXLX3UU8FBjauG9NnsZHkHztXoIcTsOKoOw030fyjheN9svkTULjJxtYag9DZz5Jz5qkWZDPxTFwA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^4.2.0",
+				"@types/aria-query": "^5.0.1",
 				"aria-query": "^5.0.0",
 				"chalk": "^4.1.0",
 				"dom-accessibility-api": "^0.5.9",
@@ -8066,9 +8067,9 @@
 			}
 		},
 		"node_modules/@types/aria-query": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-			"integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+			"integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
 			"dev": true
 		},
 		"node_modules/@types/babel__core": {
@@ -46141,14 +46142,14 @@
 			}
 		},
 		"@testing-library/dom": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.0.tgz",
-			"integrity": "sha512-6YWYPPpxG3e/xOo6HIWwB/58HukkwIVTOaZ0VwdMVjhRUX/01E4FtQbck9GazOOj7MXHc5RBzMrU86iBJHbI+A==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.0.tgz",
+			"integrity": "sha512-d9ULIT+a4EXLX3UU8FBjauG9NnsZHkHztXoIcTsOKoOw030fyjheN9svkTULjJxtYag9DZz5Jz5qkWZDPxTFwA==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^4.2.0",
+				"@types/aria-query": "^5.0.1",
 				"aria-query": "^5.0.0",
 				"chalk": "^4.1.0",
 				"dom-accessibility-api": "^0.5.9",
@@ -46421,9 +46422,9 @@
 			}
 		},
 		"@types/aria-query": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-			"integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
+			"integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q==",
 			"dev": true
 		},
 		"@types/babel__core": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
 		"@lesjoursfr/html-to-epub": "^3.1.0",
 		"@remark-embedder/core": "^3.0.1",
 		"@remark-embedder/transformer-oembed": "^3.0.0",
+		"@testing-library/dom": "^8.20.0",
 		"@testing-library/jest-dom": "^5.16.5",
 		"@testing-library/preact": "^3.2.2",
 		"@types/classnames": "^2.3.1",

--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -3,11 +3,6 @@
 .tabs {
 	-webkit-tap-highlight-color: transparent;
 
-	@include until(822px) {
-		// Override the js-calculated minHeight when the layout can wrap
-		min-height: 0 !important;
-	}
-
 	&__tab-list {
 		padding: 0;
 		margin: 0 1rem -2px;
@@ -62,5 +57,33 @@
 		border: 2px solid var(--darkPrimary);
 		border-radius: 0.5rem;
 		padding: 1.5rem;
+
+		&[aria-hidden="true"] {
+			display: none;
+		}
+	}
+
+	@include from(823px) {
+		@supports (display: grid) {
+			&.tabs-small {
+				display: grid;
+				grid-template-columns: minmax(0, 1fr);
+				align-items: start;
+
+				.tabs__tab-list {
+					grid-row-start: 1;
+				}
+
+				.tabs__tab-panel {
+					grid-row-start: 2;
+					grid-column-start: 1;
+
+					&[aria-hidden="true"] {
+						display: block;
+						visibility: hidden;
+					}
+				}
+			}
+		}
 	}
 }

--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -1,5 +1,12 @@
+@import "./_utils.scss";
+
 .tabs {
 	-webkit-tap-highlight-color: transparent;
+
+	@include until(822px) {
+		// Override the js-calculated minHeight when the layout can wrap
+		min-height: 0 !important;
+	}
 
 	&__tab-list {
 		padding: 0;

--- a/src/styles/tabs.scss
+++ b/src/styles/tabs.scss
@@ -63,6 +63,10 @@
 		}
 	}
 
+	// Small tab sections have bottom "spacing" (hack using grid layout) to prevent content jumps on large screens
+	//   - this should be turned off at small widths where the tab content can wrap.
+	//
+	// Breakpoint is based on the rendered width of .postViewContent, which is 822px (768px .post-body width + padding & margins)
 	@include from(823px) {
 		@supports (display: grid) {
 			&.tabs-small {

--- a/src/utils/markdown/scripts/tabs.test.ts
+++ b/src/utils/markdown/scripts/tabs.test.ts
@@ -1,0 +1,90 @@
+import { screen } from "@testing-library/dom";
+import { enableTabs } from "./tabs";
+
+const tabsHtml = `
+	<ul role="tablist" class="tabs__tab-list">
+		<li role="tab" class="tabs__tab" data-tabname="angular" aria-selected="true" aria-controls="panel-0" id="tab-0" tabindex="0">Angular</li>
+		<li role="tab" class="tabs__tab" data-tabname="react" aria-selected="false" aria-controls="panel-1" id="tab-1" tabindex="0">React</li>
+		<li role="tab" class="tabs__tab" data-tabname="vue" aria-selected="false" aria-controls="panel-2" id="tab-2" tabindex="0">Vue</li>
+	</ul>
+	<div id="panel-0" role="tabpanel" class="tabs__tab-panel" tabindex="0" aria-labelledby="tab-0">
+		Angular
+	</div>
+	<div id="panel-1" role="tabpanel" class="tabs__tab-panel" tabindex="0" aria-labelledby="tab-1" aria-hidden="true">
+		React
+	</div>
+	<div id="panel-2" role="tabpanel" class="tabs__tab-panel" tabindex="0" aria-labelledby="tab-2" aria-hidden="true">
+		Vue
+	</div>
+`;
+
+function createTabs() {
+	const tabs = document.createElement("div");
+	tabs.className = "tabs";
+	tabs.innerHTML = tabsHtml;
+	document.body.appendChild(tabs);
+
+	return {
+		tabs,
+		tab0: tabs.querySelector("#tab-0") as HTMLLIElement,
+		tab1: tabs.querySelector("#tab-1") as HTMLLIElement,
+		tab2: tabs.querySelector("#tab-2") as HTMLLIElement,
+		panel0: tabs.querySelector("#panel-0") as HTMLDivElement,
+		panel1: tabs.querySelector("#panel-1") as HTMLDivElement,
+		panel2: tabs.querySelector("#panel-2") as HTMLDivElement,
+	};
+}
+
+describe("tabs.ts", () => {
+	test("enableTabs runs without errors", () => {
+		createTabs();
+		enableTabs();
+	});
+
+	test("switching tabs changes the aria-hidden panel value", () => {
+		const tabs = createTabs();
+		enableTabs();
+
+		// the user clicks tab0
+		tabs.tab0.click();
+		// expectation: panel0 is displayed
+		expect(tabs.panel0.getAttribute("aria-hidden")).toBeNull();
+		expect(tabs.panel1.getAttribute("aria-hidden")).toBe("true");
+		expect(tabs.panel2.getAttribute("aria-hidden")).toBe("true");
+
+		// select tab1
+		tabs.tab1.click();
+		// expectation: panel1 is displayed
+		expect(tabs.panel0.getAttribute("aria-hidden")).toBe("true");
+		expect(tabs.panel1.getAttribute("aria-hidden")).toBeNull();
+		expect(tabs.panel2.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	test("switching tabs affects multiple tab containers", () => {
+		const container1 = createTabs();
+		const container2 = createTabs();
+		enableTabs();
+
+		// change to tab2 from the first container
+		container1.tab2.click();
+		// expectation: the first container is displaying panel2
+		expect(container1.panel0.getAttribute("aria-hidden")).toBe("true");
+		expect(container1.panel1.getAttribute("aria-hidden")).toBe("true");
+		expect(container1.panel2.getAttribute("aria-hidden")).toBeNull();
+		// expectation: the second container is displaying panel2
+		expect(container2.panel0.getAttribute("aria-hidden")).toBe("true");
+		expect(container2.panel1.getAttribute("aria-hidden")).toBe("true");
+		expect(container2.panel2.getAttribute("aria-hidden")).toBeNull();
+
+		// change to tab1 from the second container
+		container2.tab1.click();
+		// expectation: the first container is displaying panel1
+		expect(container1.panel0.getAttribute("aria-hidden")).toBe("true");
+		expect(container1.panel1.getAttribute("aria-hidden")).toBeNull();
+		expect(container1.panel2.getAttribute("aria-hidden")).toBe("true");
+		// expectation: the second container is displaying panel1
+		expect(container2.panel0.getAttribute("aria-hidden")).toBe("true");
+		expect(container2.panel1.getAttribute("aria-hidden")).toBeNull();
+		expect(container2.panel2.getAttribute("aria-hidden")).toBe("true");
+	});
+});

--- a/src/utils/markdown/scripts/tabs.test.ts
+++ b/src/utils/markdown/scripts/tabs.test.ts
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/dom";
 import { enableTabs } from "./tabs";
 
 const tabsHtml = `
@@ -86,5 +85,28 @@ describe("tabs.ts", () => {
 		expect(container2.panel0.getAttribute("aria-hidden")).toBe("true");
 		expect(container2.panel1.getAttribute("aria-hidden")).toBeNull();
 		expect(container2.panel2.getAttribute("aria-hidden")).toBe("true");
+	});
+
+	test("selected tab persists between pages", () => {
+		const container1 = createTabs();
+		enableTabs();
+
+		// change to tab2 from the first container
+		container1.tab2.click();
+		// expectation: the first container is displaying panel2
+		expect(container1.panel0.getAttribute("aria-hidden")).toBe("true");
+		expect(container1.panel1.getAttribute("aria-hidden")).toBe("true");
+		expect(container1.panel2.getAttribute("aria-hidden")).toBeNull();
+
+		// remove the container1 tab container from the DOM
+		container1.tabs.remove();
+
+		// create & enable a new tab container (as if loading a new page)
+		const container2 = createTabs();
+		enableTabs();
+		// expectation: the new container is also displaying panel2
+		expect(container2.panel0.getAttribute("aria-hidden")).toBe("true");
+		expect(container2.panel1.getAttribute("aria-hidden")).toBe("true");
+		expect(container2.panel2.getAttribute("aria-hidden")).toBeNull();
 	});
 });

--- a/src/utils/markdown/scripts/tabs.ts
+++ b/src/utils/markdown/scripts/tabs.ts
@@ -75,56 +75,6 @@ export const enableTabs = () => {
 		tabEntries.push(entry);
 	});
 
-	function measureTabs() {
-		for (const tabEntry of tabEntries) {
-			// Get parent element
-			let parent: HTMLElement;
-			for (const [_, tab] of tabEntry) {
-				parent = tab.parent;
-				break;
-			}
-
-			// Clone element and append to parent ("fixed" should avoid dramatic layout changes, but still calculate layout bounds)
-			const parentClone = parent.cloneNode(true) as HTMLElement;
-			parentClone.style.position = "fixed";
-			document.body.appendChild(parentClone);
-
-			// Determine the max & min height values
-			let minHeight = 0;
-			let maxPanel: Element | null = null;
-			parentClone.querySelectorAll('[role="tabpanel"]').forEach((tabPanel) => {
-				tabPanel.removeAttribute("hidden");
-
-				if (!minHeight || tabPanel.clientHeight < minHeight) {
-					minHeight = tabPanel.clientHeight;
-				}
-
-				if (maxPanel && maxPanel.clientHeight > tabPanel.clientHeight) {
-					tabPanel.setAttribute("hidden", "true");
-					return;
-				}
-
-				maxPanel && maxPanel.setAttribute("hidden", "true");
-				maxPanel = tabPanel;
-			});
-
-			// Store the total parent height when maxPanel is visible
-			const maxHeight = parentClone.clientHeight;
-
-			// Remove the cloned node from the window
-			parentClone.remove();
-
-			// this min height should only be applied if the height diff. is < 50vh && the total height is < 100vh
-			if (
-				maxHeight - minHeight < window.innerHeight * 0.5 &&
-				maxHeight < window.innerHeight
-			)
-				parent.style.minHeight = maxHeight + "px";
-		}
-	}
-
-	setTimeout(measureTabs, 0);
-
 	function changeTabs(tabName: string) {
 		// find all tabs on the page that match the selected tabname
 		for (const tabEntry of tabEntries) {
@@ -134,7 +84,7 @@ export const enableTabs = () => {
 			// Set all encountered tabs as selected
 			tab.tab.setAttribute("aria-selected", "true");
 			// Show the selected panel
-			tab.panel.removeAttribute("hidden");
+			tab.panel.removeAttribute("aria-hidden");
 
 			// Iterate through sibling tabs
 			for (const [otherKey, otherTab] of tabEntry) {
@@ -143,7 +93,7 @@ export const enableTabs = () => {
 				// Set all sibling tabs as unselected
 				otherTab.tab.setAttribute("aria-selected", "false");
 				// Hide sibling tab panels
-				otherTab.panel.setAttribute("hidden", `true`);
+				otherTab.panel.setAttribute("aria-hidden", `true`);
 			}
 		}
 
@@ -167,7 +117,10 @@ export const enableTabs = () => {
 	for (const tabEntry of tabEntries) {
 		for (const [_, tab] of tabEntry) {
 			// If the tab is hidden and the heading is contained within the tab
-			if (tab.panel.hasAttribute("hidden") && tab.panel.contains(heading)) {
+			if (
+				tab.panel.hasAttribute("aria-hidden") &&
+				tab.panel.contains(heading)
+			) {
 				tab.tab.click();
 				setTimeout(() => {
 					heading.scrollIntoView(true);

--- a/src/utils/markdown/scripts/tabs.ts
+++ b/src/utils/markdown/scripts/tabs.ts
@@ -16,7 +16,7 @@ export const enableTabs = () => {
 	function handleKeydown(this: HTMLElement, e: KeyboardEvent) {
 		if (e.keyCode === 39 || e.keyCode === 37) {
 			const tabs = this.children;
-			let tabfocus = +(this.dataset.tabfocus || 0);
+			let tabfocus = Number(this.dataset.tabfocus || 0);
 			tabs[tabfocus].setAttribute("tabindex", "-1");
 			if (e.keyCode === 39) {
 				// Move right

--- a/src/utils/markdown/scripts/tabs.ts
+++ b/src/utils/markdown/scripts/tabs.ts
@@ -5,7 +5,6 @@ type TabEntry = Map<
 	{
 		tab: HTMLElement;
 		panel: HTMLElement;
-		parent: HTMLElement;
 	}
 >;
 
@@ -62,7 +61,6 @@ export const enableTabs = () => {
 			entry.set(tab.dataset.tabname, {
 				tab,
 				panel,
-				parent,
 			});
 
 			// Add a click event handler to each tab
@@ -114,7 +112,7 @@ export const enableTabs = () => {
 	const heading = document.getElementById(hash.slice(1));
 	if (!heading) return;
 
-	for (const tabEntry of tabEntries) {
+	for (const tabEntry of tabEntries)
 		for (const [_, tab] of tabEntry) {
 			// If the tab is hidden and the heading is contained within the tab
 			if (
@@ -128,5 +126,4 @@ export const enableTabs = () => {
 				return;
 			}
 		}
-	}
 };


### PR DESCRIPTION
This PR aims to automatically expand tab containers to the largest available tab content size when possible - to prevent moving around items on the page when a tab is selected. This should prevent most unintended scroll movement and possibly improve performance (by reducing the scope of layout recalculations when tabs are changed).

This is currently implemented using CSS `display: grid;` to overlap tab panels in the same grid cell, and switching from `hidden="true"` to `aria-hidden="true" visibility: hidden;` when hidden (so that hidden tabs still affect the layout).

However, these changes *will not apply* in the following conditions:
- Any tab has an approx. line height of >30 (determined during markdown rendering)
- The viewport is <=822px width (i.e. a mobile layout, where tab content could wrap and further expand the tab height)

The PR also includes some further optimizations of the tabs script:
- Removed some `querySelector` calls in favor of building a `TabEntry` structure with references to each tab
  - these references were already being kept in-scope and iterated through on load, so there shouldn't be any performance implications here
- Moved "keydown" and "click" listeners to reduce scope (and reuse the same listener between elements)
- Remove recursive `checkElementsParents` fn in favor of [`Node.contains()`](https://developer.mozilla.org/en-US/docs/Web/API/Node/contains)