### PR TITLE
[UwU] Fix mailing list input layout shift

### DIFF
--- a/content/site/about-us.es.md
+++ b/content/site/about-us.es.md
@@ -1,4 +1,4 @@
-<p class="text-style-headline-2">Nuestro objetivo es proveer los mejores recursos posibles para aprender cualquier tema relacionado con las ciencias de la computación</p>
+<p><span class="text-style-headline-2">Nuestro objetivo es proveer los mejores recursos posibles para aprender cualquier tema relacionado con las ciencias de la computación</span></p>
 
 Ya sea desde cómo se almacena la memoria en assembly o cómo hacer animaciones complejas en CSS, hasta lo que es un bucle For, queremos brindar recursos que sean acogedores, de apoyo e informativos.
 

--- a/content/site/about-us.fr.md
+++ b/content/site/about-us.fr.md
@@ -1,4 +1,4 @@
-<p class="text-style-headline-2">Notre but est de fournir les meilleurs ressources pour apprendre n’importe quel aspect dans le domaine de l’informatique</p>
+<p><span class="text-style-headline-2">Notre but est de fournir les meilleurs ressources pour apprendre n’importe quel aspect dans le domaine de l’informatique</span></p>
 
 C’est quoi une boucle “for”? Comment créer des animations avec CSS? Comment se fait le stockage mémoire avec Assembly? Quel que soit le sujet, nous voudrions nous assurer que le site soit accueillant, incitatif et informatif.
 

--- a/content/site/about-us.md
+++ b/content/site/about-us.md
@@ -1,4 +1,4 @@
-<p class="text-style-headline-2">Our goal is to provide the best resources possible to learn any computer science related topic</p>
+<p><span class="text-style-headline-2">Our goal is to provide the best resources possible to learn any computer science related topic</span></p>
 
 What’s a for loop? How do I create animations in CSS? How is memory allocated in Assembly? No matter what the topic is, we want our website to be welcoming, supportive and informational.
 

--- a/content/site/about-us.pt.md
+++ b/content/site/about-us.pt.md
@@ -1,4 +1,4 @@
-<p class="text-style-headline-2">O nosso objetivo é fornecer os melhores recursos possíveis para aprender qualquer tópico que esteja relacionado a Ciência dos Computadores</p>
+<p><span class="text-style-headline-2">O nosso objetivo é fornecer os melhores recursos possíveis para aprender qualquer tópico que esteja relacionado a Ciência dos Computadores</span></p>
 
 O que é um ciclo for? Como faço animações com CSS? Como é que a memória é gerida em Assembly? Não importa qual é o tópico, nós queremos que o nosso website seja amigável, que forneça apoio e seja informativo.
 

--- a/src/components/input/input.module.scss
+++ b/src/components/input/input.module.scss
@@ -54,7 +54,6 @@
 		var(--form-field_outline_color_focused);
 	outline: var(--form-field_halo_color) solid var(--form-field_halo_width);
 	background: var(--form-field_background_focused);
-	margin: 0;
 }
 
 .input:disabled,

--- a/src/components/input/input.module.scss
+++ b/src/components/input/input.module.scss
@@ -34,13 +34,10 @@
 	padding: var(--form-field_padding-vertical)
 		var(--form-field_padding-horizontal);
 	border: var(--form-field_outline_width) solid var(--form-field_outline_color);
-	outline: rgba(0, 0, 0, 0) solid var(--form-field_halo_width);
 	border-radius: 8px;
 	background: var(--form-field_background);
 	color: var(--foreground_emphasis-high);
-	margin: calc(
-		var(--form-field_outline_width_focused) - var(--form-field_outline_width)
-	);
+	margin: 0;
 }
 
 .input:hover {
@@ -50,9 +47,12 @@
 }
 
 .input:focus-within {
-	border: var(--form-field_outline_width_focused) solid
+	// keep the border width the same size in all states, to avoid layout shift
+	border: var(--form-field_outline_width) solid
 		var(--form-field_outline_color_focused);
-	outline: var(--form-field_halo_color) solid var(--form-field_halo_width);
+	// only use outline for the :focus-within state, for visibility in high-contrast themes
+	outline: calc(var(--form-field_outline_width_focused) - var(--form-field_outline_width)) solid var(--form-field_outline_color_focused);
+	box-shadow: 0 0 0 calc(var(--form-field_outline_width_focused) - var(--form-field_outline_width) + var(--form-field_halo_width)) var(--form-field_halo_color);
 	background: var(--form-field_background_focused);
 }
 
@@ -61,7 +61,6 @@
 	background: var(--form-field_background_disabled);
 	border: var(--form-field_outline_width) solid
 		var(--form-field_outline_color_disabled);
-	outline: rgba(0, 0, 0, 0) solid var(--form-field_halo_width);
 }
 
 .labelContainer {

--- a/src/components/post-card/post-card.module.scss
+++ b/src/components/post-card/post-card.module.scss
@@ -148,6 +148,7 @@
 	flex-direction: row;
 	gap: var(--card_detail-row_gap);
 	align-items: center;
+	margin: 0;
 }
 
 .publishedDate {

--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -1,4 +1,5 @@
 @import "src/tokens/index";
+@import "./text-styles.scss";
 
 :where(a) {
 	color: var(--primary_default);
@@ -10,42 +11,49 @@
 
 .post-body {
 	h1 {
+		@extend .text-style-headline-1;
 		margin: 0 auto;
 		margin-top: var(--h1_block-padding-top);
 		margin-bottom: var(--h1_block-padding-bottom);
 	}
 
 	h2 {
+		@extend .text-style-headline-2;
 		margin: 0 auto;
 		margin-top: var(--h2_block-padding-top);
 		margin-bottom: var(--h2_block-padding-bottom);
 	}
 
 	h3 {
+		@extend .text-style-headline-3;
 		margin: 0 auto;
 		margin-top: var(--h3_block-padding-top);
 		margin-bottom: var(--h3_block-padding-bottom);
 	}
 
 	h4 {
+		@extend .text-style-headline-4;
 		margin: 0 auto;
 		margin-top: var(--h4_block-padding-top);
 		margin-bottom: var(--h4_block-padding-bottom);
 	}
 
 	h5 {
+		@extend .text-style-headline-5;
 		margin: 0 auto;
 		margin-top: var(--h5_block-padding-top);
 		margin-bottom: var(--h5_block-padding-bottom);
 	}
 
 	h6 {
+		@extend .text-style-headline-6;
 		margin: 0 auto;
 		margin-top: var(--h6_block-padding-top);
 		margin-bottom: var(--h6_block-padding-bottom);
 	}
 
 	p {
+		@extend .text-style-body-large;
 		margin-top: var(--p_block-padding-vertical);
 		margin-bottom: var(--p_block-padding-vertical);
 	}
@@ -125,6 +133,10 @@
 	img[src$=".svg"] {
 		width: 100%;
 		max-height: 50vh;
+	}
+
+	pre, code {
+		@extend .text-style-code;
 	}
 
 	p > code {

--- a/src/styles/text-styles.scss
+++ b/src/styles/text-styles.scss
@@ -39,56 +39,49 @@
 	font-family: var(--uu-font-family);
 }
 
-h1,
-.text-style-headline-1 {
+:where(.text-style-headline-1) {
 	font-family: var(--uu-font-family);
 	font-size: var(--h1_font-size);
 	font-weight: var(--weight_black);
 	line-height: var(--h1_line-height);
 }
 
-h2,
-.text-style-headline-2 {
+:where(.text-style-headline-2) {
 	font-family: var(--uu-font-family);
 	font-size: var(--h2_font-size);
 	font-weight: var(--weight_extrabold);
 	line-height: var(--h2_line-height);
 }
 
-h3,
-.text-style-headline-3 {
+:where(.text-style-headline-3) {
 	font-family: var(--uu-font-family);
 	font-size: var(--h3_font-size);
 	font-weight: var(--weight_bold);
 	line-height: var(--h3_line-height);
 }
 
-h4,
-.text-style-headline-4 {
+:where(.text-style-headline-4) {
 	font-family: var(--uu-font-family);
 	font-size: var(--h4_font-size);
 	font-weight: var(--weight_bold);
 	line-height: var(--h4_line-height);
 }
 
-h5,
-.text-style-headline-5 {
+:where(.text-style-headline-5) {
 	font-family: var(--uu-font-family);
 	font-size: var(--h5_font-size);
 	font-weight: var(--weight_bold);
 	line-height: var(--h5_line-height);
 }
 
-h6,
-.text-style-headline-6 {
+:where(.text-style-headline-6) {
 	font-family: var(--uu-font-family);
 	font-size: var(--h6_font-size);
 	font-weight: var(--weight_bold);
 	line-height: var(--h6_line-height);
 }
 
-p,
-.text-style-body-large {
+:where(.text-style-body-large) {
 	font-family: var(--uu-font-family);
 	font-size: var(--p_large_font-size);
 	font-weight: var(--weight_regular);
@@ -96,12 +89,12 @@ p,
 	margin: 0;
 }
 
-.text-style-body-large-bold {
+:where(.text-style-body-large-bold) {
 	@extend .text-style-body-large;
 	font-weight: var(--weight_semibold);
 }
 
-.text-style-body-medium {
+:where(.text-style-body-medium) {
 	font-family: var(--uu-font-family);
 	font-size: var(--p_medium_font-size);
 	font-weight: var(--weight_regular);
@@ -109,12 +102,12 @@ p,
 	margin: 0;
 }
 
-.text-style-body-medium-bold {
+:where(.text-style-body-medium-bold) {
 	@extend .text-style-body-medium;
 	font-weight: var(--weight_semibold);
 }
 
-.text-style-body-small {
+:where(.text-style-body-small) {
 	font-family: var(--uu-font-family);
 	font-size: var(--p_small_font-size);
 	font-weight: var(--weight_regular);
@@ -122,12 +115,12 @@ p,
 	margin: 0;
 }
 
-.text-style-body-small-bold {
+:where(.text-style-body-small-bold) {
 	@extend .text-style-body-small;
 	font-weight: var(--weight_semibold);
 }
 
-.text-style-button-large {
+:where(.text-style-button-large) {
 	font-family: var(--uu-font-family);
 	font-size: var(--button_large_font-size);
 	font-weight: var(--weight_semibold);
@@ -135,8 +128,7 @@ p,
 	margin: 0;
 }
 
-button,
-.text-style-button-regular {
+:where(.text-style-button-regular) {
 	font-family: var(--uu-font-family);
 	font-size: var(--button_regular_font-size);
 	font-weight: var(--weight_semibold);
@@ -144,9 +136,7 @@ button,
 	margin: 0;
 }
 
-pre,
-code,
-.text-style-code {
+:where(.text-style-code) {
 	@extend .text-style-body-large;
 	font-family: var(--uu-font-family-code);
 }

--- a/src/views/about/about.astro
+++ b/src/views/about/about.astro
@@ -29,7 +29,7 @@ const sponsors = getTranslatedPage(
 			alt={"Unicorn Utterances logo"}
 			class={style.unicornLogo}
 		/>
-		<h1>{translate(Astro, "title.about_us")}</h1>
+		<h1 class="text-style-headline-1">{translate(Astro, "title.about_us")}</h1>
 	</div>
 	<main class={`${style.aboutBody} post-body`}>
 		<TranslationsHeader locales={about.locales} />

--- a/src/views/blog-post/post-title-header/post-title-header.astro
+++ b/src/views/blog-post/post-title-header/post-title-header.astro
@@ -17,7 +17,7 @@ const editedStr = post.edited && dayjs(post.edited).format("MMMM D, YYYY");
 ---
 
 <header role="banner" class={style.container}>
-	<h1 class={style.title}>{title}</h1>
+	<h1 class={`text-style-headline-1 ${style.title}`}>{title}</h1>
 
 	<div class={style.details}>
 		<div class={style.date}>

--- a/src/views/collections/collection-chapter.astro
+++ b/src/views/collections/collection-chapter.astro
@@ -23,7 +23,7 @@ const { num, title, description, href } = Astro.props as CollectionChapter;
 			{href ? <a href={href}>{title}</a> : title}
 		</h2>
 	</div>
-	<p class={styles.description}>
+	<p class={`text-style-body-large ${styles.description}`}>
 		{description}
 	</p>
 </div>

--- a/src/views/collections/collection-page.astro
+++ b/src/views/collections/collection-page.astro
@@ -36,7 +36,7 @@ const collectionMeta = collections.find((col) => col.slug === collection.slug)!;
 const coverImgSize = getImageSize(
 	"." + coverImgPath,
 	process.cwd(),
-	process.cwd()
+	process.cwd(),
 );
 
 const coverImgAspectRatio = coverImgSize.width / coverImgSize.height;
@@ -84,12 +84,12 @@ const coverImgAspectRatio = coverImgSize.width / coverImgSize.height;
 				{
 					collectionMeta.authorsMeta.map((author) => {
 						const authorPosts = posts.filter((post) =>
-							post.authors.includes(author.id)
+							post.authors.includes(author.id),
 						);
 
 						const wordCount = authorPosts.reduce(
 							(acc, post) => acc + (post as ExtendedPostInfo).wordCount ?? 0,
-							0
+							0,
 						);
 						const href = `/unicorns/${author.id}`;
 						return (
@@ -103,7 +103,7 @@ const coverImgAspectRatio = coverImgSize.width / coverImgSize.height;
 								>
 									<UUPicture
 										picture={unicornProfilePicMap.find(
-											(u) => u.id === author.id
+											(u) => u.id === author.id,
 										)}
 										alt={author.name}
 									/>
@@ -112,29 +112,23 @@ const coverImgAspectRatio = coverImgSize.width / coverImgSize.height;
 									<p class={`text-style-body-large-bold ${styles.authorName}`}>
 										{author.name}
 									</p>
-									<div>
-										<p>
-											<span
-												class={`text-style-body-medium-bold ${styles.authorArticles}`}
-											>
-												{translate(
-													Astro,
-													"title.n_articles",
-													authorPosts.length.toString()
-												)}
-											</span>
-											<span class={styles.authorMetaSeperatorDot}>•</span>
-											<span
-												class={`text-style-body-medium-bold ${styles.authorWordCount}`}
-											>
-												{translate(
-													Astro,
-													"title.n_words",
-													wordCount.toString()
-												)}
-											</span>
-										</p>
-									</div>
+									<p class="text-style-body-large">
+										<span
+											class={`text-style-body-medium-bold ${styles.authorArticles}`}
+										>
+											{translate(
+												Astro,
+												"title.n_articles",
+												authorPosts.length.toString(),
+											)}
+										</span>
+										<span class={styles.authorMetaSeperatorDot}>•</span>
+										<span
+											class={`text-style-body-medium-bold ${styles.authorWordCount}`}
+										>
+											{translate(Astro, "title.n_words", wordCount.toString())}
+										</span>
+									</p>
 								</div>
 								<Button as="a" href={href} class={styles.viewProfileBtn}>
 									{translate(Astro, "action.view_profile")}


### PR DESCRIPTION
The modular CSS appears to have a higher specificity in prod than in dev mode, resulting in some unreliable behavior. This fix hopefully prevents any more text-styles related issues involving this.

- All of the text-styles classes now use a `:where()` selector to reduce their specificity
- Any default text styling for elements is removed.
  * i.e. no more `p, .text-style-body-large { ...`. Any `<p>` or `<h#>` element will need to specify which text style class to use.
  * This prevents a `<p class="text-style-body-small">` from being affected by the `text-style-body-large` styling (since the two selectors would conflict if placed inside a `:where()` selector)
  * Selectors in `.post-body` now `@extend` the respective text styles to apply them to post contents
- The `margin: 0;` causing input layout shift on focus has been removed.
  * This was entirely unrelated to the specificity problems, but the `margin: 0;` property in `text-style-body-medium` meant that the layout shift would not occur in dev mode.