### PR TITLE
[UwU] Misc. spacing, scaling, & centering fixes

### DIFF
--- a/src/components/post-card/post-card.module.scss
+++ b/src/components/post-card/post-card.module.scss
@@ -55,6 +55,8 @@
 	border: var(--card_border-width) solid var(--card_border-color);
 	background: var(--card_background-color);
 	overflow: hidden;
+
+	@include transition(background-color border-color);
 }
 
 .postBase:hover {

--- a/src/components/post-card/post-card.tsx
+++ b/src/components/post-card/post-card.tsx
@@ -22,9 +22,9 @@ function PostCardMeta({ post, unicornProfilePicMap }: PostCardProps) {
 					/>
 					<ul className={style.authorList}>
 						{post.authorsMeta.map((author, i, arr) => (
-							<li>
+							<li class="text-style-body-small-bold">
 								<a
-									className={`text-style-body-small-bold ${style.authorName}`}
+									className={`${style.authorName}`}
 									href={`/unicorns/${author.id}`}
 								>
 									{author.name}

--- a/src/global.scss
+++ b/src/global.scss
@@ -18,7 +18,6 @@
 @import "./styles/utilities";
 
 :root {
-	font-size: 1rem;
 	scrollbar-color: var(--focus-outline_primary) var(--background_primary);
 	transition: scrollbar-color $animStyle $animSpeed;
 

--- a/src/styles/container.scss
+++ b/src/styles/container.scss
@@ -2,13 +2,7 @@
 
 .container {
 	margin: 0 auto;
-	padding: 0 var(--spc-4x);
+	padding: 0 var(--site-spacing);
 
-	@include from($desktopSmall) {
-		max-width: $desktopSmall;
-	}
-
-	@include from($desktopLarge) {
-		max-width: $desktopLarge;
-	}
+	max-width: var(--max-width_l);
 }

--- a/src/styles/grid.scss
+++ b/src/styles/grid.scss
@@ -2,7 +2,7 @@
 
 :where(.grid) {
 	display: grid;
-	gap: var(--spc-8x);
+	gap: var(--site-spacing);
 	grid-template-columns: 1fr;
 }
 

--- a/src/styles/markdown/blockquote.scss
+++ b/src/styles/markdown/blockquote.scss
@@ -1,5 +1,4 @@
 :root {
-	--blockquote_margin: var(--spc-4x);
 	--blockquote_border-width: var(--border-width_l);
 	--blockquote_border-color: var(--primary_variant);
 	--blockquote_padding-start: var(--spc-3x);
@@ -7,7 +6,7 @@
 
 blockquote:not([class]) {
 	position: relative;
-	margin: var(--blockquote_margin) 0;
+	margin: var(--site-spacing) 0;
 	padding: 0;
 	padding-left: calc(var(--blockquote_border-width) + var(--blockquote_padding-start));
 

--- a/src/styles/markdown/embed.scss
+++ b/src/styles/markdown/embed.scss
@@ -1,11 +1,9 @@
 @import "src/tokens/index";
 
 :root {
-
 	--embed_header_padding: var(--spc-4x);
 	--embed_header_gap: var(--spc-2x);
 	--embed_corner-radius: var(--corner-radius_l);
-	--embed_margin: var(--spc-4x);
 
 	--embed-iframe_margin: calc( var(--embed_header_padding) / 2 );
 	--embed-iframe_corner-radius: calc( var(--embed_corner-radius) - var(--embed-iframe_margin) );
@@ -29,7 +27,7 @@
 	flex-direction: column;
 	border-radius: var(--embed_corner-radius);
 	background-color: var(--embed_background-color);
-	margin: var(--spc-4x) 0;
+	margin: var(--site-spacing) 0;
 
 	&__header {
 		display: flex;

--- a/src/styles/markdown/hints.scss
+++ b/src/styles/markdown/hints.scss
@@ -1,8 +1,6 @@
 @import "src/tokens/index";
 
 :root {
-	--hint-margin: var(--spc-4x);
-
 	// Padding and gap must be consistent to maintain visual balance
 	--hint-container_padding: var(--spc-1x);
 	--hint-container_gap: var(--hint-container-padding);
@@ -41,7 +39,7 @@
 }
 
 .hint {
-	margin: var(--hint-margin) 0;
+	margin: var(--site-spacing) 0;
 
 	&> .hint__container {
 		display: inline-block;

--- a/src/styles/markdown/lists.scss
+++ b/src/styles/markdown/lists.scss
@@ -1,7 +1,6 @@
 @import "src/tokens/index";
 
 :root {
-	--list_margin: var(--spc-4x);
 	--list_padding-start: var(--spc-1x);
 
 	--list_item_padding-start: var(--spc-3x);
@@ -14,7 +13,7 @@
 
 .post-body ul:not([class]) {
 	list-style-type: none;
-	margin: var(--list-margin) 0;
+	margin: var(--site-spacing) 0;
 	padding: calc(var(--list_item_padding-vertical) / 2) 0;
 	padding-left: var(--list_padding-start);
 

--- a/src/styles/markdown/lists.scss
+++ b/src/styles/markdown/lists.scss
@@ -28,7 +28,6 @@
 
 		&> *:first-child {
 			margin-top: 0;
-			padding-top: 0;
 		}
 	}
 }

--- a/src/styles/markdown/table.scss
+++ b/src/styles/markdown/table.scss
@@ -1,7 +1,6 @@
 @import "src/styles/text-styles.scss";
 
 :root {
-	--table_margin: var(--spc-4x);
 	--table_padding-horizontal: var(--spc-1x);
 	--table_padding-bottom: var(--spc-1x);
 	--table_corner-radius: var(--spc-4x);
@@ -48,7 +47,7 @@ tbody tr:last-child {
 .table-container {
 	max-width: 100%;
 	width: max-content;
-	margin: var(--hint-margin) 0;
+	margin: var(--site-spacing) 0;
 
 	border-radius: var(--table_corner-radius);
 	padding: 0 var(--table_padding-horizontal);

--- a/src/styles/markdown/tabs.scss
+++ b/src/styles/markdown/tabs.scss
@@ -24,6 +24,10 @@
 	--tab_focus-outline_color: var(--focus-outline_primary);
 }
 
+.tabs {
+	margin: var(--site-spacing) 0;
+}
+
 .tabs__tab-list {
 	margin: 0 !important;
 	list-style: none;

--- a/src/styles/markdown/tabs.scss
+++ b/src/styles/markdown/tabs.scss
@@ -88,11 +88,13 @@
 .tabs__tab-panel__inner > *:first-child {
 	border-top-right-radius: var(--tabbed-wrapper_corner-radius_inner);
 	border-top-left-radius: var(--tabbed-wrapper_corner-radius_inner);
+	margin-top: 0;
 }
 
 .tabs__tab-panel__inner > *:last-child {
 	border-bottom-right-radius: var(--tabbed-wrapper_corner-radius_inner);
 	border-bottom-left-radius: var(--tabbed-wrapper_corner-radius_inner);
+	margin-bottom: 0;
 }
 
 @include from($tabletLarge) {

--- a/src/styles/markdown/tooltips.scss
+++ b/src/styles/markdown/tooltips.scss
@@ -53,12 +53,10 @@
 
 		&> *:first-child {
 			margin-top: 0;
-			padding-top: 0;
 		}
 
 		&> *:last-child {
 			margin-bottom: 0;
-			padding-bottom: 0;
 		}
 	}
 }

--- a/src/styles/markdown/tooltips.scss
+++ b/src/styles/markdown/tooltips.scss
@@ -1,5 +1,4 @@
 :root {
-	--tooltip_margin: var(--spc-4x);
 	--tooltip_padding-vertical: var(--spc-3x);
 	--tooltip_padding-start: var(--spc-3x);
 	--tooltip_padding-end: var(--spc-5x);
@@ -22,7 +21,7 @@
 
 	border-radius: var(--tooltip_corner-radius);
 
-	margin: var(--tooltip_margin) 0;
+	margin: var(--site-spacing) 0;
 	padding: var(--tooltip_padding-vertical) 0;
 	padding-left: var(--tooltip_padding-start);
 	padding-right: var(--tooltip_padding-end);

--- a/src/styles/text-styles.scss
+++ b/src/styles/text-styles.scss
@@ -33,7 +33,6 @@
 
 :root {
 	font-family: var(--uu-font-family);
-	font-size: 1rem;
 }
 
 h1, .text-style-headline-1 {

--- a/src/styles/text-styles.scss
+++ b/src/styles/text-styles.scss
@@ -73,7 +73,7 @@ h6, .text-style-headline-6 {
 	line-height: var(--h6_line-height);
 }
 
-:root, p, .text-style-body-large {
+p, .text-style-body-large {
 	font-family: var(--uu-font-family);
 	font-size: var(--p_large_font-size);
 	font-weight: var(--weight_regular);

--- a/src/styles/text-styles.scss
+++ b/src/styles/text-styles.scss
@@ -31,6 +31,11 @@
 
 // TODO: Add back fallback font for Figtree
 
+:root {
+	font-family: var(--uu-font-family);
+	font-size: 1rem;
+}
+
 h1, .text-style-headline-1 {
 	font-family: var(--uu-font-family);
 	font-size: var(--h1_font-size);

--- a/src/views/blog-post/post-title-header/post-title-header.astro
+++ b/src/views/blog-post/post-title-header/post-title-header.astro
@@ -36,11 +36,8 @@ const editedStr = post.edited && dayjs(post.edited).format("MMMM D, YYYY");
 			<ul aria-label="Post authors" role="list" class={style.authors__list}>
 				{
 					post.authorsMeta.map((author, i) => (
-						<li>
-							<a
-								class="text-style-button-regular"
-								href={`/unicorns/${author.id}`}
-							>
+						<li class="text-style-button-regular">
+							<a href={`/unicorns/${author.id}`}>
 								{[author.name, i + 1 < post.authorsMeta.length ? "," : ""]}
 							</a>
 						</li>

--- a/src/views/collections/collection-page.module.scss
+++ b/src/views/collections/collection-page.module.scss
@@ -189,7 +189,6 @@
 
   @include from($tabletSmall) {
     grid-template-columns: min-content 1fr min-content;
-    grid-template-rows: 1fr 1fr;
     grid-column-gap: var(--collection-page_description_padding-top);
   }
 }
@@ -197,6 +196,7 @@
 .authorImage {
   height: var(--collection-page_author_avatar_size);
   width: var(--collection-page_author_avatar_size);
+  align-self: center;
   border-radius: 50%;
   overflow: hidden;
   border-style: solid;
@@ -218,6 +218,9 @@
 }
 
 .authorMetaData {
+  height: max-content;
+  align-self: center;
+
   grid-row: 1;
   grid-column: 2;
 

--- a/src/views/unicorn/unicorn-layout/unicorn-layout.module.scss
+++ b/src/views/unicorn/unicorn-layout/unicorn-layout.module.scss
@@ -5,7 +5,7 @@
 	display: flex;
 	flex-direction: column;
 	flex-wrap: nowrap;
-	gap: var(--spc-8x);
+	gap: var(--site-spacing);
 
 	@include from($desktopSmall) {
 		flex-direction: row;
@@ -20,7 +20,7 @@
 
 .sidebar {
 	@include from($desktopSmall) {
-		top: var(--spc-8x);
+		top: var(--site-spacing);
 		min-width: 320px;
 
 		width: 1px;


### PR DESCRIPTION
- Remove `1fr 1fr` row template, which was forcing both the metadata & bio rows to be an equal height
- Add `align-self: center` to items on the metadata row for vertical alignment
- Fixed scaling bug with a font style incorrectly applied to `:root`
- Replace spacing styles with `var(--site-spacing)` to match specs