### PR TITLE
chore: fix the infinity symbol on your guide within Safari

### DIFF
--- a/src/page-components/collections/framework-field-guide/segments/your-guide.module.scss
+++ b/src/page-components/collections/framework-field-guide/segments/your-guide.module.scss
@@ -105,6 +105,8 @@ img.guidePicture,
 	font-weight: 500;
 	font-size: 2.5rem;
 	line-height: 1;
+	// This solves a weird issue where the infinity symbol has a weird line off to the right on Safari
+	letter-spacing: 0.1px;
 
 	@include from($desktop) {
 		font-size: 4.5rem;


### PR DESCRIPTION
Previously, on Safari,  there would be a bug in Safari that caused a line on the right side of the Infinity symbol to appear.

**Before:** 
<img width="180" alt="image" src="https://user-images.githubusercontent.com/9100169/206322112-ce15cb90-3225-48b4-9612-de0d47b133fe.png">

**After:**


This PR appears to side-step this issue without causing headaches on Chrome or Firefox
