### PR TITLE
[UwU] Prevent search filters from teleporting off the page

### DIFF
--- a/src/views/search/components/filter-dialog.module.scss
+++ b/src/views/search/components/filter-dialog.module.scss
@@ -30,7 +30,10 @@
 	width: calc(100% - var(--site-spacing) * 2);
 	height: 80vh;
 	border: none;
-	overflow: hidden;
+	// this should be overflow: clip; to prevent the browser scrolling within the element when a filter checkbox is focused:
+	// https://stackoverflow.com/q/75419337
+	// https://github.com/unicorn-utterances/unicorn-utterances/issues/653
+	overflow: clip;
 }
 
 .dialog::backdrop {

--- a/src/views/search/search-page.tsx
+++ b/src/views/search/search-page.tsx
@@ -354,7 +354,10 @@ function SearchPageBase({ unicornProfilePicMap }: SearchPageProps) {
 					height: `calc(100vh - ${headerHeight}px)`,
 					top: headerHeight,
 					position: "sticky",
-					overflow: "hidden",
+					// this should be overflow: clip; to prevent the browser scrolling within the element when a filter checkbox is focused:
+					// https://stackoverflow.com/q/75419337
+					// https://github.com/unicorn-utterances/unicorn-utterances/issues/653
+					overflow: "clip",
 				}}
 				searchString={search}
 			/>


### PR DESCRIPTION
Fixed #653 by replacing `overflow: hidden` with `overflow: clip` on the affected containers. This prevents their content from being programmatically scrolled whenever a React input is interacted with.