### PR TITLE
[UwU] Pagination mobile breakpoint

### DIFF
--- a/src/components/pagination/pagination.module.scss
+++ b/src/components/pagination/pagination.module.scss
@@ -31,8 +31,12 @@
 	list-style: none;
 }
 
-.paginationItem {
+.paginationItemExtra {
+	display: none;
 
+	@include from($tabletSmall) {
+		display: block;
+	}
 }
 
 .paginationButton {

--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -1,29 +1,32 @@
 import styles from "./pagination.module.scss";
-import { Button } from "components/index";
 import forward from "src/icons/arrow_right.svg?raw";
 import back from "src/icons/arrow_left.svg?raw";
 import { PaginationMenuAndPopover } from "components/pagination/pagination-popover";
 import { useEffect, useState } from "preact/hooks";
-import { PaginationProps } from "components/pagination/types";
+import { PaginationButtonProps, PaginationProps } from "components/pagination/types";
 
-const PAGE_BUTTON_COUNT = 2;
+const PAGE_BUTTON_COUNT = 6;
 
-function PaginationButton(props: {
-	pageNum: number;
-	selected: boolean;
-	href: string;
-}) {
+function PaginationButton({
+	pageInfo,
+	pageNum,
+	href,
+	selected
+}: PaginationButtonProps) {
+	const pageOptionalMin = Math.min(Math.max(1, pageInfo.currentPage - 1), pageInfo.lastPage - 3);
+	const isOptional = pageNum < pageOptionalMin || pageNum > pageOptionalMin + 3;
+
 	return (
-		<li className={`${styles.paginationItem}`}>
+		<li className={`${styles.paginationItem} ${isOptional ? styles.paginationItemExtra : ''}`}>
 			<a
 				className={`text-style-body-medium-bold ${styles.paginationButton} ${
-					props.selected ? styles.selected : ""
+					selected ? styles.selected : ""
 				}`}
-				href={props.href}
-				aria-label={`Go to page ${props.pageNum}`}
-				aria-current={props.selected || undefined}
+				href={href}
+				aria-label={`Go to page ${pageNum}`}
+				aria-current={selected || undefined}
 			>
-				{props.pageNum + ""}
+				{pageNum + ""}
 			</a>
 		</li>
 	);
@@ -100,6 +103,7 @@ export const Pagination = ({
 					{pages.map((pageNum) => {
 						return typeof pageNum === "number" ? (
 							<PaginationButton
+								pageInfo={page}
 								pageNum={pageNum}
 								selected={pageNum === page.currentPage}
 								href={getPageHref(pageNum)}

--- a/src/components/pagination/types.ts
+++ b/src/components/pagination/types.ts
@@ -1,8 +1,17 @@
+export interface PageInfo {
+	currentPage: number;
+	lastPage: number;
+}
+
+export interface PaginationButtonProps {
+	pageInfo: PageInfo;
+	pageNum: number;
+	selected: boolean;
+	href: string;
+}
+
 export interface PaginationProps {
-	page: {
-		currentPage: number;
-		lastPage: number;
-	};
+	page: PageInfo;
 	class?: string;
 	id?: string;
 	rootURL?: string;


### PR DESCRIPTION
- Changes the pagination item count to show the correct number of items on desktop
- Adds a mobile breakpoint that hides some of the items on mobile
  (specifically, leaves only the 4 closest pages, plus the "more", "next", and "previous" buttons)