### PR TITLE
Sticky table headers, smaller line-height, & better wrapping on tables

### DIFF
--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -124,10 +124,13 @@
 		}
 	}
 
-	thead {
+	// Only use a sticky header on tables with 4+ rows
+	table:has(tr:nth-child(4)) thead {
 		position: sticky;
 		top: 0;
+	}
 
+	thead {
 		border-top-left-radius: var(--cardRadius);
 		border-top-right-radius: var(--cardRadius);
 		// This effectively sets a background using an extremely inset box shadow, which is affected by the border radius

--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -81,30 +81,40 @@
 		margin-top: 0.75em;
 	}
 
-	table tr:last-child th:first-child {
-		border-bottom-left-radius: 10px;
+	thead tr:first-child {
+		th, td {
+			border-top: none;
+		}
 	}
 
-	table tr:last-child td:first-child {
-		border-bottom-left-radius: 10px;
+	tbody tr:last-child {
+		th, td {
+			border-bottom: none;
+		}
 	}
 
-	table tr:last-child td:last-child {
-		border-bottom-right-radius: 10px;
+	table tr {
+		td:first-child, th:first-child {
+			border-left: none;
+		}
+	}
+
+	table tr {
+		td:last-child, th:last-child {
+			border-right: none;
+		}
 	}
 
 	.table-container {
 		max-width: 100%;
-		overflow: auto;
+		// overflow: auto;
 	}
 
 	table {
-		border: var(--cardOutlineStyle);
 		border-radius: var(--cardRadius);
 		border-collapse: collapse;
 		// Border-collapse and border-radius don't mix. This is a workaround for that issue
 		box-shadow: 0 0 0 1px var(--primary);
-		overflow: hidden;
 
 		@include until($endSmallScreenSize) {
 			ul {
@@ -114,16 +124,25 @@
 		}
 	}
 
-	tr,
-	td,
-	th {
-		border: var(--cardOutlineStyle);
+	thead {
+		position: sticky;
+		top: 0;
+
+		border-top-left-radius: var(--cardRadius);
+		border-top-right-radius: var(--cardRadius);
+		// This effectively sets a background using an extremely inset box shadow, which is affected by the border radius
+		box-shadow: inset 100vw 100vh 0 var(--cardActiveBackground), var(--cardActiveBoxShadow);
 	}
 
 	td,
 	th {
-		padding-left: 1rem;
-		padding-right: 1rem;
+		border: var(--cardOutlineStyle);
+		padding: .3rem .6rem;
+		line-height: 110%;
+
+		&> code {
+			word-break: break-word;
+		}
 
 		@include until($endSmallScreenSize) {
 			padding-left: 5px;


### PR DESCRIPTION
This PR introduces a number of changes to the table styling:
- Reduces padding & line height on table cells
- Wraps inline code blocks within table cells
- Eliminates horizontal scrolling on table containers
- Fixes the cut off table borders bug (caused by the overflow property)
- Adds sticky table headers

Comparison: (on https://unicorn-utterances.com/posts/ultimate-windows-development-environment-guide)
| Existing version | Changes in this PR |
|----------------------|------------------|
| ![2023-03-05-021858_848x604_scrot](https://user-images.githubusercontent.com/13000407/222947645-0a64b5a4-e3e0-4dc8-a38c-010162f7b951.png) | ![2023-03-05-022857_824x379_scrot](https://user-images.githubusercontent.com/13000407/222947689-b68c20cd-41f2-4fb3-b668-f350558b0bbb.png) |

