### PR TITLE
Fix inconsistent classes on translated posts

### DIFF
--- a/src/components/layout/layout.astro
+++ b/src/components/layout/layout.astro
@@ -8,8 +8,6 @@ import { Icon } from "astro-icon";
 const rootPath = `/`;
 
 const isBase = Astro.url.pathname === rootPath;
-const isBlogPost = Astro.url.pathname.startsWith(`${rootPath}posts`);
-const isCollection = Astro.url.pathname.startsWith(`${rootPath}collections`);
 
 interface LayoutProps {
 	disableThemeToggle?: boolean;
@@ -56,13 +54,5 @@ const { disableThemeToggle } = Astro.props as LayoutProps;
 			</div>
 		</div>
 	</header>
-	<div
-		class={isCollection
-			? ""
-			: !isBlogPost
-			? "listViewContent"
-			: "postViewContent"}
-	>
-		<slot />
-	</div>
+	<slot />
 </div>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -10,7 +10,7 @@ const locale = "en";
 <Document lang={locale}>
 	<SEO slot="head" title="404: Not Found" />
 
-	<main>
+	<main class="listViewContent">
 		<Picture
 			class="sadUnicorn"
 			src={sadUnicorn}

--- a/src/pages/[locale]/about.astro
+++ b/src/pages/[locale]/about.astro
@@ -48,5 +48,7 @@ const { otherLocales } = getOtherAboutLocales(locale, globResults);
 			currentLang: locale,
 		}}
 	/>
-	<About globResults={globResults} locale={locale} />
+	<div class="listViewContent">
+		<About globResults={globResults} locale={locale} />
+	</div>
 </Document>

--- a/src/pages/[locale]/posts/[postid].astro
+++ b/src/pages/[locale]/posts/[postid].astro
@@ -62,5 +62,7 @@ const otherLangs = translations
 		}}
 		shareImage={`/${post.slug}.twitter-preview.png`}
 	/>
-	<BlogPost locale={locale} Content={Content} post={post} posts={posts} />
+	<div class="postViewContent">
+		<BlogPost locale={locale} Content={Content} post={post} posts={posts} />
+	</div>
 </Document>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -21,5 +21,7 @@ const { otherLocales } = getOtherAboutLocales(locale, aboutUsLocales);
 			currentLang: locale,
 		}}
 	/>
-	<About globResults={aboutUsLocales} locale={locale} />
+	<div class="listViewContent">
+		<About globResults={aboutUsLocales} locale={locale} />
+	</div>
 </Document>

--- a/src/pages/confirm.astro
+++ b/src/pages/confirm.astro
@@ -10,7 +10,7 @@ const locale = "en";
 <Document lang={locale}>
 	<SEO title="Confirm Your Email" slot="head" />
 
-	<main>
+	<main class="listViewContent">
 		<Picture
 			class="helloUnicorn"
 			src={helloUnicorn}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,5 +26,7 @@ const page = {
 
 <Document>
 	<SEO slot="head" title="Homepage" />
-	<PostListTemplate posts={postsToDisplay} page={page} rootURL={"/"} />
+	<div class="listViewContent">
+		<PostListTemplate posts={postsToDisplay} page={page} rootURL={"/"} />
+	</div>
 </Document>

--- a/src/pages/page/[page].astro
+++ b/src/pages/page/[page].astro
@@ -23,5 +23,7 @@ const SEOTitle = `Post page ${pageIndex}`;
 
 <Document>
 	<SEO slot="head" title={SEOTitle} />
-	<PostListTemplate posts={page.data} page={page} rootURL={"/"} />
+	<div class="listViewContent">
+		<PostListTemplate posts={page.data} page={page} rootURL={"/"} />
+	</div>
 </Document>

--- a/src/pages/posts/[postid].astro
+++ b/src/pages/posts/[postid].astro
@@ -58,5 +58,7 @@ const otherLangs = translations
 		}}
 		shareImage={`/${post.slug}.twitter-preview.png`}
 	/>
-	<BlogPost locale={"en"} Content={Content} post={post} posts={posts} />
+	<div class="postViewContent">
+		<BlogPost locale={"en"} Content={Content} post={post} posts={posts} />
+	</div>
 </Document>

--- a/src/pages/thanks.astro
+++ b/src/pages/thanks.astro
@@ -10,7 +10,7 @@ const locale = "en";
 <Document lang={locale}>
 	<SEO title="Thank You!" slot="head" />
 
-	<main>
+	<main class="listViewContent">
 		<Picture
 			class="proudUnicorn"
 			src={proudUnicorn}

--- a/src/pages/unicorns/[unicornid]/index.astro
+++ b/src/pages/unicorns/[unicornid]/index.astro
@@ -41,11 +41,13 @@ const rootURL = `/unicorns/${unicorn.id}/`;
 		unicornsData={[unicorn]}
 		type="profile"
 	/>
-	<UnicornsPage
-		unicorn={unicorn}
-		page={page}
-		posts={postsToDisplay}
-		allPosts={enPosts}
-		rootURL={rootURL}
-	/>
+	<div class="listViewContent">
+		<UnicornsPage
+			unicorn={unicorn}
+			page={page}
+			posts={postsToDisplay}
+			allPosts={enPosts}
+			rootURL={rootURL}
+		/>
+	</div>
 </Document>

--- a/src/pages/unicorns/[unicornid]/page/[page].astro
+++ b/src/pages/unicorns/[unicornid]/page/[page].astro
@@ -43,11 +43,13 @@ const rootURL = `/unicorns/${unicorn.id}/`;
 		unicornsData={[unicorn]}
 		type="profile"
 	/>
-	<UnicornsPage
-		unicorn={unicorn}
-		page={page}
-		posts={page.data}
-		allPosts={allPosts}
-		rootURL={rootURL}
-	/>
+	<div class="listViewContent">
+		<UnicornsPage
+			unicorn={unicorn}
+			page={page}
+			posts={page.data}
+			allPosts={allPosts}
+			rootURL={rootURL}
+		/>
+	</div>
 </Document>


### PR DESCRIPTION
Fixes an issue where the `"listViewContent"` class is incorrectly applied to a localized blog post layout instead of the `"postViewContent"` class, causing a difference in page margins.

This class has been moved out of the `<Layout>` component and is now set per-layout at the top component level.