### PR TITLE
Fix mobile responsiveness on contributors/about page

### DIFF
--- a/src/page-components/about/about.module.scss
+++ b/src/page-components/about/about.module.scss
@@ -43,6 +43,7 @@
 .userProfilePicture {
 	height: 85px;
 	width: 85px;
+	min-width: 85px;
 }
 
 .unicornLogo {


### PR DESCRIPTION
See #490, images did not have a min width and would scale according to `display: flex` in mobile layouts.