### PR TITLE
Exclude gifs from image optimization

### DIFF
--- a/src/utils/markdown/rehype-astro-image-md.ts
+++ b/src/utils/markdown/rehype-astro-image-md.ts
@@ -72,7 +72,7 @@ export const rehypeAstroImageMd: Plugin<
 					);
 				}
 
-				if (src.endsWith(".svg")) {
+				if (src.endsWith(".svg") || src.endsWith(".gif")) {
 					node.properties.src = src;
 					return;
 				}


### PR DESCRIPTION
This PR excludes .gif images from image optimization to avoid broken picture tags.

There is currently only one post using gifs which exhibits the loading issue when the `medium-zoom` overlay is opened: https://unicorn-utterances.com/posts/async-pipe-is-not-pure