### PR TITLE
Fix image loading at weird sizes

### DIFF
--- a/src/utils/markdown/get-picture-hack.ts
+++ b/src/utils/markdown/get-picture-hack.ts
@@ -3,7 +3,7 @@ import {
 	GetPictureParams,
 	GetPictureResult,
 } from "@astrojs/image/dist/lib/get-picture";
-import sharp_service from "../../../node_modules/@astrojs/image/dist/loaders/sharp.js";
+import squoosh_service from "../../../node_modules/@astrojs/image/dist/loaders/squoosh.js";
 
 export function getPicture(
 	params: GetPictureParams
@@ -11,8 +11,8 @@ export function getPicture(
 	// HACK: This is a hack that heavily relies on `getImage`'s internals :(
 	globalThis.astroImage = {
 		...(globalThis.astroImage || {}),
-		loader: globalThis.astroImage?.loader ?? sharp_service,
-		defaultLoader: globalThis.astroImage?.defaultLoader ?? sharp_service,
+		loader: globalThis.astroImage?.loader ?? squoosh_service,
+		defaultLoader: globalThis.astroImage?.defaultLoader ?? squoosh_service,
 	};
 
 	return astroImage.getPicture(params);

--- a/src/utils/markdown/rehype-astro-image-md.ts
+++ b/src/utils/markdown/rehype-astro-image-md.ts
@@ -77,6 +77,7 @@ export const rehypeAstroImageMd: Plugin<
 					return;
 				}
 
+				const originalDimensions = { ...dimensions };
 				const imgRatioHeight = dimensions.height / dimensions.width;
 				const imgRatioWidth = dimensions.width / dimensions.height;
 				if (maxHeight && dimensions.height > maxHeight) {
@@ -91,8 +92,8 @@ export const rehypeAstroImageMd: Plugin<
 
 				const pictureResult = await getPicture({
 					src: src,
-					widths: [dimensions.width],
 					formats: ["webp", "png"],
+					widths: [dimensions.width, originalDimensions.width],
 					aspectRatio: imgRatioWidth,
 					alt: node.properties.alt || "",
 				});

--- a/src/utils/markdown/rehype-astro-image-md.ts
+++ b/src/utils/markdown/rehype-astro-image-md.ts
@@ -92,8 +92,8 @@ export const rehypeAstroImageMd: Plugin<
 
 				const pictureResult = await getPicture({
 					src: src,
-					formats: ["webp", "png"],
 					widths: [dimensions.width, originalDimensions.width],
+					formats: ["avif", "webp", "png"],
 					aspectRatio: imgRatioWidth,
 					alt: node.properties.alt || "",
 				});

--- a/src/utils/markdown/rehype-astro-image-md.ts
+++ b/src/utils/markdown/rehype-astro-image-md.ts
@@ -81,12 +81,12 @@ export const rehypeAstroImageMd: Plugin<
 				const imgRatioWidth = dimensions.width / dimensions.height;
 				if (maxHeight && dimensions.height > maxHeight) {
 					dimensions.height = maxHeight;
-					dimensions.width = maxHeight * imgRatioWidth;
+					dimensions.width = Math.floor(maxHeight * imgRatioWidth);
 				}
 
 				if (maxWidth && dimensions.width > maxWidth) {
 					dimensions.width = maxWidth;
-					dimensions.height = maxWidth * imgRatioHeight;
+					dimensions.height = Math.floor(maxWidth * imgRatioHeight);
 				}
 
 				const pictureResult = await getPicture({

--- a/src/utils/markdown/rehype-astro-image-md.ts
+++ b/src/utils/markdown/rehype-astro-image-md.ts
@@ -92,37 +92,59 @@ export const rehypeAstroImageMd: Plugin<
 
 				const pictureResult = await getPicture({
 					src: src,
-					widths: [dimensions.width, originalDimensions.width],
+					widths: [dimensions.width],
 					formats: ["avif", "webp", "png"],
 					aspectRatio: imgRatioWidth,
 					alt: node.properties.alt || "",
 				});
 
-				const pngSource = pictureResult.sources.reduce((prev, source) => {
-					const largestSrc = getLargestSourceSetSrc(source.srcset);
-					// select first option
-					if (!prev) return largestSrc;
-					// SVG first
-					if (prev.src.endsWith(".svg")) return prev;
-					if (largestSrc.src.endsWith(".svg")) return prev;
-					// Prefer `w`
-					if (prev.sizeType === "w" && largestSrc.sizeType === "x") return prev;
-					if (largestSrc.sizeType === "w" && prev.sizeType === "x")
-						return largestSrc;
-					// Get the bigger of the two
-					if (largestSrc.size > prev.size) return largestSrc;
-					// Prefer PNG and JPG
-					if (largestSrc.size === prev.size) {
-						if (
-							prev.src.endsWith(".webp") &&
-							(largestSrc.src.endsWith(".png") ||
-								largestSrc.src.endsWith(".jpg") ||
-								largestSrc.src.endsWith(".jpeg"))
-						)
+				let pngSource = {
+					src: src,
+					size: originalDimensions.width,
+				};
+
+				if (
+					!(
+						src.endsWith(".png") ||
+						src.endsWith(".jpg") ||
+						src.endsWith(".jpeg")
+					)
+				) {
+					const originalPictureResult = await getPicture({
+						src: src,
+						widths: [originalDimensions.width],
+						formats: ["png"],
+						aspectRatio: imgRatioWidth,
+						alt: node.properties.alt || "",
+					});
+
+					pngSource = originalPictureResult.sources.reduce((prev, source) => {
+						const largestSrc = getLargestSourceSetSrc(source.srcset);
+						// select first option
+						if (!prev) return largestSrc;
+						// SVG first
+						if (prev.src.endsWith(".svg")) return prev;
+						if (largestSrc.src.endsWith(".svg")) return prev;
+						// Prefer `w`
+						if (prev.sizeType === "w" && largestSrc.sizeType === "x")
+							return prev;
+						if (largestSrc.sizeType === "w" && prev.sizeType === "x")
 							return largestSrc;
-					}
-					return prev;
-				}, null as ReturnType<typeof getLargestSourceSetSrc>);
+						// Get the bigger of the two
+						if (largestSrc.size > prev.size) return largestSrc;
+						// Prefer PNG and JPG
+						if (largestSrc.size === prev.size) {
+							if (
+								prev.src.endsWith(".webp") &&
+								(largestSrc.src.endsWith(".png") ||
+									largestSrc.src.endsWith(".jpg") ||
+									largestSrc.src.endsWith(".jpeg"))
+							)
+								return largestSrc;
+						}
+						return prev;
+					}, null as ReturnType<typeof getLargestSourceSetSrc>);
+				}
 
 				const sources = pictureResult.sources.map((attrs) => {
 					return h("source", attrs);


### PR DESCRIPTION
I noticed in a draft of FFG, that images won't load properly in some instances:

![image](https://user-images.githubusercontent.com/9100169/230754789-a315ad2e-9e0d-42a9-93dc-1c2b177dbde4.png)

Despite being valid MD:

![image](https://user-images.githubusercontent.com/9100169/230754793-dc83e23e-26a0-40dc-b01c-ed1256654394.png)

This PR fixes this issue, which seems to be caused by a weird `width` caused by some odd math calculations:

```
/_image?f=avif&w=632.4705882352941&h=768&ar=0.8235294117647058&href=%2Fcontent%2Fblog%2Fffg-fundamentals-intro-to-components%2Fsidebar.png 632.4705882352941w
```

This PR also:

- Updates our `sharp` image to use `squoosh`
- Adds `AVIF` support to in-MD images
- Fixes medium-image-zoom