### PR TITLE
Fix iframe embed placeholder size

### DIFF
--- a/src/styles/iframe-replacement.scss
+++ b/src/styles/iframe-replacement.scss
@@ -1,4 +1,5 @@
 .iframe-replacement-container {
+	box-sizing: border-box;
 	border: var(--cardOutlineStyle);
 	border-radius: var(--cardRadius);
 	background: var(--darkPrimary);

--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -132,7 +132,9 @@
 	}
 
 	iframe {
-		width: 100%;
+		box-sizing: border-box;
+		display: block;
+		max-width: 100%;
 		min-height: 500px;
 		border: var(--cardOutlineStyle);
 		border-radius: 8px;

--- a/src/utils/markdown/constants.ts
+++ b/src/utils/markdown/constants.ts
@@ -1,2 +1,2 @@
 // default sizing used for iframes (MarkdownRenderer/media.tsx)
-export const EMBED_SIZE = { w: 704, h: 500 };
+export const EMBED_SIZE = { w: "100%", h: 500 };

--- a/src/utils/markdown/rehype-unicorn-iframe-click-to-run.ts
+++ b/src/utils/markdown/rehype-unicorn-iframe-click-to-run.ts
@@ -137,11 +137,9 @@ export const rehypeUnicornIFrameClickToRun: Plugin<
 						"data-pageicon": iframePicture
 							? JSON.stringify(iframePicture)
 							: undefined,
-						"data-width": width,
-						"data-height": height,
-						style: `height: ${+height ? `${height}px` : height}; width: ${
-							+width ? `${width}px` : width
-						};`,
+						style: `height: ${
+							Number(height) ? `${height}px` : height
+						}; width: ${Number(width) ? `${width}px` : width};`,
 					},
 					[
 						iframePicture

--- a/src/utils/markdown/rehype-unicorn-iframe-click-to-run.ts
+++ b/src/utils/markdown/rehype-unicorn-iframe-click-to-run.ts
@@ -139,7 +139,9 @@ export const rehypeUnicornIFrameClickToRun: Plugin<
 							: undefined,
 						"data-width": width,
 						"data-height": height,
-						style: `height: ${height}px; width: ${width}px;`,
+						style: `height: ${+height ? `${height}px` : height}; width: ${
+							+width ? `${width}px` : width
+						};`,
 					},
 					[
 						iframePicture

--- a/src/utils/markdown/scripts/iframe-click-to-run.ts
+++ b/src/utils/markdown/scripts/iframe-click-to-run.ts
@@ -8,8 +8,8 @@ export const iFrameClickToRun = () => {
 			const iframe = document.createElement("iframe");
 			(iframe as any).loading = "lazy";
 			iframe.src = el.parentElement.dataset.iframeurl;
-			iframe.height = el.parentElement.dataset.height;
-			iframe.width = el.parentElement.dataset.width;
+			iframe.style.width = el.parentElement.style.width;
+			iframe.style.height = el.parentElement.style.height;
 			el.parentElement.replaceWith(iframe);
 		});
 	});


### PR DESCRIPTION
This PR makes the iframe container sizing consistent with its replacement element, so that no page jumps occur when switching between them.