### PR TITLE
fix #492 - ensure equal width columns on the post grid

### DIFF
--- a/src/components/post-card-list/post-card-list.module.scss
+++ b/src/components/post-card-list/post-card-list.module.scss
@@ -12,7 +12,7 @@ ul.postsListContainer, .postsListContainer > ul[data-isPostList="true"] {
 	grid-gap: 24px;
 
 	@include from($startMediumScreenSize) {
-		grid-template-columns: 1fr 1fr;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 
 		&:empty {
 			grid-template-columns: 1fr;


### PR DESCRIPTION
Prevents the post grid columns from expanding when a significant length of text with no breakpoints is used as the post preview/description.