### PR TITLE
[UwU] Fix article nav order on mobile

### DIFF
--- a/src/views/blog-post/article-nav/article-nav.module.scss
+++ b/src/views/blog-post/article-nav/article-nav.module.scss
@@ -91,12 +91,19 @@
 	}
 
 	&--previous {
+		&:not(:only-child) {
+			grid-row: 2;
+		}
+
 		@include from($tabletSmall) {
+			grid-row: 1;
 			grid-column: 1;
 		}
 	}
 
 	&--next {
+		grid-row: 1;
+
 		@include from($tabletSmall) {
 			grid-column: 2;
 		}


### PR DESCRIPTION
Reorders the next/previous article nav buttons on mobile, so that "next" appears above the "previous" button.