### PR TITLE
[UwU] Migration pagination to use React Aria

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -33,7 +33,7 @@ module.exports = {
 			},
 		},
 		{
-			files: ["*.ts"],
+			files: ["*.ts", "*.tsx"],
 			parser: "@typescript-eslint/parser",
 			extends: ["plugin:@typescript-eslint/recommended"],
 			rules: {

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -46,7 +46,13 @@ export default defineConfig({
 	vite: {
 		ssr: {
 			external: ["svgo"],
-			noExternal: ["@floating-ui/react", "@floating-ui/react-dom"],
+			noExternal: [
+				"react-aria",
+				"react-stately",
+				/@react-aria/,
+				/@react-stately/,
+				/@react-types/,
+			],
 		},
 		plugins: [svgr()],
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,10 @@
 			"version": "0.3.0-alpha.1",
 			"license": "MPL-2.0",
 			"dependencies": {
-				"@floating-ui/react": "^0.24.3",
 				"medium-zoom": "^1.0.8",
-				"preact": "^10.16.0"
+				"preact": "^10.16.0",
+				"react-aria": "^3.26.0",
+				"react-stately": "^3.24.0"
 			},
 			"devDependencies": {
 				"@astrojs/image": "^0.17.1",
@@ -1885,43 +1886,48 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
-		"node_modules/@floating-ui/core": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.3.1.tgz",
-			"integrity": "sha512-Bu+AMaXNjrpjh41znzHqaz3r2Nr8hHuHZT6V2LBKMhyMl0FgKA62PNYbqnfgmzOhoWZj70Zecisbo4H1rotP5g=="
-		},
-		"node_modules/@floating-ui/dom": {
-			"version": "1.4.5",
-			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.4.5.tgz",
-			"integrity": "sha512-96KnRWkRnuBSSFbj0sFGwwOUd8EkiecINVl0O9wiZlZ64EkpyAOG3Xc2vKKNJmru0Z7RqWNymA+6b8OZqjgyyw==",
+		"node_modules/@formatjs/ecma402-abstract": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.17.0.tgz",
+			"integrity": "sha512-6ueQTeJZtwKjmh23bdkq/DMqH4l4bmfvtQH98blOSbiXv/OUiyijSW6jU22IT8BNM1ujCaEvJfTtyCYVH38EMQ==",
 			"dependencies": {
-				"@floating-ui/core": "^1.3.1"
+				"@formatjs/intl-localematcher": "0.4.0",
+				"tslib": "^2.4.0"
 			}
 		},
-		"node_modules/@floating-ui/react": {
-			"version": "0.24.8",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.8.tgz",
-			"integrity": "sha512-AuYeDoaR8jtUlUXtZ1IJ/6jtBkGnSpJXbGNzokBL87VDJ8opMq1Bgrc0szhK482ReQY6KZsMoZCVSb4xwalkBA==",
+		"node_modules/@formatjs/fast-memoize": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
+			"integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
 			"dependencies": {
-				"@floating-ui/react-dom": "^2.0.1",
-				"aria-hidden": "^1.2.3",
-				"tabbable": "^6.0.1"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
+				"tslib": "^2.4.0"
 			}
 		},
-		"node_modules/@floating-ui/react-dom": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.1.tgz",
-			"integrity": "sha512-rZtAmSht4Lry6gdhAJDrCp/6rKN7++JnL1/Anbr/DdeyYXQPxvg/ivrbYvJulbRf4vL8b212suwMM2lxbv+RQA==",
+		"node_modules/@formatjs/icu-messageformat-parser": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.6.0.tgz",
+			"integrity": "sha512-yT6at0qc0DANw9qM/TU8RZaCtfDXtj4pZM/IC2WnVU80yAcliS3KVDiuUt4jSQAeFL9JS5bc2hARnFmjPdA6qw==",
 			"dependencies": {
-				"@floating-ui/dom": "^1.3.0"
-			},
-			"peerDependencies": {
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
+				"@formatjs/ecma402-abstract": "1.17.0",
+				"@formatjs/icu-skeleton-parser": "1.6.0",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@formatjs/icu-skeleton-parser": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.6.0.tgz",
+			"integrity": "sha512-eMmxNpoX/J1IPUjPGSZwo0Wh+7CEvdEMddP2Jxg1gQJXfGfht/FdW2D5XDFj3VMbOTUQlDIdZJY7uC6O6gjPoA==",
+			"dependencies": {
+				"@formatjs/ecma402-abstract": "1.17.0",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@formatjs/intl-localematcher": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.4.0.tgz",
+			"integrity": "sha512-bRTd+rKomvfdS4QDlVJ6TA/Jx1F2h/TBVO5LjvhQ7QPPHp19oPNMIum7W2CMEReq/zPxpmCeB31F9+5gl/qtvw==",
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@gar/promisify": {
@@ -1962,6 +1968,39 @@
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true
+		},
+		"node_modules/@internationalized/date": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.3.0.tgz",
+			"integrity": "sha512-qfRd7jCIgUjabI8RxeAsxhLDRS1u8eUPX96GB5uBp1Tpm6YY6dVveE7YwsTEV6L4QOp5LKFirFHHGsL/XQwJIA==",
+			"dependencies": {
+				"@swc/helpers": "^0.5.0"
+			}
+		},
+		"node_modules/@internationalized/message": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.1.tgz",
+			"integrity": "sha512-ZgHxf5HAPIaR0th+w0RUD62yF6vxitjlprSxmLJ1tam7FOekqRSDELMg4Cr/DdszG5YLsp5BG3FgHgqquQZbqw==",
+			"dependencies": {
+				"@swc/helpers": "^0.5.0",
+				"intl-messageformat": "^10.1.0"
+			}
+		},
+		"node_modules/@internationalized/number": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.2.1.tgz",
+			"integrity": "sha512-hK30sfBlmB1aIe3/OwAPg9Ey0DjjXvHEiGVhNaOiBJl31G0B6wMaX8BN3ibzdlpyRNE9p7X+3EBONmxtJO9Yfg==",
+			"dependencies": {
+				"@swc/helpers": "^0.5.0"
+			}
+		},
+		"node_modules/@internationalized/string": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.1.1.tgz",
+			"integrity": "sha512-fvSr6YRoVPgONiVIUhgCmIAlifMVCeej/snPZVzbzRPxGpHl3o1GRe+d/qh92D8KhgOciruDUH8I5mjdfdjzfA==",
+			"dependencies": {
+				"@swc/helpers": "^0.5.0"
+			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -3875,6 +3914,1389 @@
 				"url": "https://opencollective.com/preact"
 			}
 		},
+		"node_modules/@react-aria/breadcrumbs": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/@react-aria/breadcrumbs/-/breadcrumbs-3.5.3.tgz",
+			"integrity": "sha512-rmkApAflZm7Finn3vxLGv7MbsMaPo5Bn7/lf8GBztNfzmLWP/dAA5bgvi1sj1T6sWJOuFJT8u04ImUwBCLh8cQ==",
+			"dependencies": {
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/link": "^3.5.2",
+				"@react-aria/utils": "^3.18.0",
+				"@react-types/breadcrumbs": "^3.6.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/button": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/button/-/button-3.8.0.tgz",
+			"integrity": "sha512-QdvXTQgn+QEWOHoMbUIPXSBIN5P2r1zthRvqDJMTCzuT0I6LbNAq7RoojEbRrcn0DbTa/nZPzOOYsZXjgteRdw==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/toggle": "^3.6.0",
+				"@react-types/button": "^3.7.3",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/calendar": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/calendar/-/calendar-3.4.0.tgz",
+			"integrity": "sha512-Ly+9KsOXWZTlOYDZeIYCWNuMZg7ZiJC497Z4U3SqaWmDsZaqwU8ZnLmZ1xUWq1cYvK9rnWPnnpby1JUgttY9RA==",
+			"dependencies": {
+				"@internationalized/date": "^3.3.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/live-announcer": "^3.3.1",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/calendar": "^3.3.0",
+				"@react-types/button": "^3.7.3",
+				"@react-types/calendar": "^3.3.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/checkbox": {
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.9.2.tgz",
+			"integrity": "sha512-gpvC+EnrxcQ9wupnoXsIDUmhSeBpxWtfRIYYypn6Ta6NY9Ubkh4H/8xE9/27nhJltHf5rzEcLfKg4QlEftab/w==",
+			"dependencies": {
+				"@react-aria/label": "^3.6.0",
+				"@react-aria/toggle": "^3.6.2",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/checkbox": "^3.4.3",
+				"@react-stately/toggle": "^3.6.0",
+				"@react-types/checkbox": "^3.4.4",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/combobox": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/combobox/-/combobox-3.6.2.tgz",
+			"integrity": "sha512-SWbA2vH26zcrZDbXdPJtZNR6ywYPdf4LU8/7IKLs1Iv7mrlICr9Cmeywiu2RuFRosuR1hGSy1hibBTgPO6V/sw==",
+			"dependencies": {
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/listbox": "^3.10.0",
+				"@react-aria/live-announcer": "^3.3.1",
+				"@react-aria/menu": "^3.10.0",
+				"@react-aria/overlays": "^3.15.0",
+				"@react-aria/selection": "^3.16.0",
+				"@react-aria/textfield": "^3.10.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/combobox": "^3.5.2",
+				"@react-stately/layout": "^3.12.2",
+				"@react-types/button": "^3.7.3",
+				"@react-types/combobox": "^3.6.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/datepicker": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/datepicker/-/datepicker-3.5.0.tgz",
+			"integrity": "sha512-oUfLbfFwe5XgS2Womx0t0gA8797mGQjjxZAGa9lGSNGFx26NOfhWBh24lAYQzQnZ5ot/DxDSJmzLjN6WEWv9pQ==",
+			"dependencies": {
+				"@internationalized/date": "^3.3.0",
+				"@internationalized/number": "^3.2.1",
+				"@internationalized/string": "^3.1.1",
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/label": "^3.6.0",
+				"@react-aria/spinbutton": "^3.5.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/datepicker": "^3.5.0",
+				"@react-types/button": "^3.7.3",
+				"@react-types/calendar": "^3.3.0",
+				"@react-types/datepicker": "^3.4.0",
+				"@react-types/dialog": "^3.5.3",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/dialog": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.3.tgz",
+			"integrity": "sha512-wXpAqnt6TtR4X/5Xk5HCTBM0qyPcF2bXFQ5z2gSwl1olgoQ5znZEgMqMLbMmwb4dsWGGtAueULs6fVZk766ygA==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/overlays": "^3.15.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/overlays": "^3.6.0",
+				"@react-types/dialog": "^3.5.3",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/dnd": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/dnd/-/dnd-3.3.0.tgz",
+			"integrity": "sha512-rk46inb6XdVR5cIFzuMoqUfdqgqb+GHOIFGDiwhHYONeCdvQKD31ztQZ78yITORmPOmjrnn6r2V3GQ6Oz54WSQ==",
+			"dependencies": {
+				"@internationalized/string": "^3.1.1",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/live-announcer": "^3.3.1",
+				"@react-aria/overlays": "^3.15.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-aria/visually-hidden": "^3.8.2",
+				"@react-stately/dnd": "^3.2.2",
+				"@react-types/button": "^3.7.3",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/focus": {
+			"version": "3.13.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.13.0.tgz",
+			"integrity": "sha512-9DW7RqgbFWiImZmkmTIJGe9LrQBqEeLYwlKY+F1FTVXerIPiCCQ3JO3ESEa4lFMmkaHoueFLUrq2jkYjRNqoTw==",
+			"dependencies": {
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0",
+				"clsx": "^1.1.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/grid": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/grid/-/grid-3.8.0.tgz",
+			"integrity": "sha512-7z1xFAbLPgUPROrXwuJk94STQPQ/K8rCLshhwTAg70uFVCPNnrm3jxQ6vE/lddPB+yss9Ee33GwSCrEXdzJkTw==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/live-announcer": "^3.3.1",
+				"@react-aria/selection": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/grid": "^3.7.0",
+				"@react-stately/selection": "^3.13.2",
+				"@react-stately/virtualizer": "^3.6.0",
+				"@react-types/checkbox": "^3.4.4",
+				"@react-types/grid": "^3.1.8",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/gridlist": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/gridlist/-/gridlist-3.5.0.tgz",
+			"integrity": "sha512-xBCWyTtJNdUKSSUWXPMEi4lTnM1NRUlEJNi0eTNPIQVZOwQ7AgkEOD6uI+C6mgBL8q0oJwyIAfhK3zdwUCQSPg==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/grid": "^3.8.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/selection": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/list": "^3.9.0",
+				"@react-types/checkbox": "^3.4.4",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/i18n": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.8.0.tgz",
+			"integrity": "sha512-zeohg7d66zPLnGQl1rJuVJJ/gP7GmUMxEKIFRwE+rg2u02ldKxJMSb8QKGo605QpFWqo7CuuWYvKJP5Mj+Em/w==",
+			"dependencies": {
+				"@internationalized/date": "^3.3.0",
+				"@internationalized/message": "^3.1.1",
+				"@internationalized/number": "^3.2.1",
+				"@internationalized/string": "^3.1.1",
+				"@react-aria/ssr": "^3.7.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/interactions": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.16.0.tgz",
+			"integrity": "sha512-vXANFKVd6ONqNw8U+ZWbSA8lrduCOXw7cWsYosTa5dZ24ZJfRfbhlvRe8CaAKMhB/rOOmvTLaAwdIPia6JtLDg==",
+			"dependencies": {
+				"@react-aria/ssr": "^3.7.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/label": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.6.0.tgz",
+			"integrity": "sha512-o6Z9YAbvywj/b995HOl7fS9vf8FVmhWiJkKwFyCi/M1A7FXBqgtPcdPDNHaaKOhvQcwnLs4iMVMJwZdn/dLVDA==",
+			"dependencies": {
+				"@react-aria/utils": "^3.18.0",
+				"@react-types/label": "^3.7.4",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/link": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/link/-/link-3.5.2.tgz",
+			"integrity": "sha512-CCFP11Uietro6TUZpWBoq3Ql/6qss/ODC5XM6oNxckj72IHruFIj8V7Y0tL5x0aE6h38hlKcDf8NCxkQqz2edg==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-types/link": "^3.4.3",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/listbox": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/listbox/-/listbox-3.10.0.tgz",
+			"integrity": "sha512-4NelMDZAPoy2W4uoKZsMpdrC6XJQiZU+vpuhnzUT1eWTneDsEHKHSHQFtymoe8VrUEPrCV16EeMk1vRVvjCfAw==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/label": "^3.6.0",
+				"@react-aria/selection": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/list": "^3.9.0",
+				"@react-types/listbox": "^3.4.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/live-announcer": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@react-aria/live-announcer/-/live-announcer-3.3.1.tgz",
+			"integrity": "sha512-hsc77U7S16trM86d+peqJCOCQ7/smO1cybgdpOuzXyiwcHQw8RQ4GrXrS37P4Ux/44E9nMZkOwATQRT2aK8+Ew==",
+			"dependencies": {
+				"@swc/helpers": "^0.5.0"
+			}
+		},
+		"node_modules/@react-aria/menu": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.10.0.tgz",
+			"integrity": "sha512-zOOOXvx21aGSxZsXvLa3NV48hLk0jBC/zu5WZHT0Mo/wAe0+43f8p/U3AT8Gc4WnxYbIestcdLaIwgeagSoLtQ==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/overlays": "^3.15.0",
+				"@react-aria/selection": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/menu": "^3.5.3",
+				"@react-stately/tree": "^3.7.0",
+				"@react-types/button": "^3.7.3",
+				"@react-types/menu": "^3.9.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/meter": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/@react-aria/meter/-/meter-3.4.3.tgz",
+			"integrity": "sha512-1RUr93cNfMqTfyGtQ+SqFYLqlOqza6TEmXmtdCExPuZVRUZRjQRkqPoYuL8CPwHKlU4sbSlLiNeUu/HhV6pyTg==",
+			"dependencies": {
+				"@react-aria/progress": "^3.4.3",
+				"@react-types/meter": "^3.3.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/numberfield": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/numberfield/-/numberfield-3.6.0.tgz",
+			"integrity": "sha512-LbtRS/JciPicYLjqAP87gufInzZ2rlOQlKu0tQK8l/Hwc2cPOWUldDXbrGgxrXwbMxfEASmfI6qYz8uhTGmIyw==",
+			"dependencies": {
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/live-announcer": "^3.3.1",
+				"@react-aria/spinbutton": "^3.5.0",
+				"@react-aria/textfield": "^3.10.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/numberfield": "^3.5.0",
+				"@react-types/button": "^3.7.3",
+				"@react-types/numberfield": "^3.4.2",
+				"@react-types/shared": "^3.18.1",
+				"@react-types/textfield": "^3.7.2",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/overlays": {
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.15.0.tgz",
+			"integrity": "sha512-MeLn74GvXZfi881NSx5sSd5eTduki/PMk4vPvMNp2Xm+9nGHm0FbGu2GMIGgarYy5JC7l/bOO7H01YrS4AozPg==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/ssr": "^3.7.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-aria/visually-hidden": "^3.8.2",
+				"@react-stately/overlays": "^3.6.0",
+				"@react-types/button": "^3.7.3",
+				"@react-types/overlays": "^3.8.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/progress": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/@react-aria/progress/-/progress-3.4.3.tgz",
+			"integrity": "sha512-u8aUrnnQGsRZWx5vBfBhf70TeGeN/gEJzcthef5YDUQZG8O2IDhzR1GLqBmn1RvdcSDvBdhRSpMXd+6bL1WzGw==",
+			"dependencies": {
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/label": "^3.6.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-types/progress": "^3.4.1",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/radio": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.6.2.tgz",
+			"integrity": "sha512-R7vyh0G2HaUe0+SGa/LDMYuGnNC/15L6yfuljpP8ZUDPw9bR/6BuE1BDCI0ov1EXQ1lQ/vcvZMbf78OC72vPrg==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/label": "^3.6.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/radio": "^3.8.2",
+				"@react-types/radio": "^3.4.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/searchfield": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/@react-aria/searchfield/-/searchfield-3.5.3.tgz",
+			"integrity": "sha512-OqkXTZrjesqRxBR0WIOh0cezwmuXDQpsdua9nnGj0+8BIGCHuxvUOpw1HA3eTsf4AbZfygngC7pMT1lOR21upg==",
+			"dependencies": {
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/textfield": "^3.10.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/searchfield": "^3.4.3",
+				"@react-types/button": "^3.7.3",
+				"@react-types/searchfield": "^3.4.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/select": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/select/-/select-3.11.0.tgz",
+			"integrity": "sha512-UEYhw7wK4XoPMVbTa3UykPcri9GIV777WvXeKEykS1nMbJzu1I1LUE5py4ymhaI7DbpZ+gWZPTA0iot8IYQOWQ==",
+			"dependencies": {
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/label": "^3.6.0",
+				"@react-aria/listbox": "^3.10.0",
+				"@react-aria/menu": "^3.10.0",
+				"@react-aria/selection": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-aria/visually-hidden": "^3.8.2",
+				"@react-stately/select": "^3.5.2",
+				"@react-types/button": "^3.7.3",
+				"@react-types/select": "^3.8.1",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/selection": {
+			"version": "3.16.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.16.0.tgz",
+			"integrity": "sha512-qQ4X0+wtLz0+qjsoj1T0hVehA0CbZdu0Ax+lCzWmj+ZDivtdeNpVQl+K0yj9p95MnzLgIbnY7zU2zDQrYqKDOQ==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/selection": "^3.13.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/separator": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@react-aria/separator/-/separator-3.3.3.tgz",
+			"integrity": "sha512-kBGEXSSUiJLPS9foS5/7jgzpdp3/Yb1aMvVuvRGuNxDUsPAmvaYUT3qZ44Zf3hoxKfRFb4452KcoZ03w3Jfcvg==",
+			"dependencies": {
+				"@react-aria/utils": "^3.18.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/slider": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.5.0.tgz",
+			"integrity": "sha512-7qvzWZzwSww/+kLiSC8UJo4csHo8ndFzpzE2jUOom+hKMFomg5gIF4vqJI3ieWwF6rm6bbLmhxN4GvmNebVMwA==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/label": "^3.6.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/radio": "^3.8.2",
+				"@react-stately/slider": "^3.4.0",
+				"@react-types/radio": "^3.4.2",
+				"@react-types/shared": "^3.18.1",
+				"@react-types/slider": "^3.5.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/spinbutton": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/spinbutton/-/spinbutton-3.5.0.tgz",
+			"integrity": "sha512-WWLPiJd2nbv17dSbcbOm+TXlLO9ZIEA86ft/CTkvRYRG48kDn++4f16QcA0Gr+7dKdLQGbKkCf61jMJ3q8t5Hw==",
+			"dependencies": {
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/live-announcer": "^3.3.1",
+				"@react-aria/utils": "^3.18.0",
+				"@react-types/button": "^3.7.3",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/ssr": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.7.0.tgz",
+			"integrity": "sha512-bfufjg4ESE5giN+Fxj1XIzS5f/YIhqcGc+Ve+vUUKU8xZ8t/Xtjlv8F3kjqDBQdk//n3mluFY7xG1wQVB9rMLQ==",
+			"dependencies": {
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/switch": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/switch/-/switch-3.5.2.tgz",
+			"integrity": "sha512-mhV4Ip3t241s7gp4ETDe61AsSDox5TZXkiWt8add65p/LMESYBju9hGtbrxkMNCW62AuYCTAIadHoEOpy9HIIg==",
+			"dependencies": {
+				"@react-aria/toggle": "^3.6.2",
+				"@react-stately/toggle": "^3.6.0",
+				"@react-types/switch": "^3.3.2",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/table": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/table/-/table-3.10.0.tgz",
+			"integrity": "sha512-N42Ill9fdjeWKC/516fPMpPa79B0c+teFJ/fhcROLFrlwotgLKwndIG/InkE1L6FKeiJ8JL33FgUnxfRGafa8Q==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/grid": "^3.8.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/live-announcer": "^3.3.1",
+				"@react-aria/selection": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-aria/visually-hidden": "^3.8.2",
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/table": "^3.10.0",
+				"@react-stately/virtualizer": "^3.6.0",
+				"@react-types/checkbox": "^3.4.4",
+				"@react-types/grid": "^3.1.8",
+				"@react-types/shared": "^3.18.1",
+				"@react-types/table": "^3.7.0",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/tabs": {
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/@react-aria/tabs/-/tabs-3.6.1.tgz",
+			"integrity": "sha512-P/P3HA+b1Q917hVvXn1kzFl3dQnMTwYR8JKY5gjfjLQsAAEfJzSO3wLR0vNSp6Cz2FTAVCH4yzwP1G+bRLZVnw==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/selection": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/list": "^3.9.0",
+				"@react-stately/tabs": "^3.5.0",
+				"@react-types/shared": "^3.18.1",
+				"@react-types/tabs": "^3.3.0",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/tag": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/tag/-/tag-3.1.0.tgz",
+			"integrity": "sha512-N3h34k23jK7xuMh4eMDJoUG1xsNUw6zz+r9mmSMMLCxU38w+RH27ywEpKheW25M7LhfggqTjbjnPOpPpBnrENQ==",
+			"dependencies": {
+				"@react-aria/gridlist": "^3.5.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/label": "^3.6.0",
+				"@react-aria/selection": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/list": "^3.9.0",
+				"@react-types/button": "^3.7.3",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/textfield": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/textfield/-/textfield-3.10.0.tgz",
+			"integrity": "sha512-TYFgDTlxrljakD0TGOkoSCvot9BfVCZSrTKy3+/PICSTkPIzXThLIQmpX6yObLMXQSNW6SvBCl6CMetJMJHcbw==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/label": "^3.6.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-types/shared": "^3.18.1",
+				"@react-types/textfield": "^3.7.2",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/toggle": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.6.2.tgz",
+			"integrity": "sha512-bRz/ybajeLEsJLt1ARRL7CtWs6bwvkNLWy/wpJnH2TJ3+lMpH+EKbWBVJoAP7wQ5jIVVpxKJLhpf6w6x8ZLtdw==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/toggle": "^3.6.0",
+				"@react-types/checkbox": "^3.4.4",
+				"@react-types/shared": "^3.18.1",
+				"@react-types/switch": "^3.3.2",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/tooltip": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.6.0.tgz",
+			"integrity": "sha512-D38C7M58ZXWmY2+TXDczbbYRj9/KhIDyE/rLI0KhZR/iXDOJvmB9DT8HZuZLPsntq4Wl6mpmfPggT/R91nvR2Q==",
+			"dependencies": {
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/tooltip": "^3.4.2",
+				"@react-types/shared": "^3.18.1",
+				"@react-types/tooltip": "^3.4.2",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/utils": {
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.18.0.tgz",
+			"integrity": "sha512-eLs0ExzXx/D3P9qe6ophJ87ZFcI1oRTyRa51M59pCad7grrpk0gWcYrBjMwcR457YWOQQWCeLuq8QJl2QxCW6Q==",
+			"dependencies": {
+				"@react-aria/ssr": "^3.7.0",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0",
+				"clsx": "^1.1.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-aria/visually-hidden": {
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.2.tgz",
+			"integrity": "sha512-MFTqqSvPfc8u3YlzNfQ3ITX4eVQpZDiSqLPKj3Zyr86CKlba5iG8WGqjiJhD2GNHlvmcF/mITXTsNzm0KxFE7g==",
+			"dependencies": {
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0",
+				"clsx": "^1.1.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/calendar": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.3.0.tgz",
+			"integrity": "sha512-fnqdxCTlkikgldEyW8ciPNUWhqaUsQKTx6X6XGob6VCwK59k0LmdlgZX+dXj0q2ezC+w4lnvz8TzpoRQ7GY8lw==",
+			"dependencies": {
+				"@internationalized/date": "^3.3.0",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/calendar": "^3.3.0",
+				"@react-types/datepicker": "^3.4.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/checkbox": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.4.3.tgz",
+			"integrity": "sha512-TEd50vrUTHZWt8qO7ySLG2MlWJbsCvyx+pA1VhLJw6hRfjqorAjmCcpV2sEdu3EkLG7hA/Jw+7iBmGPlxmBN6A==",
+			"dependencies": {
+				"@react-stately/toggle": "^3.6.0",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/checkbox": "^3.4.4",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/collections": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.9.0.tgz",
+			"integrity": "sha512-CBpXSKmCpbIFpIToVFlzo2R1/Cj+dcU8gWw2KfPyyJX+2wHKkDIvtK01EAytDLX/vkE8O+fD5a7qMZ3pf8gpeA==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/combobox": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.5.2.tgz",
+			"integrity": "sha512-vMp3/xWv9a3DglTvvcQsJup3zZkmIANbf799j21Kc6Z4DXs+ohU81Qg5q9Z/5QuTEPsJFFv7vKXtb+VlP/TK2g==",
+			"dependencies": {
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/list": "^3.9.0",
+				"@react-stately/menu": "^3.5.3",
+				"@react-stately/select": "^3.5.2",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/combobox": "^3.6.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/data": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/data/-/data-3.10.0.tgz",
+			"integrity": "sha512-B5GqSNvvgTxVziR2nJW84HhvLOEI9AYPm/cyEdkumams7BFP8XEQStSS/SiRCMuufdHe4pnzHAQr5ynfRObwkg==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/datepicker": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.5.0.tgz",
+			"integrity": "sha512-GPscIz4jP9hDa1ChgMAWAt8g8mCpjILmSgfyuIZXegPZfa3ryKuQutYU/JGJrBom1xablAgeHIN1AWpve+4f1w==",
+			"dependencies": {
+				"@internationalized/date": "^3.3.0",
+				"@internationalized/string": "^3.1.1",
+				"@react-stately/overlays": "^3.6.0",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/datepicker": "^3.4.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/dnd": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/dnd/-/dnd-3.2.2.tgz",
+			"integrity": "sha512-1Eb4ZGh2xzTLDBV/Y+c/UoOvd2A9rglj+5o1Vo7HuIVWWc8tDJXq499B7rp/5JPcfQspF5OI4h08OWZFlPd/Ig==",
+			"dependencies": {
+				"@react-stately/selection": "^3.13.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/grid": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.7.0.tgz",
+			"integrity": "sha512-3eb7+7p9Xh/+luUOyieY2bM4CsARA8WnRB7c2++gh4dh9AEpZV4VGICGTe35+dJYr+9pbYQqVMEcEFUOaJJzZw==",
+			"dependencies": {
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/selection": "^3.13.2",
+				"@react-types/grid": "^3.1.8",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/layout": {
+			"version": "3.12.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/layout/-/layout-3.12.2.tgz",
+			"integrity": "sha512-9AGA11G5+Uo/mQoJR90lbqTR4+UFSl13jQMtqom/BYxkFGrHh3gWSUWEmg2h+n1Qa1q+oJjgaeQ9bxqlrR/wpQ==",
+			"dependencies": {
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/table": "^3.10.0",
+				"@react-stately/virtualizer": "^3.6.0",
+				"@react-types/grid": "^3.1.8",
+				"@react-types/shared": "^3.18.1",
+				"@react-types/table": "^3.7.0",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/list": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.9.0.tgz",
+			"integrity": "sha512-9DNV02zFEkJG38AtHyhvGMfpJQGwV0KMyMObs+KEujzCh+rmHdTu1rWdjzLw1ve+ecESK8UMsF4Kt6wwO0Qi6g==",
+			"dependencies": {
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/selection": "^3.13.2",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/menu": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.5.3.tgz",
+			"integrity": "sha512-RFgwVD/4BgTtJkexi1WaHpAEkQWZPvpyri0LQUgXWVqBf9PpjB8wigF3XBLMDNkL+YXE0QtzQZBNS1nJECf7rg==",
+			"dependencies": {
+				"@react-stately/overlays": "^3.6.0",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/menu": "^3.9.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/numberfield": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.5.0.tgz",
+			"integrity": "sha512-2R39hXQpQzoVDl1r3TZDKUEKf6lHbhiOpcBOYTPOne+YJOyMXQ6PnXAOTVuIcgTNdagukhXQVoDYH2B/1FvJOA==",
+			"dependencies": {
+				"@internationalized/number": "^3.2.1",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/numberfield": "^3.4.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/overlays": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.0.tgz",
+			"integrity": "sha512-0Bgy4xwCXKM+jkHAGJMN19ZFXNgKstf6qJozfH79j3E5erY30ZStwT7gbAnwv112zFUQLHBKo+3wJTGWuHgs8Q==",
+			"dependencies": {
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/overlays": "^3.8.0",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/radio": {
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.8.2.tgz",
+			"integrity": "sha512-tjlXask1IEGzzXwdc495K+wsHhyVhtaMhAeTbrdTD1a1fdg2g/jA0vWhN/KGO/CpnZT4vXGjJcY686Rmlrt9EQ==",
+			"dependencies": {
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/radio": "^3.4.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/searchfield": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.4.3.tgz",
+			"integrity": "sha512-mTdbWGpOA7foZJwkiR0AP5beh66I1feHMQ9/7/3lR4ETqLQ29vVXte+jc3+RrlFy+Adup0Ziwzs3DMfMZ0rN8Q==",
+			"dependencies": {
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/searchfield": "^3.4.2",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/select": {
+			"version": "3.5.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.5.2.tgz",
+			"integrity": "sha512-hIDAXFNg+q8rGQy5YKEaOz4NoWsckoQoi18vY8u6VsFUIhfYaYL76x6zKbTwekZLYuroifH7Fv81tBvRZmXikQ==",
+			"dependencies": {
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/list": "^3.9.0",
+				"@react-stately/menu": "^3.5.3",
+				"@react-stately/selection": "^3.13.2",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/select": "^3.8.1",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/selection": {
+			"version": "3.13.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.13.2.tgz",
+			"integrity": "sha512-rVnseneG9XWuS0+JEsa0EhRfTZsupm9JiEuZHZ19YeLewjVdFpjgBMDZb8ZYoyilNXVjyUwaoq94FsOXotsg9w==",
+			"dependencies": {
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/slider": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.4.0.tgz",
+			"integrity": "sha512-VvGJ1XkFIIEXP0eg9xqK/NztimBCSRmEqLgqlwzeDJAtuFXZzPRgJGrodGnqGmhoLsTFaY8YleLh/1hgf6rO0g==",
+			"dependencies": {
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/shared": "^3.18.1",
+				"@react-types/slider": "^3.5.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/table": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.10.0.tgz",
+			"integrity": "sha512-LDF97lZIkCDYNFw5Yz1eREedO9QerPDchxXUXlPVyjwLiZ4ADlhz6W/NTq6gm2PgrHljY/0+Kd5zEgVySLMTEw==",
+			"dependencies": {
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/grid": "^3.7.0",
+				"@react-stately/selection": "^3.13.2",
+				"@react-types/grid": "^3.1.8",
+				"@react-types/shared": "^3.18.1",
+				"@react-types/table": "^3.7.0",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/tabs": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.5.0.tgz",
+			"integrity": "sha512-N6B0+ZyW6mbmY/kHl0GKGj/i7MtA141A7yYJFSLDdvq1Hb2x7V1Y6gfl40FkSW4W9y3oQtKU+rTxV0EyjEJMWQ==",
+			"dependencies": {
+				"@react-stately/list": "^3.9.0",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/shared": "^3.18.1",
+				"@react-types/tabs": "^3.3.0",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/toggle": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.6.0.tgz",
+			"integrity": "sha512-w+Aqh78H9MLs0FDUYTjAzYhrHQWaDJ2zWjyg2oYcSvERES0+D0obmPvtJLWsFrJ8fHJrTmxd7ezVFBY9BbPeFQ==",
+			"dependencies": {
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/checkbox": "^3.4.4",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/tooltip": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.4.2.tgz",
+			"integrity": "sha512-tDkoYyEfdo44a3CoeiF794TFTs36d9faX0QvbR1QZ2KksjCMceOL5+26MlQjnhjEydYqw1X1YlTZbtMeor4uQw==",
+			"dependencies": {
+				"@react-stately/overlays": "^3.6.0",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/tooltip": "^3.4.2",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/tree": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.7.0.tgz",
+			"integrity": "sha512-oXOjJwy/o3XSJyBkudiEvnjWzto2jy48kmGjHCJ+B7Hv+WcbN9o7iAaHv11lOqMXRSpuF9gqox4ZZCASG+smIQ==",
+			"dependencies": {
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/selection": "^3.13.2",
+				"@react-stately/utils": "^3.7.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/utils": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.7.0.tgz",
+			"integrity": "sha512-VbApRiUV2rhozOfk0Qj9xt0qjVbQfLTgAzXLdrfeZSBnyIgo1bFRnjDpnDZKZUUCeGQcJJI03I9niaUtY+kwJQ==",
+			"dependencies": {
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-stately/virtualizer": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-stately/virtualizer/-/virtualizer-3.6.0.tgz",
+			"integrity": "sha512-f78BQT9ZSD5Hpqf6axRoNQJFqV+JjMSV2VixMfhIAcqi/fn8rEN2j3g4SPdFzTtFf2FR3+AKdBFu5tsgtk1Tgw==",
+			"dependencies": {
+				"@react-aria/utils": "^3.18.0",
+				"@react-types/shared": "^3.18.1",
+				"@swc/helpers": "^0.5.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/breadcrumbs": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/@react-types/breadcrumbs/-/breadcrumbs-3.6.0.tgz",
+			"integrity": "sha512-EnZk/f59yMQUmH2DW21uo3ajQ7nLEZ/sIMSfEZYP69CFe1by0RKi9aFRjJSrYjxRC0PSHTVPTjIG72KeBSsUGA==",
+			"dependencies": {
+				"@react-types/link": "^3.4.3",
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/button": {
+			"version": "3.7.3",
+			"resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.7.3.tgz",
+			"integrity": "sha512-Fz1t/kYinHDunmct3tADD2h3UDBPZUfRE+zCzYiymz0g+v/zYHTAqnkWToTF9ptf8HIB5L2Z2VFYpeUHFfpWzg==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/calendar": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.3.0.tgz",
+			"integrity": "sha512-5Qga+eixj+PembMwzcJmQlxif4XhSJJ54JcoyYHVf6mYLw3aE81Jc52OBi1FEWBJOW9YVOTk7VbWPFFF/oBI8A==",
+			"dependencies": {
+				"@internationalized/date": "^3.3.0",
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/checkbox": {
+			"version": "3.4.4",
+			"resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.4.4.tgz",
+			"integrity": "sha512-rJNhbW4R9HTvdbF2oTZmqGiZ/WVP3/XsU4gae7tfdhSYjG+5T5h9zau1vRhz++zwKn57wfcyNn6a83GDhhgkVw==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/combobox": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.6.2.tgz",
+			"integrity": "sha512-qitu/W3Z3/ihyqocy+8n4HZKRXF5JTMHl1ug3rKps5yCNnVdkWwjPFPM6w180c9QjquThNY3o947LZ1v59qJ4A==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/datepicker": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.4.0.tgz",
+			"integrity": "sha512-gQmbeNdVPXpaX8XsvxQb6nRLQZNlsMnDLVVpagVno7bifz2cdbthLfMe124nNT/Xr+JXolP+BtlYlZ7IRQVxdA==",
+			"dependencies": {
+				"@internationalized/date": "^3.3.0",
+				"@react-types/calendar": "^3.3.0",
+				"@react-types/overlays": "^3.8.0",
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/dialog": {
+			"version": "3.5.3",
+			"resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.3.tgz",
+			"integrity": "sha512-iTdg+UZiJpJe7Rnu9eILf8Hcd9li0Kg2eg8ba8dIc1O++ymqPmrdPWj9wj1JB9cl94E2Yg4w3W5YINiLXkdoeA==",
+			"dependencies": {
+				"@react-types/overlays": "^3.8.0",
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/grid": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.1.8.tgz",
+			"integrity": "sha512-NKk4pDbW2QXJOYnDSAYhta81CGwXOc/9tVw2WFs+1wacvxeKmh1Q+n36uAFcIdQOvVRqeGTJaYiqLFmF3fC3tA==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/label": {
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/@react-types/label/-/label-3.7.4.tgz",
+			"integrity": "sha512-SfTqPRI39GE3GFD5ZGYEeX9jXQrNqDeaaI36PJhnbgGVFz96oVVkhy9t9c2bMHcbhLLENYIHMzxrvVqXS07e7A==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/link": {
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/@react-types/link/-/link-3.4.3.tgz",
+			"integrity": "sha512-opKfkcaeV0cir64jPcy7DS0BrmdfuWMjua+MSeNv7FfT/b65rFgPfAOKZcvLWDsaxT5HYb7pivYPBfjKqHsQKw==",
+			"dependencies": {
+				"@react-aria/interactions": "^3.16.0",
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/listbox": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@react-types/listbox/-/listbox-3.4.2.tgz",
+			"integrity": "sha512-qg980T+tl15pqgfuK8V6z+vsvsIrJEEPxcupQXP3T1O0LxWxJDakZHF0lV9qwfyB9XlnVSMZfkjDiZp9Wgf8QQ==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/menu": {
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.9.2.tgz",
+			"integrity": "sha512-OIuEOGqo8gHaP4k3Ua+RvuPN2/3Sgcl30dNFIGaK7hra4eWxOUu8TTC+/Quy6xozR/SvFhqCLCoMKixy6MblWQ==",
+			"dependencies": {
+				"@react-types/overlays": "^3.8.0",
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/meter": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-types/meter/-/meter-3.3.2.tgz",
+			"integrity": "sha512-o21Zz+3LNjvBueMap+q2otGp5t2Xeb/lIMM4Y+v8j5XO+bLcHaAjdQB/TgKRe8iYFm3IqwpVtV9A38IWDtpLRQ==",
+			"dependencies": {
+				"@react-types/progress": "^3.4.1",
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/numberfield": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.4.2.tgz",
+			"integrity": "sha512-SGzuuFf5wCSRPvpV+bnykiXSIt8pkpBBVp8tlygB66pQSBV7VLdUvWGohaayPSM+3Z+WkU+osgzYtGq5wh+C3Q==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/overlays": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.0.tgz",
+			"integrity": "sha512-0JxwUW3xwXjsT+nVI5dVE1KUm8QKxnQj9vjqgsazX213+klRd/QdeuFJgcbxzCVFOS/mLkP4o/ATjxt4+1eQsA==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/progress": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/@react-types/progress/-/progress-3.4.1.tgz",
+			"integrity": "sha512-Y6cTvvJjbfFBeB7Zb3PizhhO3+YLWXpIP8opto15RWu11ktgZVMUgsnlsJgE3dFeoZ7UHwXdCYf8JOzBw5VPHA==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/radio": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.4.2.tgz",
+			"integrity": "sha512-SE6sjZjZbyuJMJNNdlhoutVr+QFRt1Vz7DZj4UaOswW5SD/Xb+xFdW8i6ETKdRN17am/5SC89ltWe0R3q0pVkA==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/searchfield": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.4.2.tgz",
+			"integrity": "sha512-HQm++hIXVfEbjbRey6hYV/5hLEO6gtwt4Mft3u5I5BiT7yoQqQAD/8z9S8aUXDUU9KTrAKfL1DwrFQSkOsCWJA==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1",
+				"@react-types/textfield": "^3.7.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/select": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.8.1.tgz",
+			"integrity": "sha512-ByVKKwgpE3d08jI+Ibuom/qphlBiDKpVMwXgFgVZRAN2YvVrsix8arSo7kmXtzekz91qqDBqtt7DBCfT0E1WKw==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/shared": {
+			"version": "3.18.1",
+			"resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.18.1.tgz",
+			"integrity": "sha512-OpTYRFS607Ctfd6Tmhyk6t6cbFyDhO5K+etU35X50pMzpypo1b7vF0mkngEeTc0Xwl0e749ONZNPZskMyu5k8w==",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/slider": {
+			"version": "3.5.1",
+			"resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.5.1.tgz",
+			"integrity": "sha512-8+AMNexx7q7DqfAtQKC5tgnZdG/tIwG2tcEbFCfAQA09Djrt/xiMNz+mc7SsV1PWoWwVuSDFH9QqKPodOrJHDg==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/switch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/@react-types/switch/-/switch-3.3.2.tgz",
+			"integrity": "sha512-L0XF4J43Q7HCAJXqseAk6RMteK6k1jQ0zrG05r6lSCkxaS9fGUlgLTCiFUsf07x0ADH1Xyc7PwpfJjyEr5A4tA==",
+			"dependencies": {
+				"@react-types/checkbox": "^3.4.4",
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/table": {
+			"version": "3.7.0",
+			"resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.7.0.tgz",
+			"integrity": "sha512-tUSJPdU2eNjH/CRHs5pOCKDyQxzq8b1rJZHldvRK/GCW+B98debFOueYgw4+YGQ1E33IyzAwid+FXgY3wlZlHg==",
+			"dependencies": {
+				"@react-types/grid": "^3.1.8",
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/tabs": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.0.tgz",
+			"integrity": "sha512-uXDVXBBppb+9S8bhxF7LZhgptrF5ll25SX8/jrpnXOR0jpihq6K3fkSe5M/OBnGsybuyVGN7+Np5v7UUYrM5SQ==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/textfield": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.7.2.tgz",
+			"integrity": "sha512-TsZTf1+4Ve9QHm6mbXr26uLOA4QtZPgyjYgYclL2nHoOl67algeQIFxIVfdlNIKFFMOw5BtC6Mer0I3KUWtbOQ==",
+			"dependencies": {
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
+		"node_modules/@react-types/tooltip": {
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.2.tgz",
+			"integrity": "sha512-jkuhT4KsU3ePfVrLeQv3Z2Vt0SwZmFNUoVIlK6Q1QR8H/TuWG+SDKjbwNLcCdeVfAXcJLbEfPDT2zyGeQTwNEA==",
+			"dependencies": {
+				"@react-types/overlays": "^3.8.0",
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
 		"node_modules/@remark-embedder/core": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@remark-embedder/core/-/core-3.0.2.tgz",
@@ -4171,6 +5593,14 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/@swc/helpers": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
+			"integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+			"dependencies": {
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@testing-library/dom": {
@@ -5600,17 +7030,6 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
-		},
-		"node_modules/aria-hidden": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
-			"integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
-			"dependencies": {
-				"tslib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/aria-query": {
 			"version": "5.1.3",
@@ -7664,6 +9083,14 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.8"
+			}
+		},
+		"node_modules/clsx": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+			"integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/co": {
@@ -11443,6 +12870,17 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/intl-messageformat": {
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.0.tgz",
+			"integrity": "sha512-AvojYuOaRb6r2veOKfTVpxH9TrmjSdc5iR9R5RgBwrDZYSmAAFVT+QLbW3C4V7Qsg0OguMp67Q/EoUkxZzXRGw==",
+			"dependencies": {
+				"@formatjs/ecma402-abstract": "1.17.0",
+				"@formatjs/fast-memoize": "2.2.0",
+				"@formatjs/icu-messageformat-parser": "2.6.0",
+				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/ip": {
@@ -20100,6 +21538,53 @@
 				"preact": "*"
 			}
 		},
+		"node_modules/react-aria": {
+			"version": "3.26.0",
+			"resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.26.0.tgz",
+			"integrity": "sha512-G+dh25hEdDLfAGbKyahzasnyxXhd99y6xlMZjNtHoWB7wXod/9M3P3W6mdANvCEogxU28ATRdV1bv6A2JbuSYg==",
+			"dependencies": {
+				"@react-aria/breadcrumbs": "^3.5.3",
+				"@react-aria/button": "^3.8.0",
+				"@react-aria/calendar": "^3.4.0",
+				"@react-aria/checkbox": "^3.9.2",
+				"@react-aria/combobox": "^3.6.2",
+				"@react-aria/datepicker": "^3.5.0",
+				"@react-aria/dialog": "^3.5.3",
+				"@react-aria/dnd": "^3.3.0",
+				"@react-aria/focus": "^3.13.0",
+				"@react-aria/gridlist": "^3.5.0",
+				"@react-aria/i18n": "^3.8.0",
+				"@react-aria/interactions": "^3.16.0",
+				"@react-aria/label": "^3.6.0",
+				"@react-aria/link": "^3.5.2",
+				"@react-aria/listbox": "^3.10.0",
+				"@react-aria/menu": "^3.10.0",
+				"@react-aria/meter": "^3.4.3",
+				"@react-aria/numberfield": "^3.6.0",
+				"@react-aria/overlays": "^3.15.0",
+				"@react-aria/progress": "^3.4.3",
+				"@react-aria/radio": "^3.6.2",
+				"@react-aria/searchfield": "^3.5.3",
+				"@react-aria/select": "^3.11.0",
+				"@react-aria/selection": "^3.16.0",
+				"@react-aria/separator": "^3.3.3",
+				"@react-aria/slider": "^3.5.0",
+				"@react-aria/ssr": "^3.7.0",
+				"@react-aria/switch": "^3.5.2",
+				"@react-aria/table": "^3.10.0",
+				"@react-aria/tabs": "^3.6.1",
+				"@react-aria/tag": "^3.1.0",
+				"@react-aria/textfield": "^3.10.0",
+				"@react-aria/tooltip": "^3.6.0",
+				"@react-aria/utils": "^3.18.0",
+				"@react-aria/visually-hidden": "^3.8.2",
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
+		},
 		"node_modules/react-dom": {
 			"name": "@preact/compat",
 			"version": "17.1.2",
@@ -20115,6 +21600,38 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
 			"dev": true
+		},
+		"node_modules/react-stately": {
+			"version": "3.24.0",
+			"resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.24.0.tgz",
+			"integrity": "sha512-4jNCR7rQBqvV8aKxm8giUWms/Wxlo9MMLUDDKfg75LEiCaqLcnxSC99HsEVKSao3RI0JCCj2ihewh6grRW/AgQ==",
+			"dependencies": {
+				"@react-stately/calendar": "^3.3.0",
+				"@react-stately/checkbox": "^3.4.3",
+				"@react-stately/collections": "^3.9.0",
+				"@react-stately/combobox": "^3.5.2",
+				"@react-stately/data": "^3.10.0",
+				"@react-stately/datepicker": "^3.5.0",
+				"@react-stately/dnd": "^3.2.2",
+				"@react-stately/list": "^3.9.0",
+				"@react-stately/menu": "^3.5.3",
+				"@react-stately/numberfield": "^3.5.0",
+				"@react-stately/overlays": "^3.6.0",
+				"@react-stately/radio": "^3.8.2",
+				"@react-stately/searchfield": "^3.4.3",
+				"@react-stately/select": "^3.5.2",
+				"@react-stately/selection": "^3.13.2",
+				"@react-stately/slider": "^3.4.0",
+				"@react-stately/table": "^3.10.0",
+				"@react-stately/tabs": "^3.5.0",
+				"@react-stately/toggle": "^3.6.0",
+				"@react-stately/tooltip": "^3.4.2",
+				"@react-stately/tree": "^3.7.0",
+				"@react-types/shared": "^3.18.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+			}
 		},
 		"node_modules/read-pkg": {
 			"version": "3.0.0",
@@ -22666,11 +24183,6 @@
 			"funding": {
 				"url": "https://opencollective.com/unts"
 			}
-		},
-		"node_modules/tabbable": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-			"integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
 		},
 		"node_modules/tar": {
 			"version": "6.1.15",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"epub": "tsx --tsconfig tsconfig.script.json build-scripts/generate-epubs.ts",
 		"tsc": "tsc --noEmit && astro check",
 		"test": "jest",
-		"prepare": "husky install"
+		"prepare": "husky install && playwright install"
 	},
 	"devDependencies": {
 		"@astrojs/image": "^0.17.1",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
 		"*.{js,ts,astro,jsx}": "prettier --write"
 	},
 	"dependencies": {
-		"@floating-ui/react": "^0.24.3",
+		"react-aria": "^3.26.0",
+		"react-stately": "^3.24.0",
 		"medium-zoom": "^1.0.8",
 		"preact": "^10.16.0"
 	},

--- a/src/components/input/input.module.scss
+++ b/src/components/input/input.module.scss
@@ -52,7 +52,6 @@
 		var(--form-field_outline_color_focused);
 	outline: var(--form-field_halo_color) solid var(--form-field_halo_width);
 	background: var(--form-field_background_focused);
-	margin: 0;
 }
 
 .input:disabled,

--- a/src/components/pagination/pagination-popover.module.scss
+++ b/src/components/pagination/pagination-popover.module.scss
@@ -15,12 +15,12 @@
 	background: var(--page-popup_background-color);
 	border: var(--page-popup_border-width) solid var(--page-popup_border-color);
 	box-shadow: var(--shadow_popup_light);
-	padding: var(--page-popup_padding);
 	min-width: 13.5rem;
 	border-radius: var(--page-popup_corner-radius);
 }
 
 .popupInner {
+	padding: var(--page-popup_padding);
 	display: flex;
 	flex-direction: column;
 	gap: var(--page-popup_gap);

--- a/src/components/pagination/pagination-popover.module.scss
+++ b/src/components/pagination/pagination-popover.module.scss
@@ -1,68 +1,97 @@
 @import "src/tokens/index";
 
 :root {
-  --page-popup_padding: var(--spc-6x);
-  --page-popup_gap: var(--spc-4x);
-  --page-popup_offset: var(--spc-8x);
-  --page-popup_corner-radius: var(--corner-radius_l);
-  --page-popup_border-width: var(--border-width_m);
+	--page-popup_padding: var(--spc-6x);
+	--page-popup_gap: var(--spc-4x);
+	--page-popup_offset: var(--spc-8x);
+	--page-popup_corner-radius: var(--corner-radius_l);
+	--page-popup_border-width: var(--border-width_m);
 
-  --page-popup_background-color: var(--background_primary);
-  --page-popup_border-color: var(--primary_variant);
+	--page-popup_background-color: var(--background_primary);
+	--page-popup_border-color: var(--primary_variant);
 }
 
 .popup {
-  background: var(--page-popup_background-color);
-  border: var(--page-popup_border-width) solid var(--page-popup_border-color);
-  box-shadow: var(--shadow_popup_light);
-  padding: var(--page-popup_padding);
-  min-width: 13.5rem;
-  border-radius: var(--page-popup_corner-radius);
+	background: var(--page-popup_background-color);
+	border: var(--page-popup_border-width) solid var(--page-popup_border-color);
+	box-shadow: var(--shadow_popup_light);
+	padding: var(--page-popup_padding);
+	min-width: 13.5rem;
+	border-radius: var(--page-popup_corner-radius);
 }
 
 .popupInner {
-  display: flex;
-  flex-direction: column;
-  gap: var(--page-popup_gap);
+	display: flex;
+	flex-direction: column;
+	gap: var(--page-popup_gap);
 }
 
 .popupInput {
-  width: 1px;
-  flex-grow: 1;
-  text-align: center;
-  min-width: calc(3ch + calc(var(--form-field_padding-horizontal) * 2));
-  -moz-appearance: textfield;
+	width: 1px;
+	flex-grow: 1;
+	text-align: center;
+	min-width: calc(3ch + calc(var(--form-field_padding-horizontal) * 2));
+	-moz-appearance: textfield;
 }
 
 .popupInput::-webkit-outer-spin-button,
 .popupInput::-webkit-inner-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
+	-webkit-appearance: none;
+	margin: 0;
 }
 
 .popupTopArea {
-  display: flex;
-  gap: var(--page-popup_gap);
-  align-items: center;
+	display: flex;
+	gap: var(--page-popup_gap);
+	align-items: center;
 }
 
 .buttonContainer {
-  height: 100%;
-  width: 100%;
-  flex-grow: 0;
+	height: 100%;
+	width: 100%;
+	flex-grow: 0;
 }
 
 .iconButton {
-  height: calc(var(--form-field_padding-vertical) * 2 + var(--p_medium_line-height));
-  width: calc(var(--form-field_padding-vertical) * 2 + var(--p_medium_line-height));
+	height: calc(
+		var(--form-field_padding-vertical) * 2 + var(--p_medium_line-height)
+	);
+	width: calc(
+		var(--form-field_padding-vertical) * 2 + var(--p_medium_line-height)
+	);
 }
 
 .buttonContainer svg {
-  height: 100%;
-  width: 100%;
-  flex-grow: 0;
+	height: 100%;
+	width: 100%;
+	flex-grow: 0;
 }
 
-.popup > svg {
-  fill: var(--page-popup_background-color);
+.underlay {
+	position: fixed;
+	inset: 0;
+}
+
+.arrow {
+	position: absolute;
+}
+
+.arrow[data-placement="top"] {
+	top: 100%;
+	transform: translateX(-50%);
+}
+
+.arrow[data-placement="bottom"] {
+	bottom: 100%;
+	transform: translateX(-50%) rotate(180deg);
+}
+
+.arrow[data-placement="left"] {
+	left: 100%;
+	transform: translateY(-50%) rotate(-90deg);
+}
+
+.arrow[data-placement="right"] {
+	right: 100%;
+	transform: translateY(-50%) rotate(90deg);
 }

--- a/src/components/pagination/pagination-popover.tsx
+++ b/src/components/pagination/pagination-popover.tsx
@@ -1,17 +1,6 @@
-import {
-	arrow,
-	FloatingArrow,
-	FloatingFocusManager,
-	offset,
-	useClick,
-	useDismiss,
-	useFloating,
-	useInteractions,
-	useRole,
-} from "@floating-ui/react";
 import { useRef, useState } from "preact/hooks";
-import { Fragment } from "preact";
-import { createPortal, StateUpdater } from "preact/compat";
+import { Fragment, RefObject } from "preact";
+import { createPortal } from "preact/compat";
 import mainStyles from "./pagination.module.scss";
 import more from "src/icons/more_horiz.svg?raw";
 import { PaginationProps } from "components/pagination/types";
@@ -20,10 +9,19 @@ import { Button, IconOnlyButton } from "components/button/button";
 import subtract from "../../icons/subtract.svg?raw";
 import add from "../../icons/add.svg?raw";
 import { Input } from "components/input/input";
+import {
+	useDialog,
+	useOverlayTrigger,
+	usePopover,
+	Overlay,
+	DismissButton,
+} from "react-aria";
+import { OverlayTriggerState, useOverlayTriggerState } from "react-stately";
+import { DOMProps } from "@react-types/shared";
 
 function PopupContents(
 	props: Pick<PaginationProps, "page" | "getPageHref" | "softNavigate"> & {
-		setIsOpen: StateUpdater<boolean>;
+		close: () => void;
 	}
 ) {
 	const [count, setCount] = useState(props.page.currentPage);
@@ -35,7 +33,7 @@ function PopupContents(
 				e.preventDefault();
 				if (props.softNavigate) {
 					props.softNavigate(props.getPageHref(count));
-					props.setIsOpen(false);
+					props.close();
 					return;
 				}
 				location.href = props.getPageHref(count);
@@ -59,7 +57,7 @@ function PopupContents(
 					data-testid="pagination-popup-input"
 					class={style.popupInput}
 					value={count}
-					onChange={(e) => {
+					onInput={(e) => {
 						const newVal = (e.target as HTMLInputElement).valueAsNumber;
 						if (newVal > props.page.lastPage) {
 							setCount(props.page.lastPage);
@@ -97,75 +95,104 @@ function PopupContents(
 	);
 }
 
+interface PaginationPopoverProps
+	extends Pick<PaginationProps, "page" | "getPageHref" | "softNavigate"> {
+	triggerRef: RefObject<Element>;
+	state: OverlayTriggerState;
+	overlayProps: DOMProps;
+}
+
+function PaginationPopover({
+	triggerRef,
+	state,
+	overlayProps,
+	...props
+}: PaginationPopoverProps) {
+	/* Setup popover */
+	const popoverRef = useRef(null);
+	const { popoverProps, underlayProps, arrowProps, placement } = usePopover(
+		{
+			shouldFlip: true,
+			offset: 32 - 14 / 2,
+			popoverRef,
+			triggerRef,
+		},
+		state
+	);
+
+	/* Setup dialog */
+	const dialogRef = useRef(null);
+	const { dialogProps, titleProps } = useDialog(overlayProps, dialogRef);
+
+	return (
+		<Overlay>
+			<div {...underlayProps} className={style.underlay} />
+
+			<div {...popoverProps} ref={popoverRef} className={style.popup}>
+				<svg
+					width="24"
+					height="14"
+					viewBox="0 0 24 14"
+					fill="none"
+					{...arrowProps}
+					className={style.arrow}
+					data-placement={placement}
+				>
+					<path
+						d="M9.6 12.8L0 0H24L14.4 12.8C13.2 14.4 10.8 14.4 9.6 12.8Z"
+						fill="var(--page-popup_background-color)"
+					/>
+					<path
+						d="M2.5 2.08616e-06L11.2 11.6C11.6 12.1333 12.4 12.1333 12.8 11.6L21.5 2.08616e-06L24 0L14.4 12.8C13.2 14.4 10.8 14.4 9.6 12.8L0 2.08616e-06H2.5Z"
+						fill="var(--page-popup_border-color)"
+					/>
+				</svg>
+				<DismissButton onDismiss={state.close} />
+				<div {...dialogProps} ref={dialogRef}>
+					<h1 {...titleProps} className="visually-hidden">
+						Go to page
+					</h1>
+					<PopupContents {...props} close={state.close} />
+				</div>
+				<DismissButton onDismiss={state.close} />
+			</div>
+		</Overlay>
+	);
+}
+
 export function PaginationMenuAndPopover(
 	props: Pick<PaginationProps, "page" | "getPageHref" | "softNavigate">
 ) {
-	const [isOpen, setIsOpen] = useState(false);
-	const arrowRef = useRef(null);
-
-	const { refs, floatingStyles, context } = useFloating({
-		open: isOpen,
-		placement: "top",
-		onOpenChange: setIsOpen,
-		middleware: [
-			offset(32 - 14 / 2),
-			arrow({
-				element: arrowRef,
-			}),
-		],
-	});
-
-	const click = useClick(context);
-	const dismiss = useDismiss(context);
-	const role = useRole(context);
-
-	const { getReferenceProps, getFloatingProps } = useInteractions([
-		click,
-		dismiss,
-		role,
-	]);
-
-	const portal = createPortal(
-		<FloatingFocusManager
-			context={context}
-			order={["floating", "content"]}
-			modal={false}
-			returnFocus={false}
-		>
-			<div
-				ref={refs.setFloating}
-				style={floatingStyles as never}
-				{...getFloatingProps()}
-				class={style.popup}
-			>
-				<PopupContents {...props} setIsOpen={setIsOpen} />
-				<FloatingArrow
-					ref={arrowRef}
-					context={context}
-					height={14}
-					width={24}
-					stroke={"var(--page-popup_border-color)"}
-					strokeWidth={2}
-					tipRadius={1.5}
-				/>
-			</div>
-		</FloatingFocusManager>,
-		document.querySelector("body")
+	/* Setup trigger */
+	const triggerRef = useRef(null);
+	const state = useOverlayTriggerState({});
+	const { triggerProps, overlayProps } = useOverlayTrigger(
+		{ type: "dialog" },
+		state,
+		triggerRef
 	);
 
 	return (
 		<Fragment>
 			<li className={`${mainStyles.paginationItem}`}>
+				{/* Add onClick since onPress doesn't work with Preact well */}
 				<button
+					ref={triggerRef}
+					onClick={triggerProps.onPress as never}
+					{...triggerProps}
 					data-testid="pagination-menu"
-					ref={refs.setReference}
-					{...getReferenceProps()}
-					aria-selected={isOpen}
 					className={`text-style-body-medium-bold ${mainStyles.extendPageButton} ${mainStyles.paginationButton} ${mainStyles.paginationIconButton}`}
 					dangerouslySetInnerHTML={{ __html: more }}
 				/>
 			</li>
-			{isOpen && portal}
+			{state.isOpen && (
+				<PaginationPopover
+					{...props}
+					triggerRef={triggerRef}
+					state={state}
+					overlayProps={overlayProps}
+				/>
+			)}
 		</Fragment>
 	);
 }

--- a/src/components/pagination/pagination-popover.tsx
+++ b/src/components/pagination/pagination-popover.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from "preact/hooks";
 import { Fragment, RefObject } from "preact";
-import { createPortal } from "preact/compat";
 import mainStyles from "./pagination.module.scss";
 import more from "src/icons/more_horiz.svg?raw";
 import { PaginationProps } from "components/pagination/types";
@@ -44,8 +43,11 @@ function PopupContents(
 					data-testid="pagination-popup-decrement"
 					type="button"
 					tag="button"
-					onClick={() => setCount((v) => v - 1)}
-					disabled={count <= 1}
+					onClick={() => {
+						if (count <= 1) return false;
+						setCount((v) => v - 1);
+					}}
+					aria-disabled={count <= 1}
 					class={style.iconButton}
 				>
 					<div
@@ -73,8 +75,12 @@ function PopupContents(
 					data-testid="pagination-popup-increment"
 					type="button"
 					tag="button"
-					onClick={() => setCount((v) => v + 1)}
-					disabled={count >= props.page.lastPage}
+					onClick={() => {
+						// Disabled
+						if (count >= props.page.lastPage) return false;
+						setCount((v) => v + 1);
+					}}
+					aria-disabled={count >= props.page.lastPage}
 					class={style.iconButton}
 				>
 					<div

--- a/src/components/pagination/pagination.module.scss
+++ b/src/components/pagination/pagination.module.scss
@@ -31,6 +31,9 @@
 	list-style: none;
 }
 
+.paginationItem {
+}
+
 .paginationItemExtra {
 	display: none;
 
@@ -61,7 +64,6 @@
 	box-sizing: border-box;
 }
 
-
 .paginationButton.selected {
 	background-color: var(--nav-btn_background-color_selected);
 	color: var(--nav-btn_foreground-color_selected);
@@ -86,7 +88,8 @@
 	box-sizing: border-box;
 }
 
-.paginationButton:disabled, .paginationButton[aria-disabled="true"] {
+.paginationButton:disabled,
+.paginationButton[aria-disabled="true"] {
 	background-color: var(--nav-btn_background-color_disabled);
 	color: var(--nav-btn_foreground-color_disabled);
 }

--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -149,7 +149,8 @@
 	}
 }
 
-.buttonIcon svg, .iconOnlyButtonIcon svg {
+.buttonIcon svg,
+.iconOnlyButtonIcon svg {
 	width: 100%;
 	height: 100%;
 }
@@ -250,7 +251,8 @@
 	}
 }
 
-.button[disabled] {
+.button[disabled],
+.button[aria-disabled="true"]:not([data-not-actually-disabled="true"]) {
 	text-decoration: none;
 	pointer-events: none;
 	background-color: var(--btn_disabled_background-color);


### PR DESCRIPTION
> This PR builds on top of #618, merge that first.

This PR replaces Floating UI with React Aria, in expectations of using that package more for other UI elements.

It's about the same bundle size with my testing, and has a known reputation of handling A11Y better.

# Implementation Notes

I had to migrate to using `aria-disabled` rather than `disabled` prop for the pagination increment/decrement buttons. Without doing so, the buttons lose focus which causes the focus manager to break and cause bad UX.