### PR TITLE
[UwU] Fix filter checkbox text selection causing strange behavior

### DIFF
--- a/src/components/checkbox-box/checkbox-box.module.scss
+++ b/src/components/checkbox-box/checkbox-box.module.scss
@@ -41,6 +41,12 @@
 	align-items: center;
 	justify-content: center;
 	flex-shrink: 0;
+
+	// prevents the user from selecting nodes inside the checkbox, which causes
+	// strange behavior when the state is changed (possibly caused by the browser
+	// re-evaluating the selection when the checkbox is re-rendered)
+	// https://github.com/unicorn-utterances/unicorn-utterances/issues/652
+	user-select: none;
 }
 
 .boxContainer {


### PR DESCRIPTION
Adds `user-select: none;` to the checkbox icon container to prevent it from being selected. This might've been causing strange onclick behavior (causing double-clicks) when nodes inside the selection were rerendered.