### PR TITLE
Revert "Fix iframe embed placeholder size"

### DIFF
--- a/src/styles/iframe-replacement.scss
+++ b/src/styles/iframe-replacement.scss
@@ -1,5 +1,4 @@
 .iframe-replacement-container {
-	box-sizing: border-box;
 	border: var(--cardOutlineStyle);
 	border-radius: var(--cardRadius);
 	background: var(--darkPrimary);

--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -132,9 +132,7 @@
 	}
 
 	iframe {
-		box-sizing: border-box;
-		display: block;
-		max-width: 100%;
+		width: 100%;
 		min-height: 500px;
 		border: var(--cardOutlineStyle);
 		border-radius: 8px;

--- a/src/utils/markdown/constants.ts
+++ b/src/utils/markdown/constants.ts
@@ -1,2 +1,2 @@
 // default sizing used for iframes (MarkdownRenderer/media.tsx)
-export const EMBED_SIZE = { w: "100%", h: 500 };
+export const EMBED_SIZE = { w: 704, h: 500 };

--- a/src/utils/markdown/rehype-unicorn-iframe-click-to-run.ts
+++ b/src/utils/markdown/rehype-unicorn-iframe-click-to-run.ts
@@ -137,9 +137,9 @@ export const rehypeUnicornIFrameClickToRun: Plugin<
 						"data-pageicon": iframePicture
 							? JSON.stringify(iframePicture)
 							: undefined,
-						style: `height: ${
-							Number(height) ? `${height}px` : height
-						}; width: ${Number(width) ? `${width}px` : width};`,
+						"data-width": width,
+						"data-height": height,
+						style: `height: ${height}px; width: ${width}px;`,
 					},
 					[
 						iframePicture

--- a/src/utils/markdown/scripts/iframe-click-to-run.ts
+++ b/src/utils/markdown/scripts/iframe-click-to-run.ts
@@ -8,8 +8,8 @@ export const iFrameClickToRun = () => {
 			const iframe = document.createElement("iframe");
 			(iframe as any).loading = "lazy";
 			iframe.src = el.parentElement.dataset.iframeurl;
-			iframe.style.width = el.parentElement.style.width;
-			iframe.style.height = el.parentElement.style.height;
+			iframe.height = el.parentElement.dataset.height;
+			iframe.width = el.parentElement.dataset.width;
 			el.parentElement.replaceWith(iframe);
 		});
 	});


### PR DESCRIPTION
Temporarily reverts unicorn-utterances/unicorn-utterances#472 until it can be resubmitted with a fix - this broke the Framework Field Guide landing page because of page-specific CSS.