### PR TITLE
[UwU] Ellipsize text on collection card overflow

### DIFF
--- a/src/components/collection-card/collection-card.astro
+++ b/src/components/collection-card/collection-card.astro
@@ -28,7 +28,7 @@ const { collection, unicornProfilePicMap } = Astro.props as CollectionCardProps;
 const coverImgPath = getFullRelativePath(
 	"/content/collections",
 	collection.slug,
-	collection.coverImg
+	collection.coverImg,
 );
 
 const collectionPosts = getPostsByCollection(collection.slug, "en");
@@ -50,7 +50,9 @@ const collectionPosts = getPostsByCollection(collection.slug, "en");
 		/>
 		<div>
 			<h2 class={`text-style-headline-4 ${style.title}`}>{collection.title}</h2>
-			<p class={`text-style-body-medium`}>{collection.description}</p>
+			<p class={`text-style-body-medium ${style.description}`}>
+				{collection.description}
+			</p>
 		</div>
 	</div>
 	<div class={style.bottomRow}>

--- a/src/components/collection-card/collection-card.module.scss
+++ b/src/components/collection-card/collection-card.module.scss
@@ -49,11 +49,23 @@
 	display: flex;
 	margin-left: var(--collection-card_content_padding-left);
 	margin-right: var(--collection-card_content_padding-right);
+
+	&> div {
+		// prevent div from expanding beyond container size due to text overflow
+		min-width: 0;
+	}
 }
 
 .title {
 	margin-top: var(--collection-card_content_padding-top);
 	margin-bottom: var(--collection-card_title_padding-bottom);
+}
+
+.title, .description {
+	// prevents text overflow when the container is smaller than a single word (issue #620)
+	// - this otherwise has no effect, since the container can always expand vertically
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .bottomRow {


### PR DESCRIPTION
- Prevents collection card content from extending beyond the flex container size
- Adds `text-overflow: ellipsis` to prevent individual words overflowing past the container