### PR TITLE
fix: previous and next blog icons render properly now

### DIFF
--- a/src/page-components/blog-post/series/series-nav.astro
+++ b/src/page-components/blog-post/series/series-nav.astro
@@ -21,10 +21,7 @@ const nextPost = postSeries[postIndex + 1];
 	{
 		prevPost ? (
 			<a href={`/posts/${prevPost.slug}`} class={`baseBtn prependIcon`}>
-				<span
-					style={{ display: "inline-flex" }}
-					set:html={{ __html: NavigateBefore }}
-				/>
+				<span style={{ display: "inline-flex" }} set:html={NavigateBefore} />
 				Previous Chapter: {getShortTitle(prevPost)}
 			</a>
 		) : null
@@ -33,10 +30,7 @@ const nextPost = postSeries[postIndex + 1];
 		nextPost ? (
 			<a href={`/posts/${nextPost.slug}`} class={`baseBtn appendIcon`}>
 				Next Chapter: {getShortTitle(nextPost)}
-				<span
-					style={{ display: "inline-flex" }}
-					set:html={{ __html: NavigateNext }}
-				/>
+				<span style={{ display: "inline-flex" }} set:html={NavigateNext} />
 			</a>
 		) : (
 			<div />


### PR DESCRIPTION
# Broken

![Arrows rendering a "[Object object]"](https://user-images.githubusercontent.com/9100169/209079040-ce1bd92c-a6dc-41a5-aa6a-9b17529fa31c.png)

# Fixed

![The arrows rendering properly](https://user-images.githubusercontent.com/9100169/209078992-baff31e9-4c3b-4b2b-8e28-828432a883e9.png)
