### PR TITLE
[UwU] Avoid clipping focus states in the search sidebar

### DIFF
--- a/src/views/search/components/filter-sidebar.module.scss
+++ b/src/views/search/components/filter-sidebar.module.scss
@@ -7,10 +7,14 @@
 	display: flex;
 	flex-direction: column;
 	gap: var(--search-page_filter_sidebar_gap);
-	padding: var(--search-page_filter_sidebar_padding-top)
-		var(--search-page_filter_sidebar_padding-end)
-		var(--search-page_filter_sidebar_padding-bottom)
-		var(--search-page_filter_sidebar_padding-start);
+	padding-top: var(--search-page_filter_sidebar_padding-top);
+	padding-bottom: var(--search-page_filter_sidebar_padding-bottom);
+	padding-left: var(--search-page_filter_sidebar_padding-start);
+
+	// ensure the minimum padding to not clip focus states (#666)
+	padding-right: calc(var(--search-page_filter_sidebar_padding-end) + var(--spc-1x));
+	margin-right: calc(-1 * var(--spc-1x));
+
 	transition: margin-left 300ms ease-in-out;
 }
 


### PR DESCRIPTION
Ensures that the sidebar container has sufficient padding to not clip focus state outlines.