### PR TITLE
[UwU] Make rehype and remark plugins more type strict

### DIFF
--- a/build-scripts/social-previews/shared-post-preview-png.ts
+++ b/build-scripts/social-previews/shared-post-preview-png.ts
@@ -11,6 +11,7 @@ import remarkToRehype from "remark-rehype";
 import { findAllAfter } from "unist-util-find-all-after";
 import rehypeStringify from "rehype-stringify";
 import { Layout, PAGE_HEIGHT, PAGE_WIDTH } from "./base";
+import { Literal } from "unist";
 
 // https://github.com/shikijs/twoslash/issues/147
 const remarkTwoslash =
@@ -27,7 +28,7 @@ const unifiedChain = () => {
 			// join code parts into one element
 			const value =
 				nodes
-					.map((node) => (node as any).value)
+					.map((node) => (node as Literal).value)
 					.join("\n")
 					.trim() +
 				"\n" +
@@ -40,7 +41,7 @@ const unifiedChain = () => {
 				children: [
 					{
 						type: "code",
-						lang: (nodes[0] as any)?.lang || "javascript",
+						lang: (nodes[0] as { lang?: string })?.lang || "javascript",
 						value,
 					},
 				],
@@ -61,13 +62,13 @@ const shikiSCSS = fs.readFileSync("src/styles/shiki.scss", "utf8");
 
 export const renderPostPreviewToString = async (
 	layout: Layout,
-	post: ExtendedPostInfo
+	post: ExtendedPostInfo,
 ) => {
 	const authorImageMap = Object.fromEntries(
 		post.authorsMeta.map((author) => [
 			author.id,
 			readFileAsBase64(author.profileImgMeta.absoluteFSPath),
-		])
+		]),
 	);
 
 	const postHtml = await markdownToHtml(post.contentMeta);
@@ -100,7 +101,7 @@ export const renderPostPreviewToString = async (
 			width: PAGE_WIDTH,
 			height: PAGE_HEIGHT,
 			authorImageMap,
-		})
+		}),
 	)}
 	</body>
 	</html>

--- a/src/utils/get-all-posts.ts
+++ b/src/utils/get-all-posts.ts
@@ -8,6 +8,12 @@ import { rehypeUnicornPopulatePost } from "./markdown/rehype-unicorn-populate-po
 import { postsDirectory, posts } from "./data";
 import { Languages, ExtendedPostInfo } from "types/index";
 import * as path from "path";
+import { Plugin } from "unified";
+import { AstroVFile } from "utils/markdown/types";
+
+type UnwrapPlugin<T extends Plugin> = (
+	...params: Parameters<Exclude<T, void>>
+) => Exclude<ReturnType<Exclude<T, void>>, void>;
 
 const getIndexPath = (lang: Languages) => {
 	const indexPath = lang !== "en" ? `index.${lang}.md` : `index.md`;
@@ -16,7 +22,7 @@ const getIndexPath = (lang: Languages) => {
 
 export function getExtendedPost(
 	slug: string,
-	lang: Languages
+	lang: Languages,
 ): ExtendedPostInfo {
 	const indexFile = path.resolve(postsDirectory, slug, getIndexPath(lang));
 	const file = {
@@ -26,12 +32,14 @@ export function getExtendedPost(
 				frontmatter: {},
 			},
 		},
-	};
+	} as AstroVFile;
 
-	(rehypeUnicornPopulatePost as any)()(undefined, file);
+	(
+		rehypeUnicornPopulatePost as UnwrapPlugin<typeof rehypeUnicornPopulatePost>
+	)()(undefined, file);
 
 	return {
-		...((file.data.astro.frontmatter as any) || {}).frontmatterBackup,
+		...(file.data.astro.frontmatter || {}).frontmatterBackup,
 		...file.data.astro.frontmatter,
 	};
 }

--- a/src/utils/markdown/file-tree/rehype-file-tree.ts
+++ b/src/utils/markdown/file-tree/rehype-file-tree.ts
@@ -38,8 +38,8 @@ export const rehypeFileTree = () => {
 		function replaceFiletreeNodes(nodes: Node[]) {
 			const items: Array<Directory | File> = [];
 
-			const isNodeElement = (node: any): node is Element =>
-				typeof node === "object" && node.type === "element";
+			const isNodeElement = (node: unknown): node is Element =>
+				typeof node === "object" && node["type"] === "element";
 
 			function traverseUl(listNode: Element, listItems: typeof items) {
 				if (listNode.children.length === 0) return;
@@ -53,7 +53,7 @@ export const rehypeFileTree = () => {
 						(child) =>
 							child.type === "comment" ||
 							child.type !== "text" ||
-							!/^\n+$/.test(child.value)
+							!/^\n+$/.test(child.value),
 					);
 
 					const [firstChild, ...otherChildren] = listItem.children;
@@ -81,7 +81,7 @@ export const rehypeFileTree = () => {
 						comment.push(fragments.join(" "));
 					}
 					const subTreeIndex = otherChildren.findIndex(
-						(child) => child.type === "element" && child.tagName === "ul"
+						(child) => child.type === "element" && child.tagName === "ul",
 					);
 					const commentNodes =
 						subTreeIndex > -1
@@ -89,7 +89,7 @@ export const rehypeFileTree = () => {
 							: [...otherChildren];
 					otherChildren.splice(
 						0,
-						subTreeIndex > -1 ? subTreeIndex : otherChildren.length
+						subTreeIndex > -1 ? subTreeIndex : otherChildren.length,
 					);
 					comment.push(...commentNodes);
 
@@ -97,7 +97,7 @@ export const rehypeFileTree = () => {
 
 					// Decide a node is a directory if it ends in a `/` or contains another list.
 					const directoryNode = otherChildren.find(
-						(child) => child.type === "element" && child.tagName === "ul"
+						(child) => child.type === "element" && child.tagName === "ul",
 					);
 
 					const isDirectory =
@@ -154,7 +154,7 @@ export const rehypeFileTree = () => {
 			}
 
 			const list = nodes.find(
-				(node) => isNodeElement(node) && node.tagName === "ul"
+				(node) => isNodeElement(node) && node.tagName === "ul",
 			) as Element;
 
 			if (!list) throw "No list found in filetree";
@@ -168,13 +168,13 @@ export const rehypeFileTree = () => {
 			tree,
 			{ type: "raw", value: "<!-- filetree:start -->" } as never,
 			{ type: "raw", value: "<!-- filetree:end -->" } as never,
-			replaceFiletreeNodes
+			replaceFiletreeNodes,
 		);
 		replaceAllBetween(
 			tree,
 			{ type: "comment", value: " filetree:start " } as never,
 			{ type: "comment", value: " filetree:end " } as never,
-			replaceFiletreeNodes
+			replaceFiletreeNodes,
 		);
 	};
 };

--- a/src/utils/markdown/rehype-excerpt.ts
+++ b/src/utils/markdown/rehype-excerpt.ts
@@ -1,6 +1,7 @@
 import { Root } from "hast";
 import { Plugin } from "unified";
 import { visit } from "unist-util-visit";
+import { AstroVFile } from "utils/markdown/types";
 
 interface RehypeExcerptProps {
 	maxLength: number;
@@ -9,11 +10,11 @@ interface RehypeExcerptProps {
 export const rehypeExcerpt: Plugin<[RehypeExcerptProps | never], Root> = ({
 	maxLength,
 }) => {
-	return (tree, file) => {
+	return (tree, file: AstroVFile) => {
 		const getFileExcerpt = () =>
-			(file?.data?.astro as any)?.frontmatter?.excerpt as string;
+			file?.data?.astro?.frontmatter?.excerpt as string;
 		const setFileExcerpt = (val) => {
-			(file.data.astro as any).frontmatter.excerpt = val;
+			file.data.astro.frontmatter.excerpt = val;
 		};
 		if (!getFileExcerpt()) {
 			setFileExcerpt("");

--- a/src/utils/markdown/rehype-unicorn-get-suggested-posts.ts
+++ b/src/utils/markdown/rehype-unicorn-get-suggested-posts.ts
@@ -2,6 +2,7 @@ import { Root } from "hast";
 import { Plugin } from "unified";
 import { getSuggestedArticles } from "../get-suggested-articles";
 import path from "path";
+import { AstroVFile } from "utils/markdown/types";
 
 interface RehypeUnicornGetSuggestedPostsProps {}
 
@@ -9,20 +10,20 @@ export const rehypeUnicornGetSuggestedPosts: Plugin<
 	[RehypeUnicornGetSuggestedPostsProps | never],
 	Root
 > = () => {
-	return (_, file) => {
+	return (_, file: AstroVFile) => {
 		const splitFilePath = path.dirname(file.path).split(path.sep);
 		// "collections" | "blog"
 		const parentFolder = splitFilePath.at(-2);
 
 		if (parentFolder === "collections") return;
 
-		function setData(key: string, val: any) {
-			(file.data.astro as any).frontmatter[key] = val;
+		function setData(key: string, val: unknown) {
+			file.data.astro.frontmatter[key] = val;
 		}
 
 		const post = {
-			...(file.data.astro as any).frontmatter.frontmatterBackup,
-			...(file.data.astro as any).frontmatter,
+			...file.data.astro.frontmatter.frontmatterBackup,
+			...file.data.astro.frontmatter,
 		};
 
 		const suggestedArticles = getSuggestedArticles(post, post.locale);

--- a/src/utils/markdown/rehype-unicorn-populate-post.ts
+++ b/src/utils/markdown/rehype-unicorn-populate-post.ts
@@ -5,14 +5,12 @@ import { readFileSync } from "fs";
 import * as path from "path";
 import { collections, posts } from "../data";
 import { getLanguageFromFilename } from "..";
+import { AstroVFile } from "utils/markdown/types";
 
 interface RehypeUnicornPopulatePostProps {}
 
-export const rehypeUnicornPopulatePost: Plugin<
-	[RehypeUnicornPopulatePostProps | never],
-	Root
-> = () => {
-	return (_, file) => {
+export const rehypeUnicornPopulatePost = (() => {
+	return (_, file: AstroVFile) => {
 		const fileContents = readFileSync(file.path, "utf8");
 		const { data: frontmatter, content } = matter(fileContents);
 
@@ -40,7 +38,7 @@ export const rehypeUnicornPopulatePost: Plugin<
 		}
 
 		// Write the data to Astro's frontmatter
-		Object.assign((file.data.astro as any).frontmatter, {
+		Object.assign(file.data.astro.frontmatter, {
 			slug,
 			locale,
 			...data,
@@ -48,4 +46,4 @@ export const rehypeUnicornPopulatePost: Plugin<
 			contentMeta: content,
 		});
 	};
-};
+}) satisfies Plugin<[RehypeUnicornPopulatePostProps | never], Root>;

--- a/src/utils/markdown/rehype-word-count.ts
+++ b/src/utils/markdown/rehype-word-count.ts
@@ -28,6 +28,7 @@ import { visit } from "unist-util-visit";
 import { unified } from "unified";
 import english from "retext-english";
 import rehypeRetext from "rehype-retext";
+import { AstroVFile } from "utils/markdown/types";
 
 interface RemarkCountProps {}
 
@@ -67,7 +68,7 @@ export type WordCounts = {
 };
 
 export const rehypeWordCount: Plugin<[RemarkCountProps | never], Root> = () => {
-	return async (tree, file) => {
+	return async (tree, file: AstroVFile) => {
 		const counts = {} as WordCounts;
 
 		/**
@@ -80,7 +81,7 @@ export const rehypeWordCount: Plugin<[RemarkCountProps | never], Root> = () => {
 		 * Plus, there's weird syntax parsing issues.
 		 */
 		if (file.path.includes(".mdx")) {
-			(file.data.astro as any).frontmatter.wordCount = 0;
+			file.data.astro.frontmatter.wordCount = 0;
 			return;
 		}
 
@@ -88,7 +89,7 @@ export const rehypeWordCount: Plugin<[RemarkCountProps | never], Root> = () => {
 			.use(rehypeRetext, unified().use(english).use(count(counts)))
 			.run(tree);
 
-		(file.data.astro as any).frontmatter.wordCount =
+		file.data.astro.frontmatter.wordCount =
 			(counts.InlineCodeWords || 0) + (counts.WordNode || 0);
 	};
 };

--- a/src/utils/markdown/types.ts
+++ b/src/utils/markdown/types.ts
@@ -1,0 +1,8 @@
+import { VFile } from "vfile";
+import { MarkdownAstroData } from "@astrojs/markdown-remark";
+
+export type AstroVFile = VFile & {
+	data: {
+		astro: MarkdownAstroData;
+	};
+};


### PR DESCRIPTION
This PR makes the remark and rehype typings more strict in UWU to prep for a eslint dep upgrade that strongly dislikes `any` usage whenever possible.