### PR TITLE
[UwU] Remove default sort type

### DIFF
--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -55,6 +55,7 @@ function Popover({
 interface SelectProps<T extends object> extends AriaSelectProps<T> {
 	class?: string;
 	className?: string;
+	defaultValue: string;
 }
 
 export function Select<T extends object>({
@@ -75,7 +76,7 @@ export function Select<T extends object>({
 	return (
 		<div style={{ display: "inline-block" }}>
 			<div {...labelProps} class={"visually-hidden"}>
-				Post sort order
+				{props.label}
 			</div>
 			<HiddenSelect
 				isDisabled={props.isDisabled}
@@ -107,7 +108,7 @@ export function Select<T extends object>({
 				<span {...valueProps}>
 					{state.selectedItem
 						? state.selectedItem.rendered
-						: "Select an option"}
+						: props.defaultValue}
 				</span>
 			</Button>
 

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -56,11 +56,14 @@ interface SelectProps<T extends object> extends AriaSelectProps<T> {
 	class?: string;
 	className?: string;
 	defaultValue: string;
+	prefixSelected: string;
 }
 
 export function Select<T extends object>({
 	class: className = "",
 	className: classNameName = "",
+	defaultValue,
+	prefixSelected = "",
 	...props
 }: PropsWithChildren<SelectProps<T>>) {
 	const state = useSelectState(props);
@@ -106,9 +109,8 @@ export function Select<T extends object>({
 				}
 			>
 				<span {...valueProps}>
-					{state.selectedItem
-						? state.selectedItem.rendered
-						: props.defaultValue}
+					{prefixSelected}
+					{state.selectedItem ? state.selectedItem.rendered : defaultValue}
 				</span>
 			</Button>
 

--- a/src/views/search/components/filter-display.tsx
+++ b/src/views/search/components/filter-display.tsx
@@ -19,8 +19,8 @@ interface FilterDisplayProps {
 	setSelectedTags: (tags: string[]) => void;
 	selectedAuthorIds: string[];
 	setSelectedAuthorIds: (authors: string[]) => void;
-	sort: "newest" | "oldest";
-	setSort: (sortBy: "newest" | "oldest") => void;
+	sort: "newest" | "oldest" | null;
+	setSort: (sortBy: "newest" | "oldest" | null) => void;
 	desktopStyle?: CSSProperties;
 	isFilterDialogOpen: boolean;
 	setFilterIsDialogOpen: (isOpen: boolean) => void;

--- a/src/views/search/components/filter-sidebar.tsx
+++ b/src/views/search/components/filter-sidebar.tsx
@@ -22,8 +22,8 @@ interface FilterSidebar {
 	setSelectedTags: (tags: string[]) => void;
 	selectedAuthorIds: string[];
 	setSelectedAuthorIds: (authors: string[]) => void;
-	sort: "newest" | "oldest";
-	setSort: (sortBy: "newest" | "oldest") => void;
+	sort: "newest" | "oldest" | null;
+	setSort: (sortBy: "newest" | "oldest" | null) => void;
 	tags: ExtendedTag[];
 	authors: ExtendedUnicorn[];
 	onSelectedAuthorChange: (authorId: string) => void;
@@ -74,7 +74,14 @@ export const FilterSidebar = ({
 				className={styles.buttonsContainer}
 				value={sort}
 				label={"Sort order"}
-				onChange={(val) => setSort(val as "newest")}
+				onChange={(val) => {
+					if (sort === val) {
+						setSort(null);
+						return;
+					}
+
+					setSort(val as "newest");
+				}}
 			>
 				<RadioButton value={"newest"}>Newest</RadioButton>
 				<RadioButton value={"oldest"}>Oldest</RadioButton>

--- a/src/views/search/components/search-topbar.tsx
+++ b/src/views/search/components/search-topbar.tsx
@@ -8,6 +8,7 @@ import {
 	RadioButton,
 	RadioButtonGroup,
 } from "components/button-radio-group/button-radio-group";
+import { StateUpdater } from "preact/hooks";
 
 interface SearchTopbarProps {
 	onSubmit: (search: string) => void;
@@ -16,8 +17,8 @@ interface SearchTopbarProps {
 	setSearch: (search: string) => void;
 	setContentToDisplay: (content: "all" | "articles" | "collections") => void;
 	contentToDisplay: "all" | "articles" | "collections";
-	setSort: (sort: "newest" | "oldest") => void;
-	sort: "newest" | "oldest";
+	sort: "newest" | "oldest" | null;
+	setSort: (sortBy: "newest" | "oldest" | null) => void;
 	setFilterIsDialogOpen: (isOpen: boolean) => void;
 }
 
@@ -94,10 +95,18 @@ export const SearchTopbar = ({
 						Filter
 					</Button>
 					<Select
-						label={"Order"}
+						label={"Post sort order"}
+						defaultValue={"Sort order"}
 						selectedKey={sort}
-						onSelectionChange={(v) => setSort(v)}
+						onSelectionChange={(v) => {
+							if (!v) {
+								setSort(null);
+								return;
+							}
+							setSort(v);
+						}}
 					>
+						<Item key={""}>Default</Item>
 						<Item key={"newest"}>Newest</Item>
 						<Item key={"oldest"}>Oldest</Item>
 					</Select>
@@ -109,7 +118,14 @@ export const SearchTopbar = ({
 					className={style.topBarSmallTabletButtonsToggle}
 					value={sort}
 					label={"Sort order"}
-					onChange={(val) => setSort(val as "newest")}
+					onChange={(val) => {
+						if (sort === val) {
+							setSort(null);
+							return;
+						}
+
+						setSort(val as "newest");
+					}}
 				>
 					<RadioButton value={"newest"}>Newest</RadioButton>
 					<RadioButton value={"oldest"}>Oldest</RadioButton>

--- a/src/views/search/components/search-topbar.tsx
+++ b/src/views/search/components/search-topbar.tsx
@@ -96,7 +96,8 @@ export const SearchTopbar = ({
 					</Button>
 					<Select
 						label={"Post sort order"}
-						defaultValue={"Sort order"}
+						prefixSelected={"Sort by: "}
+						defaultValue={"Relevance"}
 						selectedKey={sort}
 						onSelectionChange={(v) => {
 							if (!v) {
@@ -106,7 +107,7 @@ export const SearchTopbar = ({
 							setSort(v);
 						}}
 					>
-						<Item key={""}>Default</Item>
+						<Item key={""}>Relevance</Item>
 						<Item key={"newest"}>Newest</Item>
 						<Item key={"oldest"}>Oldest</Item>
 					</Select>

--- a/src/views/search/search-page.tsx
+++ b/src/views/search/search-page.tsx
@@ -42,7 +42,7 @@ import {
 } from "../../utils/search";
 import { debounce } from "utils/debounce";
 
-const DEFAULT_SORT = "newest";
+const DEFAULT_SORT = null;
 const DEFAULT_CONTENT_TO_DISPLAY = "all";
 
 interface SearchPageProps {
@@ -173,8 +173,8 @@ function SearchPageBase({ unicornProfilePicMap }: SearchPageProps) {
 	}, [urlParams]);
 
 	const setSelectedUnicorns = useCallback(
-		(sort: string[]) => {
-			pushState({ key: FILTER_AUTHOR_KEY, val: sort.toString() });
+		(authors: string[]) => {
+			pushState({ key: FILTER_AUTHOR_KEY, val: authors.toString() });
 			pushState({ key: SEARCH_PAGE_KEY, val: undefined }); // reset to page 1
 		},
 		[urlParams],
@@ -188,8 +188,8 @@ function SearchPageBase({ unicornProfilePicMap }: SearchPageProps) {
 	}, [urlParams]);
 
 	const setSelectedTags = useCallback(
-		(sort: string[]) => {
-			pushState({ key: FILTER_TAGS_KEY, val: sort.toString() });
+		(tags: string[]) => {
+			pushState({ key: FILTER_TAGS_KEY, val: tags.toString() });
 			pushState({ key: SEARCH_PAGE_KEY, val: undefined }); // reset to page 1
 		},
 		[urlParams],
@@ -204,8 +204,8 @@ function SearchPageBase({ unicornProfilePicMap }: SearchPageProps) {
 	}, [urlParams]);
 
 	const setContentToDisplay = useCallback(
-		(sort: "all" | "articles" | "collections") => {
-			pushState({ key: CONTENT_TO_DISPLAY_KEY, val: sort });
+		(display: "all" | "articles" | "collections") => {
+			pushState({ key: CONTENT_TO_DISPLAY_KEY, val: display });
 			pushState({ key: SEARCH_PAGE_KEY, val: undefined }); // reset to page 1
 		},
 		[urlParams],
@@ -220,14 +220,18 @@ function SearchPageBase({ unicornProfilePicMap }: SearchPageProps) {
 	// Setup sort
 	const sort = useMemo(() => {
 		const results = urlParams.get(SORT_KEY);
-		if (!results) return DEFAULT_SORT;
-		return results === "newest" ? "newest" : "oldest";
+		if (!results) return DEFAULT_SORT as null;
+		return results as "newest" | "oldest" | null;
 	}, [urlParams]);
 
 	const setSort = useCallback(
-		(sort: "newest" | "oldest") => {
-			pushState({ key: SORT_KEY, val: sort });
+		(sort: "newest" | "oldest" | null) => {
 			pushState({ key: SEARCH_PAGE_KEY, val: undefined }); // reset to page 1
+			if (!sort) {
+				pushState({ key: SORT_KEY, val: undefined });
+				return;
+			}
+			pushState({ key: SORT_KEY, val: sort });
 		},
 		[urlParams],
 	);
@@ -236,57 +240,64 @@ function SearchPageBase({ unicornProfilePicMap }: SearchPageProps) {
 	 * Filter and sort posts
 	 */
 	const filteredAndSortedPosts = useMemo(() => {
-		return [...data.posts]
-			.sort(
+		const posts = [...data.posts];
+		if (sort) {
+			posts.sort(
 				(a, b) =>
 					(sort === "newest" ? -1 : 1) *
 					(new Date(a.published).getTime() - new Date(b.published).getTime()),
-			)
-			.filter((post) => {
-				if (
-					selectedTags.length > 0 &&
-					!post.tags.some((tag) => selectedTags.includes(tag))
-				) {
-					return false;
-				}
+			);
+		}
 
-				if (
-					selectedUnicorns.length > 0 &&
-					!post.authors.some((unicorn) => selectedUnicorns.includes(unicorn))
-				) {
-					return false;
-				}
+		return posts.filter((post) => {
+			if (
+				selectedTags.length > 0 &&
+				!post.tags.some((tag) => selectedTags.includes(tag))
+			) {
+				return false;
+			}
 
-				return true;
-			});
+			if (
+				selectedUnicorns.length > 0 &&
+				!post.authors.some((unicorn) => selectedUnicorns.includes(unicorn))
+			) {
+				return false;
+			}
+
+			return true;
+		});
 	}, [data, page, sort, selectedUnicorns, selectedTags]);
 
 	const filteredAndSortedCollections = useMemo(() => {
-		return [...data.collections]
-			.sort(
+		const collections = [...data.collections];
+
+		if (sort) {
+			collections.sort(
 				(a, b) =>
 					(sort === "newest" ? -1 : 1) *
 					(new Date(a.published).getTime() - new Date(b.published).getTime()),
-			)
-			.filter((collection) => {
-				if (
-					selectedTags.length > 0 &&
-					!collection.tags.some((tag) => selectedTags.includes(tag))
-				) {
-					return false;
-				}
+			);
+		}
 
-				if (
-					selectedUnicorns.length > 0 &&
-					!collection.authors.some((unicorn) =>
-						selectedUnicorns.includes(unicorn),
-					)
-				) {
-					return false;
-				}
+		return collections.filter((collection) => {
+			if (
+				selectedTags.length > 0 &&
+				!collection.tags.some((tag) => selectedTags.includes(tag))
+			) {
+				return false;
+			}
 
-				return true;
-			});
+			if (
+				selectedUnicorns.length > 0 &&
+				!collection.authors.some((unicorn) =>
+					selectedUnicorns.includes(unicorn),
+				)
+			) {
+				return false;
+			}
+
+			return true;
+		});
 	}, [data, page, sort, selectedUnicorns, selectedTags]);
 
 	/**


### PR DESCRIPTION
This PR allows us to remove the default sort type (and allow the user to unselect one once they active one) so that the user can see the server's default sort order (important so that we can order the search results by most relevant to the user)

Notable screenshots:

<img width="165" alt="image" src="https://github.com/unicorn-utterances/unicorn-utterances/assets/9100169/57d456cc-1654-4d05-9a2f-2698e42a4df9">

<img width="240" alt="image" src="https://github.com/unicorn-utterances/unicorn-utterances/assets/9100169/06389434-9e19-4a1e-9dd4-aaead76b2da3">

<img width="451" alt="image" src="https://github.com/unicorn-utterances/unicorn-utterances/assets/9100169/9ff6b6d8-0d36-4f43-8c8f-3d05b2a318c9">

<img width="119" alt="image" src="https://github.com/unicorn-utterances/unicorn-utterances/assets/9100169/fd41c372-b309-42c2-9a48-90acb3d8ce2c">



Closes #661