### PR TITLE
[UwU] Add search title text-shadow, fix search filter alignment

### DIFF
--- a/src/components/checkbox-box/checkbox-box.module.scss
+++ b/src/components/checkbox-box/checkbox-box.module.scss
@@ -40,6 +40,7 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
+	flex-shrink: 0;
 }
 
 .boxContainer {

--- a/src/components/checkbox-box/checkbox-box.module.scss
+++ b/src/components/checkbox-box/checkbox-box.module.scss
@@ -24,9 +24,7 @@
 	--checkbox_off_container_size: 18px;
 	--checkbox_off_container_corner-radius: 4px;
 	--checkbox_off_container_color_default: var(--transparent);
-	--checkbox_off_container_color_hovered: var(
-		--surface_primary_emphasis-medium
-	);
+	--checkbox_off_container_color_hovered: var(--surface_primary_emphasis-medium);
 	--checkbox_off_container_color_pressed: var(--primary_variant);
 	--checkbox_off_container_color_disabled: var(--background_disabled);
 

--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -25,21 +25,13 @@
 
 	// Colors: Primary buttons
 	--btn_primary_background-color_default: var(--surface_primary_emphasis-low);
-	--btn_primary_background-color_default_hovered: var(
-		--surface_primary_emphasis-medium
-	);
-	--btn_primary_background-color_default_pressed: var(
-		--surface_primary_emphasis-high
-	);
+	--btn_primary_background-color_default_hovered: var(--surface_primary_emphasis-medium);
+	--btn_primary_background-color_default_pressed: var(--surface_primary_emphasis-high);
 	--btn_primary_foreground-color_default: var(--primary_on-variant);
 
 	--btn_primary_background-color_emphasized: var(--primary_high-contrast);
-	--btn_primary_background-color_emphasized_hovered: var(
-		--primary_high-contrast_hovered
-	);
-	--btn_primary_background-color_emphasized_pressed: var(
-		--primary_high-contrast_pressed
-	);
+	--btn_primary_background-color_emphasized_hovered: var(--primary_high-contrast_hovered);
+	--btn_primary_background-color_emphasized_pressed: var(--primary_high-contrast_pressed);
 	--btn_primary_foreground-color_emphasized: var(--background_primary);
 
 	--btn_primary_focus-outline_width: var(--border-width_focus);
@@ -47,24 +39,14 @@
 	--btn_primary_focus-oultine_color: var(--focus-outline_primary);
 
 	// Colors: Secondary buttons
-	--btn_secondary_background-color_default: var(
-		--surface_secondary_emphasis-low
-	);
-	--btn_secondary_background-color_default_hovered: var(
-		--surface_secondary_emphasis-medium
-	);
-	--btn_secondary_background-color_default_pressed: var(
-		--surface_secondary_emphasis-high
-	);
+	--btn_secondary_background-color_default: var(--surface_secondary_emphasis-low);
+	--btn_secondary_background-color_default_hovered: var(--surface_secondary_emphasis-medium);
+	--btn_secondary_background-color_default_pressed: var(--surface_secondary_emphasis-high);
 	--btn_secondary_foreground-color_default: var(--secondary_on-variant);
 
 	--btn_secondary_background-color_emphasized: var(--secondary_high-contrast);
-	--btn_secondary_background-color_emphasized_hovered: var(
-		--secondary_high-contrast_hovered
-	);
-	--btn_secondary_background-color_emphasized_pressed: var(
-		--secondary_high-contrast_pressed
-	);
+	--btn_secondary_background-color_emphasized_hovered: var(--secondary_high-contrast_hovered);
+	--btn_secondary_background-color_emphasized_pressed: var(--secondary_high-contrast_pressed);
 	--btn_secondary_foreground-color_emphasized: var(--background_secondary);
 
 	--btn_secondary_focus-outline_width: var(--border-width_focus);

--- a/src/styles/markdown/embed.scss
+++ b/src/styles/markdown/embed.scss
@@ -13,9 +13,7 @@
 
 	--embed_background-color: var(--surface_primary_emphasis-none);
 	--embed_favicon_container_size: var(--min-target-size_m);
-	--embed_favicon_container_background-color: var(
-		--surface_primary_emphasis-low
-	);
+	--embed_favicon_container_background-color: var(--surface_primary_emphasis-low);
 	--embed_favicon_icon-size: var(--icon-size_regular);
 	--embed_favicon_icon_color: var(--primary_on-variant);
 	--embed_iframe_background-color: var(--surface_primary_emphasis-low);

--- a/src/styles/markdown/file-list.scss
+++ b/src/styles/markdown/file-list.scss
@@ -31,16 +31,10 @@
 
 	// Colors for folders
 	--filesystem_item_folder_container_color: var(--transparent);
-	--filesystem_item_folder_container_color_hovered: var(
-		--surface_secondary_emphasis-low
-	);
-	--filesystem_item_folder_container_color_pressed: var(
-		--surface_secondary_emphasis-medium
-	);
+	--filesystem_item_folder_container_color_hovered: var(--surface_secondary_emphasis-low);
+	--filesystem_item_folder_container_color_pressed: var(--surface_secondary_emphasis-medium);
 	--filesystem_item_folder_container_color_focused: var(--background_focus);
-	--filesystem_item_folder_container_corner-radius: var(
-		--corner-radius_circular
-	);
+	--filesystem_item_folder_container_corner-radius: var(--corner-radius_circular);
 	--filesystem_item_folder_icon-arrow_color: var(--secondary_on-variant);
 	--filesystem_item_folder_icon-folder_color: var(--secondary_default);
 	--filesystem_item_folder_label_color: var(--secondary_on-variant);
@@ -48,9 +42,7 @@
 	--filesystem_item_folder_focus-outline_color: var(--focus-outline_secondary);
 	--filesystem_item_folder_highlight_border_width: var(--border-width_s);
 	--filesystem_item_folder_highlight_border_color: var(--secondary_default);
-	--filesystem_item_folder_highlight_background-color: var(
-		--surface_secondary_emphasis-low
-	);
+	--filesystem_item_folder_highlight_background-color: var(--surface_secondary_emphasis-low);
 
 	// Colors for files
 	--filesystem_item_file_icon_color: var(--primary_default);
@@ -58,9 +50,7 @@
 	--filesystem_item_file_label_color: var(--foreground_emphasis-high);
 	--filesystem_item_file_highlight_border_width: var(--border-width_s);
 	--filesystem_item_file_highlight_border_color: var(--primary_default);
-	--filesystem_item_file_highlight_background-color: var(
-		--surface_primary_emphasis-low
-	);
+	--filesystem_item_file_highlight_background-color: var(--surface_primary_emphasis-low);
 
 	// Tokens for the level inset dividers
 	--filesystem_item_inset_margin-start: calc(

--- a/src/styles/markdown/hints.scss
+++ b/src/styles/markdown/hints.scss
@@ -22,12 +22,8 @@
 	--hint-header_gap: var(--spc-2x);
 
 	--hint-container_background-color: var(--surface_primary_emphasis-low);
-	--hint-container_background-color_hovered: var(
-		--surface_primary_emphasis-medium
-	);
-	--hint-container_background-color_pressed: var(
-		--surface_primary_emphasis-high
-	);
+	--hint-container_background-color_hovered: var(--surface_primary_emphasis-medium);
+	--hint-container_background-color_pressed: var(--surface_primary_emphasis-high);
 	--hint-container_background-color_focused: var(--background_focus);
 
 	--hint-container_foreground-color: var(--foreground_emphasis-high);

--- a/src/views/blog-post/article-nav/article-nav.module.scss
+++ b/src/views/blog-post/article-nav/article-nav.module.scss
@@ -15,12 +15,8 @@
 	--article-nav_item_overline-color: var(--primary_default);
 
 	--article-nav_item_background-color: var(--transparent);
-	--article-nav_item_background-color_hovered: var(
-		--surface_primary_emphasis-low
-	);
-	--article-nav_item_background-color_pressed: var(
-		--surface_primary_emphasis-low
-	);
+	--article-nav_item_background-color_hovered: var(--surface_primary_emphasis-low);
+	--article-nav_item_background-color_pressed: var(--surface_primary_emphasis-low);
 	--article-nav_item_background-color_focused: var(--background_focus);
 
 	--article-nav_item_border_color: var(--surface_primary_emphasis-low);

--- a/src/views/blog-post/series/series-toc.module.scss
+++ b/src/views/blog-post/series/series-toc.module.scss
@@ -7,9 +7,7 @@
 	--series-nav_header_padding-bottom: var(--spc-4x);
 
 	--series-nav_chapter-container_corner-radius: var(--corner-radius_m);
-	--series-nav_chapter-container_padding-vertical: var(
-		--series-nav_chapter-container_corner-radius
-	);
+	--series-nav_chapter-container_padding-vertical: var(--series-nav_chapter-container_corner-radius);
 	--series-nav_chapter-container_button_margin-start: var(--spc-4x);
 	--series-nav_chapter-container_button_margin-top: var(--spc-4x);
 
@@ -25,24 +23,14 @@
 
 	--series-nav_chapter-item_border_color_hovered: var(--primary_variant);
 	--series-nav_chapter-item_border_color_pressed: var(--primary_default);
-	--series-nav_chapter-item_border_color_selected: var(
-		--surface_primary_emphasis-medium
-	);
+	--series-nav_chapter-item_border_color_selected: var(--surface_primary_emphasis-medium);
 
-	--series-nav_chapter-item_background-color_hovered: var(
-		--surface_primary_emphasis-none
-	);
-	--series-nav_chapter-item_background-color_pressed: var(
-		--surface_primary_emphasis-low
-	);
+	--series-nav_chapter-item_background-color_hovered: var(--surface_primary_emphasis-none);
+	--series-nav_chapter-item_background-color_pressed: var(--surface_primary_emphasis-low);
 	--series-nav_chapter-item_arrow_color: var(--foreground_emphasis-medium);
 	--series-nav_chapter-item_title_color: var(--primary_default);
-	--series-nav_chapter-item_title_color_pressed: var(
-		--foreground_emphasis-high
-	);
-	--series-nav_chapter-item_title_color_selected: var(
-		--foreground_emphasis-medium
-	);
+	--series-nav_chapter-item_title_color_pressed: var(--foreground_emphasis-high);
+	--series-nav_chapter-item_title_color_selected: var(--foreground_emphasis-medium);
 }
 
 .seriesTableOfContent {

--- a/src/views/blog-post/table-of-contents/table-of-contents.module.scss
+++ b/src/views/blog-post/table-of-contents/table-of-contents.module.scss
@@ -158,9 +158,7 @@
 		width: 2px;
 		position: absolute;
 		left: calc(
-			-2px - var(--toc_sub-item_padding-start) - calc(var(
-							--toc_sub-item_dot_size
-						) / 2)
+			-2px - var(--toc_sub-item_padding-start) - calc(var(--toc_sub-item_dot_size) / 2)
 		);
 		bottom: 0;
 		top: unset;
@@ -181,9 +179,7 @@
 		width: 2px;
 		position: absolute;
 		left: calc(
-			-2px - var(--toc_sub-item_padding-start) - calc(var(
-							--toc_sub-item_dot_size
-						) / 2)
+			-2px - var(--toc_sub-item_padding-start) - calc(var(--toc_sub-item_dot_size) / 2)
 		);
 		bottom: 0;
 		top: unset;

--- a/src/views/collections/collection-page.module.scss
+++ b/src/views/collections/collection-page.module.scss
@@ -26,9 +26,7 @@
 	--collection-page_author_description_padding-top: var(--spc-4x);
 
 	--collection-page_author_name_color: var(--foreground_emphasis-high);
-	--collection-page_author_count-articles_color: var(
-		--foreground_emphasis-high
-	);
+	--collection-page_author_count-articles_color: var(--foreground_emphasis-high);
 	--collection-page_author_count-words_color: var(--foreground_emphasis-medium);
 	--collection-page_author_dot_color: var(--foreground_emphasis-medium);
 	--collection-page_author_description_color: var(--foreground_emphasis-high);

--- a/src/views/search/components/filter-section-item.module.scss
+++ b/src/views/search/components/filter-section-item.module.scss
@@ -32,6 +32,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	flex-shrink: 0;
 }
 
 .label {
@@ -41,6 +42,7 @@
 
 .count {
 	color: var(--search-page_filter_list_item_count_color);
+	flex-shrink: 0;
 }
 
 .containerLabel.selected {

--- a/src/views/search/components/filter-section-item.module.scss
+++ b/src/views/search/components/filter-section-item.module.scss
@@ -10,15 +10,9 @@
 	--search-page_filter_list_item_label_color: var(--foreground_emphasis-high);
 	--search-page_filter_list_item_count_color: var(--foreground_disabled);
 
-	--search-page_filter_list_item_background-color_hovered: var(
-		--surface_primary_emphasis-low
-	);
-	--search-page_filter_list_item_background-color_pressed: var(
-		--surface_primary_emphasis-medium
-	);
-	--search-page_filter_list_item_background-color_selected: var(
-		--surface_primary_emphasis-none
-	);
+	--search-page_filter_list_item_background-color_hovered: var(--surface_primary_emphasis-low);
+	--search-page_filter_list_item_background-color_pressed: var(--surface_primary_emphasis-medium);
+	--search-page_filter_list_item_background-color_selected: var(--surface_primary_emphasis-none);
 }
 
 .containerLabel {

--- a/src/views/search/components/search-hero.module.scss
+++ b/src/views/search/components/search-hero.module.scss
@@ -18,6 +18,9 @@
 	--search-hero_title_color: var(--foreground_emphasis-high);
 	--search-hero_description_color: var(--foreground_emphasis-medium);
 
+	// opaque text-shadow color, calculated from overlaying `surface_primary_emphasis-none` on `background_primary`.
+	--search-hero_title_shadow-color: #d6ecff;
+
 	--search-hero_btn_margin-top: var(--site-spacing);
 
 	@include from($tabletSmall) {
@@ -29,6 +32,14 @@
 	@include from($desktopSmall) {
 		--search-hero_container_max-width: var(--max-width_m);
 		--search-hero_icon_size: calc(var(--icon-size_regular) * 3);
+	}
+}
+
+// this is a hack for darkTheme, since `html.dark :root` won't work; `html.dark body` will
+body {
+	@include darkTheme {
+		// opaque text-shadow color, calculated from overlaying `surface_primary_emphasis-none` on `background_primary`.
+		--search-hero_title_shadow-color: #00293e;
 	}
 }
 
@@ -78,10 +89,10 @@
 	color: var(--search-hero_title_color);
 
 	text-shadow:
-		0 0 5px var(--search-hero_container_background-color),
-		0 0 6px var(--search-hero_container_background-color),
-		0 0 8px var(--search-hero_container_background-color),
-		0 0 8px var(--search-hero_container_background-color);
+		0 0 5px var(--search-hero_title_shadow-color),
+		0 0 6px var(--search-hero_title_shadow-color),
+		0 0 8px var(--search-hero_title_shadow-color),
+		0 0 8px var(--search-hero_title_shadow-color);
 }
 
 .description {

--- a/src/views/search/components/search-hero.module.scss
+++ b/src/views/search/components/search-hero.module.scss
@@ -12,9 +12,7 @@
 
 	--search-hero_icon_size: var(--icon-size_regular);
 
-	--search-hero_container_background-color: var(
-		--surface_primary_emphasis-none
-	);
+	--search-hero_container_background-color: var(--surface_primary_emphasis-none);
 	--search-hero_image_border_color: var(--background_primary);
 
 	--search-hero_title_color: var(--foreground_emphasis-high);
@@ -58,7 +56,7 @@
 	flex-direction: column;
 	gap: var(--search-hero_container_gap);
 
-	@include transition(background);
+	@include transition(background-color);
 }
 
 .image {
@@ -78,6 +76,12 @@
 .title {
 	margin: 0;
 	color: var(--search-hero_title_color);
+
+	text-shadow:
+		0 0 5px var(--search-hero_container_background-color),
+		0 0 6px var(--search-hero_container_background-color),
+		0 0 8px var(--search-hero_container_background-color),
+		0 0 8px var(--search-hero_container_background-color);
 }
 
 .description {
@@ -107,7 +111,7 @@
 .sticker7,
 .sticker8 {
 	--sticker_timing: 300ms ease-in-out;
-	z-index: 1;
+	z-index: -1;
 	position: absolute;
 	height: 24px;
 	width: 24px;


### PR DESCRIPTION
- Removes var/token indentation to fix devtools usage
- Adds `flex-shrink: 0;` to filter items to prevent misalignment with wrapping text
- Set `z-index: -1` on hero stickers and add a (hardcoded for opacity) `text-shadow` to the hero title