### PR TITLE
[UwU] Convert file list Markdown transform to JSX

### DIFF
--- a/src/styles/markdown/file-list.scss
+++ b/src/styles/markdown/file-list.scss
@@ -1,110 +1,116 @@
-.docs-file-tree {
-  --x-space: 1.75em;
-  --y-pad: 0.2em;
+.docs-file-tree-container {
+	margin: var(--site-spacing) 0;
+	padding: var(--code-block_padding);
+	border-radius: var(--code-block_corner-radius);
+	border: var(--code-block_border_width) solid var(--code-block_border_color);
+}
 
-  display: block;
-  border: 1px solid var(--primary);
-  border-radius: 0.25rem;
-  padding: 1rem 0.5rem;
-  background-color: var(--shiki-color-background);
-  overflow-x: auto;
+.docs-file-tree {
+	--x-space: 1.75em;
+	--y-pad: 0.2em;
+
+	display: block;
+	border: 1px solid var(--primary);
+	border-radius: var(--code-block_inner-corner-radius);
+	background-color: var(--white);
+	padding: var(--code-block_padding);
 }
 
 .docs-file-tree .directory > details,
 .docs-file-tree .directory > details:hover,
 .docs-file-tree .directory > details[open] {
-  margin-bottom: unset;
-  border: 0;
-  padding: 0;
-  padding-inline-start: var(--x-space);
-  background: transparent;
+	margin-bottom: unset;
+	border: 0;
+	padding: 0;
+	padding-inline-start: var(--x-space);
+	background: transparent;
 }
 
 .docs-file-tree .directory > details > summary,
 .docs-file-tree .directory > details[open] > summary {
-  background: unset;
-  border: 0;
-  padding: var(--y-pad) 0.3em;
-  font-weight: normal;
-  color: var(--black);
-  max-width: 100%;
+	background: unset;
+	border: 0;
+	padding: var(--y-pad) 0.3em;
+	font-weight: normal;
+	color: var(--black);
+	max-width: 100%;
 }
 
 .docs-file-tree .directory > details > summary::marker,
 .docs-file-tree .directory > details > summary::-webkit-details-marker {
-  color: currentColor;
+	color: currentColor;
 }
 
 .docs-file-tree .directory > details > summary:hover .tree-icon,
 .docs-file-tree .directory > details > summary:hover {
-  color: var(--lightPrimary);
-  opacity: 0.8;
+	color: var(--lightPrimary);
+	opacity: 0.8;
 }
 
 .docs-file-tree ul:is(ul),
 .docs-file-tree .directory > details ul:is(ul) {
-  margin: 0;
-  margin-inline-start: calc(1em - 1px);
-  border-inline-start: 2px solid var(--minImpactBlack);
-  padding: 0;
-  list-style: none;
+	margin: 0;
+	margin-inline-start: calc(1em - 1px);
+	border-inline-start: 2px solid var(--foreground_emphasis-low);
+	padding: 0;
+	list-style: none;
 }
 
 .docs-file-tree > ul:is(ul) {
-  margin: 0;
-  border: 0;
+	margin: 0;
+	border: 0;
 }
 
 .docs-file-tree li:is(li) {
-  margin: 0;
-  padding: var(--y-pad) 0;
+	margin: 0;
+	padding: var(--y-pad) 0;
 }
 
 .docs-file-tree .file {
-  margin-inline-start: var(--x-space);
-  color: var(--black);
+	margin-inline-start: var(--x-space);
+	color: var(--black);
 }
 
 .docs-file-tree .tree-entry {
-  display: inline-flex;
-  align-items: flex-start;
-  flex-wrap: wrap;
-  max-width: calc(100% - 1.25em);
+	display: inline-flex;
+	align-items: flex-start;
+	flex-wrap: wrap;
+	max-width: calc(100% - 1.25em);
 }
 
 @media (min-width: 30em) {
-  .docs-file-tree .tree-entry {
-    flex-wrap: nowrap;
-  }
+	.docs-file-tree .tree-entry {
+		flex-wrap: nowrap;
+	}
 }
 
 .docs-file-tree .tree-entry > :first-child {
-  flex-shrink: 0;
+	flex-shrink: 0;
 }
 
 .docs-file-tree .empty {
-  color: var(--lowImpactBlack);
-  padding-inline-start: 0.5em;
+	color: 2px solid var(--foreground_emphasis-medium);
+	padding-inline-start: 0.5em;
 }
 
 .docs-file-tree .comment {
-  color: var(--lowImpactBlack);
-  padding-inline-start: 2em;
-  max-width: 30em;
-  min-width: 15em;
+	color: var(--lowImpactBlack);
+	padding-inline-start: 2em;
+	max-width: 30em;
+	min-width: 15em;
 }
 
 .docs-file-tree .highlight {
-  display: inline-block;
-  border-radius: 0.3em;
-  padding-inline-end: 0.5em;
-  outline: 1px solid var(--lightPrimary);
+	display: inline-block;
+	border-radius: 0.3em;
+	padding-inline-end: 0.5em;
+	outline: 1px solid var(--primary_default);
 }
 
 .tree-icon {
-  fill: currentColor;
-  vertical-align: middle;
-  margin: -0.75em 0.2em;
-  width: 1.5em;
-  height: 1.5em;
+	fill: currentColor;
+	vertical-align: middle;
+	margin: -0.75em 0.2em;
+	width: 1.5em;
+	height: 1.5em;
 }

--- a/src/utils/markdown/file-tree/file-list.tsx
+++ b/src/utils/markdown/file-tree/file-list.tsx
@@ -1,0 +1,84 @@
+/** @jsxRuntime automatic */
+import { Node, Element } from "hast";
+
+interface File {
+	name: string;
+	filetype: string;
+	isDirectory: false;
+}
+
+interface Directory {
+	name: string;
+	isDirectory: true;
+	items: Array<Directory | File>;
+}
+
+interface FileProps {
+	item: File;
+}
+
+/** @jsxImportSource hastscript */
+function File({ item }: FileProps) {
+	return (
+		<span class="tree-entry">
+			<span>
+				<svg class="tree-icon" aria-hidden="true"></svg>
+				<code>{item.name}</code>
+			</span>
+		</span>
+	) as never;
+}
+
+interface DirectoryProps {
+	item: Directory;
+}
+
+/** @jsxImportSource hastscript */
+function Directory({ item }: DirectoryProps) {
+	return (
+		<details open>
+			<summary>
+				<span className="tree-entry">
+					<span>
+						<svg className="tree-icon" aria-hidden="true"></svg>
+						<code>{item.name}</code>
+					</span>
+				</span>
+			</summary>
+			<FileListList items={item.items} />
+		</details>
+	) as never;
+}
+
+interface FileListProps {
+	items: Array<Directory | File>;
+}
+
+/** @jsxImportSource hastscript */
+function FileListList({ items }: FileListProps) {
+	const isDirectory = (item: Directory | File): item is Directory => {
+		return (item as Directory).isDirectory;
+	};
+
+	return (
+		<ul className="docs-file-tree-list">
+			{items.map((item) => (
+				<li
+					className={item.isDirectory ? "directory" : "file"}
+					data-filetype={isDirectory(item) ? "dir" : item.filetype}
+				>
+					{isDirectory(item) ? <Directory item={item} /> : <File item={item} />}
+				</li>
+			))}
+		</ul>
+	) as never;
+}
+
+/** @jsxImportSource hastscript */
+export function FileList({ items }: FileListProps): Element {
+	return (
+		<div class="docs-file-tree">
+			<FileListList items={items} />
+		</div>
+	) as never;
+}

--- a/src/utils/markdown/file-tree/file-list.tsx
+++ b/src/utils/markdown/file-tree/file-list.tsx
@@ -1,5 +1,6 @@
 /** @jsxRuntime automatic */
 import { Node, Element } from "hast";
+import type { HChild } from "hastscript/lib/core";
 
 /**
  * TODO:
@@ -10,13 +11,16 @@ import { Node, Element } from "hast";
 
 export interface File {
 	name: Node;
+	comment?: HChild[];
 	filetype: string;
 	isDirectory: false;
+	isPlaceholder: boolean;
 	isHighlighted: boolean;
 }
 
 export interface Directory {
 	name: Node;
+	comment?: HChild[];
 	isDirectory: true;
 	items: Array<Directory | File>;
 	openByDefault: boolean;
@@ -32,9 +36,14 @@ function File({ item }: FileProps) {
 	return (
 		<span class="tree-entry">
 			<span>
-				<svg class="tree-icon" aria-hidden="true"></svg>
+				<span>
+					<svg class="tree-icon" aria-hidden="true"></svg>
+				</span>
 				{item.name}
 			</span>
+			{item.comment && item.comment.length ? (
+				<span class="comment">{item.comment}</span>
+			) : null}
 		</span>
 	) as never;
 }
@@ -50,9 +59,15 @@ function Directory({ item }: DirectoryProps) {
 			<summary>
 				<span className="tree-entry">
 					<span>
-						<svg className="tree-icon" aria-hidden="true"></svg>
-						<code>{item.name}</code>
+						<span>
+							<span className="sr-only">Directory</span>
+							<svg className="tree-icon" aria-hidden="true"></svg>
+						</span>
+						{item.name}
 					</span>
+					{item.comment && item.comment.length ? (
+						<span class="comment">{item.comment}</span>
+					) : null}
 				</span>
 			</summary>
 			{FileListList({ items: item.items })}

--- a/src/utils/markdown/file-tree/file-list.tsx
+++ b/src/utils/markdown/file-tree/file-list.tsx
@@ -1,16 +1,26 @@
 /** @jsxRuntime automatic */
 import { Node, Element } from "hast";
 
-interface File {
-	name: string;
+/**
+ * TODO:
+ * - [ ] Highlighted
+ * - [ ] Placeholder
+ * - [ ] SVGs
+ */
+
+export interface File {
+	name: Node;
 	filetype: string;
 	isDirectory: false;
+	isHighlighted: boolean;
 }
 
-interface Directory {
-	name: string;
+export interface Directory {
+	name: Node;
 	isDirectory: true;
 	items: Array<Directory | File>;
+	openByDefault: boolean;
+	isHighlighted: boolean;
 }
 
 interface FileProps {
@@ -23,7 +33,7 @@ function File({ item }: FileProps) {
 		<span class="tree-entry">
 			<span>
 				<svg class="tree-icon" aria-hidden="true"></svg>
-				<code>{item.name}</code>
+				{item.name}
 			</span>
 		</span>
 	) as never;
@@ -36,7 +46,7 @@ interface DirectoryProps {
 /** @jsxImportSource hastscript */
 function Directory({ item }: DirectoryProps) {
 	return (
-		<details open>
+		<details open={item.openByDefault}>
 			<summary>
 				<span className="tree-entry">
 					<span>
@@ -45,7 +55,7 @@ function Directory({ item }: DirectoryProps) {
 					</span>
 				</span>
 			</summary>
-			<FileListList items={item.items} />
+			{FileListList({ items: item.items })}
 		</details>
 	) as never;
 }
@@ -67,7 +77,7 @@ function FileListList({ items }: FileListProps) {
 					className={item.isDirectory ? "directory" : "file"}
 					data-filetype={isDirectory(item) ? "dir" : item.filetype}
 				>
-					{isDirectory(item) ? <Directory item={item} /> : <File item={item} />}
+					{isDirectory(item) ? Directory({ item }) : File({ item })}
 				</li>
 			))}
 		</ul>
@@ -76,9 +86,5 @@ function FileListList({ items }: FileListProps) {
 
 /** @jsxImportSource hastscript */
 export function FileList({ items }: FileListProps): Element {
-	return (
-		<div class="docs-file-tree">
-			<FileListList items={items} />
-		</div>
-	) as never;
+	return (<div class="docs-file-tree">{FileListList({ items })}</div>) as never;
 }

--- a/src/utils/markdown/file-tree/file-list.tsx
+++ b/src/utils/markdown/file-tree/file-list.tsx
@@ -1,13 +1,32 @@
 /** @jsxRuntime automatic */
 import { Node, Element } from "hast";
 import type { HChild } from "hastscript/lib/core";
+import { fromHtml } from "hast-util-from-html";
+import { getIcon } from "./file-tree-icons";
+import { toString } from "hast-util-to-string";
 
-/**
- * TODO:
- * - [ ] Highlighted
- * - [ ] Placeholder
- * - [ ] SVGs
- */
+/** Convert an HTML string containing an SVG into a HAST element node. */
+const makeSVGIcon = (svgString: string) => {
+	const root = fromHtml(svgString, { fragment: true });
+	const svg = root.children[0] as Element;
+	svg.properties = {
+		...svg.properties,
+		width: 16,
+		height: 16,
+		class: "tree-icon",
+		"aria-hidden": "true",
+	};
+	return svg;
+};
+
+const FileIcon = (filename: string) => {
+	const { svg } = getIcon(filename);
+	return makeSVGIcon(svg);
+};
+
+const FolderIcon = makeSVGIcon(
+	'<svg viewBox="-5 -5 26 26"><path d="M1.8 1A1.8 1.8 0 0 0 0 2.8v10.4c0 1 .8 1.8 1.8 1.8h12.4a1.8 1.8 0 0 0 1.8-1.8V4.8A1.8 1.8 0 0 0 14.2 3H7.5a.3.3 0 0 1-.2-.1l-.9-1.2A2 2 0 0 0 5 1H1.7z"/></svg>'
+);
 
 export interface File {
 	name: Node;
@@ -33,12 +52,12 @@ interface FileProps {
 
 /** @jsxImportSource hastscript */
 function File({ item }: FileProps) {
+	const rawName = toString(item.name as never);
+
 	return (
 		<span class="tree-entry">
 			<span>
-				<span>
-					<svg class="tree-icon" aria-hidden="true"></svg>
-				</span>
+				{item.isPlaceholder ? null : <span>{FileIcon(rawName)}</span>}
 				{item.name}
 			</span>
 			{item.comment && item.comment.length ? (
@@ -59,16 +78,13 @@ function Directory({ item }: DirectoryProps) {
 			<summary>
 				<span className="tree-entry">
 					<span>
-						<span>
-							<span className="sr-only">Directory</span>
-							<svg className="tree-icon" aria-hidden="true"></svg>
-						</span>
+						<span aria-label="Directory">{FolderIcon}</span>
 						{item.name}
 					</span>
-					{item.comment && item.comment.length ? (
-						<span class="comment">{item.comment}</span>
-					) : null}
 				</span>
+				{item.comment && item.comment.length ? (
+					<span class="comment">{item.comment}</span>
+				) : null}
 			</summary>
 			{FileListList({ items: item.items })}
 		</details>

--- a/src/utils/markdown/file-tree/file-list.tsx
+++ b/src/utils/markdown/file-tree/file-list.tsx
@@ -56,7 +56,7 @@ function File({ item }: FileProps) {
 
 	return (
 		<span class="tree-entry">
-			<span>
+			<span className={item.isHighlighted ? "highlight" : ""}>
 				{item.isPlaceholder ? null : <span>{FileIcon(rawName)}</span>}
 				{item.name}
 			</span>
@@ -77,7 +77,7 @@ function Directory({ item }: DirectoryProps) {
 		<details open={item.openByDefault}>
 			<summary>
 				<span className="tree-entry">
-					<span>
+					<span className={item.isHighlighted ? "highlight" : ""}>
 						<span aria-label="Directory">{FolderIcon}</span>
 						{item.name}
 					</span>
@@ -117,5 +117,9 @@ function FileListList({ items }: FileListProps) {
 
 /** @jsxImportSource hastscript */
 export function FileList({ items }: FileListProps): Element {
-	return (<div class="docs-file-tree">{FileListList({ items })}</div>) as never;
+	return (
+		<div className="docs-file-tree-container">
+			<div class="docs-file-tree">{FileListList({ items })}</div>
+		</div>
+	) as never;
 }

--- a/src/utils/markdown/file-tree/rehype-file-tree.ts
+++ b/src/utils/markdown/file-tree/rehype-file-tree.ts
@@ -18,162 +18,150 @@
  * - `index.css`
  * <!-- filetree:end -->
  */
-import { fromHtml } from "hast-util-from-html";
 import { toString } from "hast-util-to-string";
-import { h } from "hastscript";
 import type { Element, HChild } from "hastscript/lib/core";
-import { CONTINUE, SKIP, visit } from "unist-util-visit";
-import { getIcon } from "./file-tree-icons";
+import { visit } from "unist-util-visit";
 import replaceAllBetween from "unist-util-replace-all-between";
 import { Node } from "unist";
-import { Root } from "hast";
 import JSON5 from "json5";
+import { FileList, Directory, File } from "./file-list";
+import { fromHtml } from "hast-util-from-html";
 
-/** Make a text node with the pass string as its contents. */
-const Text = (value = ""): { type: "text"; value: string } => ({
-	type: "text",
-	value,
-});
+interface DirectoryMetadata {
+	open?: boolean;
+}
 
-/** Convert an HTML string containing an SVG into a HAST element node. */
-const makeSVGIcon = (svgString: string) => {
-	const root = fromHtml(svgString, { fragment: true });
-	const svg = root.children[0] as Element;
-	svg.properties = {
-		...svg.properties,
-		width: 16,
-		height: 16,
-		class: "tree-icon",
-		"aria-hidden": "true",
-	};
-	return svg;
-};
-
-const FileIcon = (filename: string) => {
-	const { svg } = getIcon(filename);
-	return makeSVGIcon(svg);
-};
-
-const FolderIcon = makeSVGIcon(
-	'<svg viewBox="-5 -5 26 26"><path d="M1.8 1A1.8 1.8 0 0 0 0 2.8v10.4c0 1 .8 1.8 1.8 1.8h12.4a1.8 1.8 0 0 0 1.8-1.8V4.8A1.8 1.8 0 0 0 14.2 3H7.5a.3.3 0 0 1-.2-.1l-.9-1.2A2 2 0 0 0 5 1H1.7z"/></svg>'
-);
+interface FileMetadata {}
 
 export const rehypeFileTree = () => {
 	return (tree) => {
 		function replaceFiletreeNodes(nodes: Node[]) {
-			const root = { type: "root", children: nodes } as Root;
-			visit(root, "element", (node) => {
-				// Strip nodes that only contain newlines
-				node.children = node.children.filter(
-					(child) =>
-						child.type === "comment" ||
-						child.type !== "text" ||
-						!/^\n+$/.test(child.value)
-				);
+			const items: Array<Directory | File> = [];
 
-				if (node.tagName !== "li") return CONTINUE;
+			const isNodeElement = (node: any): node is Element =>
+				typeof node === "object" && node.type === "element";
 
-				// Ensure node has properties so we can assign classes later.
-				if (!node.properties) node.properties = {};
+			function traverseUl(listNode: Element, listItems: typeof items) {
+				if (listNode.children.length === 0) return;
 
-				const [firstChild, ...otherChildren] = node.children;
+				for (const listItem of listNode.children) {
+					// Filter out `\n` text nodes
+					if (!(isNodeElement(listItem) && listItem.tagName === "li")) continue;
 
-				/**
-				 * If a file or folder has an object at the end, assume it's a metadata object
-				 * that we want to associate with the file or folder.
-				 *
-				 *  @eg: `folder/ {open: false}`
-				 */
-				let metadata: { open?: boolean } = {};
+					// Strip nodes that only contain newlines
+					listItem.children = listItem.children.filter(
+						(child) =>
+							child.type === "comment" ||
+							child.type !== "text" ||
+							!/^\n+$/.test(child.value)
+					);
 
-				visit({ type: "root", children: [firstChild] }, "text", (node) => {
-					const match = node.value.match(/(.*)\s*({.*})\s*$/);
-					if (match) {
-						node.value = match[1];
-						metadata = JSON5.parse(match[2]);
+					const [firstChild, ...otherChildren] = listItem.children;
+
+					/**
+					 * If a file or folder has an object at the end, assume it's a metadata object
+					 * that we want to associate with the file or folder.
+					 *
+					 *  @eg: `folder/ {open: false}`
+					 */
+					let metadata: DirectoryMetadata & FileMetadata = {};
+
+					visit({ type: "root", children: [firstChild] }, "text", (node) => {
+						const match = node.value.match(/(.*)\s*({.*})\s*$/);
+						if (match) {
+							node.value = match[1];
+							metadata = JSON5.parse(match[2]);
+						}
+					});
+
+					const comment: HChild[] = [];
+					if (firstChild.type === "text") {
+						const [filename, ...fragments] = firstChild.value.split(" ");
+						firstChild.value = filename;
+						comment.push(fragments.join(" "));
 					}
-				});
-
-				const comment: HChild[] = [];
-				if (firstChild.type === "text") {
-					const [filename, ...fragments] = firstChild.value.split(" ");
-					firstChild.value = filename;
-					comment.push(fragments.join(" "));
-				}
-				const subTreeIndex = otherChildren.findIndex(
-					(child) => child.type === "element" && child.tagName === "ul"
-				);
-				const commentNodes =
-					subTreeIndex > -1
-						? otherChildren.slice(0, subTreeIndex)
-						: [...otherChildren];
-				otherChildren.splice(
-					0,
-					subTreeIndex > -1 ? subTreeIndex : otherChildren.length
-				);
-				comment.push(...commentNodes);
-
-				const firstChildTextContent = toString(firstChild);
-
-				// Decide a node is a directory if it ends in a `/` or contains another list.
-				const isDirectory =
-					/\/\s*$/.test(firstChildTextContent) ||
-					otherChildren.some(
+					const subTreeIndex = otherChildren.findIndex(
 						(child) => child.type === "element" && child.tagName === "ul"
 					);
-				const isPlaceholder = /^\s*(\.{3}|…)\s*$/.test(firstChildTextContent);
-				const isHighlighted =
-					firstChild.type === "element" && firstChild.tagName === "strong";
-				const hasContents = otherChildren.length > 0;
+					const commentNodes =
+						subTreeIndex > -1
+							? otherChildren.slice(0, subTreeIndex)
+							: [...otherChildren];
+					otherChildren.splice(
+						0,
+						subTreeIndex > -1 ? subTreeIndex : otherChildren.length
+					);
+					comment.push(...commentNodes);
 
-				const fileExtension = isDirectory
-					? "dir"
-					: firstChildTextContent.trim().split(".").pop() || "";
+					const firstChildTextContent = toString(firstChild);
 
-				const icon = h(
-					"span",
-					isDirectory ? FolderIcon : FileIcon(firstChildTextContent)
-				);
-				if (!icon.properties) icon.properties = {};
-				if (isDirectory) {
-					icon.properties["aria-label"] = "Directory";
+					// Decide a node is a directory if it ends in a `/` or contains another list.
+					const directoryNode = otherChildren.find(
+						(child) => child.type === "element" && child.tagName === "ul"
+					);
+
+					const isDirectory =
+						/\/\s*$/.test(firstChildTextContent) || directoryNode;
+
+					const isPlaceholder = /^\s*(\.{3}|…)\s*$/.test(firstChildTextContent);
+
+					const isHighlighted =
+						firstChild.type === "element" && firstChild.tagName === "strong";
+					const hasContents = otherChildren.length > 0;
+
+					const fileExtension = directoryNode
+						? "dir"
+						: firstChildTextContent.trim().split(".").pop() || "";
+
+					// It's a file, there's no sub-tree
+					if (!isDirectory) {
+						listItems.push({
+							isDirectory: false,
+							name: firstChild,
+							filetype: fileExtension,
+							comment,
+							isHighlighted,
+							isPlaceholder,
+							...(metadata as {}),
+						});
+						continue;
+					}
+
+					const dirItems: Array<File | Directory> = [];
+					listItems.push({
+						isDirectory: true,
+						name: firstChild,
+						isHighlighted,
+						items: dirItems,
+						comment,
+						// Overwritten by `metadata.openByDefault` if it exists
+						openByDefault: metadata?.open ?? hasContents,
+					});
+
+					if (!hasContents) {
+						dirItems.push({
+							isDirectory: false,
+							name: fromHtml("..."),
+							filetype: "",
+							isHighlighted: false,
+							isPlaceholder: true,
+						});
+					}
+
+					if (!isNodeElement(directoryNode)) continue;
+					traverseUl(directoryNode, dirItems);
 				}
+			}
 
-				node.properties.class = isDirectory ? "directory" : "file";
-				if (isPlaceholder) node.properties.class += " empty";
-				node.properties["data-filetype"] = fileExtension;
+			const list = nodes.find(
+				(node) => isNodeElement(node) && node.tagName === "ul"
+			) as Element;
 
-				const treeEntry = h(
-					"span",
-					{ class: "tree-entry" },
-					h("span", { class: isHighlighted ? "highlight" : "" }, [
-						isPlaceholder ? null : icon,
-						firstChild,
-					]),
-					Text(comment.length > 0 ? " " : ""),
-					comment.length > 0
-						? h("span", { class: "comment" }, ...comment)
-						: Text()
-				);
+			if (!list) throw "No list found in filetree";
 
-				if (isDirectory) {
-					node.children = [
-						h("details", { open: metadata.open ?? hasContents }, [
-							h("summary", treeEntry),
-							...(hasContents ? otherChildren : [h("ul", h("li", "…"))]),
-						]),
-					];
-					// Continue down the tree.
-					return CONTINUE;
-				}
+			traverseUl(list, items);
 
-				node.children = [treeEntry, ...otherChildren];
-
-				// Files can’t contain further files or directories, so skip iterating children.
-				return SKIP;
-			});
-
-			return [h("div", { class: "docs-file-tree" }, root.children)];
+			return [FileList({ items })];
 		}
 
 		replaceAllBetween(


### PR DESCRIPTION
This PR doesn't include styling yet, but migrates the file list component to use JSX for the markdown transform and provides a nicer temporary styling:

<img width="467" alt="image" src="https://github.com/unicorn-utterances/unicorn-utterances/assets/9100169/80bffff6-f5cb-40e8-88fb-762c9a0f0dd9">

> Shown with highlight and comments, which are not really in the blog post