### PR TITLE
[UwU] Assorted lighthouse fixes

### DIFF
--- a/src/components/collection-card/collection-card.module.scss
+++ b/src/components/collection-card/collection-card.module.scss
@@ -46,6 +46,12 @@
 	display: flex;
 	flex-shrink: 0;
 	overflow: hidden;
+
+	& img {
+		object-fit: cover;
+		width: 160px;
+		height: 240px;
+	}
 }
 
 .topRow {

--- a/src/components/collection-card/collection-card.module.scss
+++ b/src/components/collection-card/collection-card.module.scss
@@ -50,6 +50,10 @@
 	&:where(img), & img {
 		object-fit: cover;
 	}
+
+	& img {
+		image-rendering: pixelated;
+	}
 }
 
 .topRow {

--- a/src/components/collection-card/collection-card.module.scss
+++ b/src/components/collection-card/collection-card.module.scss
@@ -47,10 +47,8 @@
 	flex-shrink: 0;
 	overflow: hidden;
 
-	& img {
+	&:where(img), & img {
 		object-fit: cover;
-		width: 160px;
-		height: 240px;
 	}
 }
 

--- a/src/components/collection-card/collection-card.module.scss
+++ b/src/components/collection-card/collection-card.module.scss
@@ -42,6 +42,10 @@
 	box-shadow: var(--shadow_sticker);
 	margin-right: var(--collection-card_content_gap);
 	margin-top: calc(0px - var(--collection-card_banner_offset));
+
+	display: flex;
+	flex-shrink: 0;
+	overflow: hidden;
 }
 
 .topRow {

--- a/src/components/collection-card/collection-card.tsx
+++ b/src/components/collection-card/collection-card.tsx
@@ -23,7 +23,7 @@ export const CollectionCard = ({
 						picture={collection.coverPicture}
 						alt=""
 						class={style.coverImg}
-						imgAttrs={{loading: "lazy"}}
+						imgAttrs={{loading: "lazy", width: 160, height: 240}}
 					/>
 				) : (
 					<img

--- a/src/components/collection-card/collection-card.tsx
+++ b/src/components/collection-card/collection-card.tsx
@@ -3,10 +3,12 @@ import { Button } from "components/index";
 import { ExtendedCollectionInfo } from "types/CollectionInfo";
 import { ProfilePictureMap } from "utils/get-unicorn-profile-pic-map";
 import forward from "src/icons/arrow_right.svg?raw";
-import { Picture as UUPicture } from "components/image/picture";
+import { Picture, Picture as UUPicture } from "components/image/picture";
+import { JSXNode } from "components/types";
+import { GetPictureResult } from "@astrojs/image/dist/lib/get-picture";
 
 interface CollectionCardProps {
-	collection: ExtendedCollectionInfo;
+	collection: ExtendedCollectionInfo & { coverPicture?: GetPictureResult };
 	unicornProfilePicMap: ProfilePictureMap;
 }
 
@@ -17,14 +19,23 @@ export const CollectionCard = ({
 	return (
 		<div className={style.container}>
 			<div className={style.topRow}>
-				<img
-					alt=""
-					src={collection.coverImgMeta.relativeServerPath}
-					loading="eager"
-					width={160}
-					height={240}
-					class={style.coverImg}
-				/>
+				{collection.coverPicture ? (
+					<Picture
+						picture={collection.coverPicture}
+						alt=""
+						class={style.coverImg}
+						imgAttrs={{loading: "lazy"}}
+					/>
+				) : (
+					<img
+						alt=""
+						src={collection.coverImgMeta.relativeServerPath}
+						loading="lazy"
+						width={160}
+						height={240}
+						class={style.coverImg}
+					/>
+				)}
 				<div>
 					<h2 className={`text-style-headline-4 ${style.title}`}>
 						{collection.title}

--- a/src/components/collection-card/collection-card.tsx
+++ b/src/components/collection-card/collection-card.tsx
@@ -3,8 +3,7 @@ import { Button } from "components/index";
 import { ExtendedCollectionInfo } from "types/CollectionInfo";
 import { ProfilePictureMap } from "utils/get-unicorn-profile-pic-map";
 import forward from "src/icons/arrow_right.svg?raw";
-import { Picture, Picture as UUPicture } from "components/image/picture";
-import { JSXNode } from "components/types";
+import { Picture as UUPicture } from "components/image/picture";
 import { GetPictureResult } from "@astrojs/image/dist/lib/get-picture";
 
 interface CollectionCardProps {
@@ -20,7 +19,7 @@ export const CollectionCard = ({
 		<div className={style.container}>
 			<div className={style.topRow}>
 				{collection.coverPicture ? (
-					<Picture
+					<UUPicture
 						picture={collection.coverPicture}
 						alt=""
 						class={style.coverImg}
@@ -53,7 +52,7 @@ export const CollectionCard = ({
 							>
 								<UUPicture
 									picture={unicornProfilePicMap.find((u) => u.id === author.id)}
-									alt={author.name}
+									alt=""
 									class={style.authorImage}
 								/>
 								<span>{author.name}</span>

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -87,6 +87,7 @@ export function SearchInput({
 				></div>
 			)}
 			<input
+				aria-label="Search"
 				{...props}
 				id={id}
 				class={`text-style-body-medium ${style.searchInput} ${
@@ -99,6 +100,7 @@ export function SearchInput({
 					class={style.clearButton}
 					tag="button"
 					type="button"
+					aria-label="Clear search"
 					{...clearButtonOnClickProps}
 				>
 					<div

--- a/src/components/pagination/pagination-popover.tsx
+++ b/src/components/pagination/pagination-popover.tsx
@@ -186,6 +186,7 @@ export function PaginationMenuAndPopover(
 					ref={triggerRef}
 					onClick={triggerProps.onPress as never}
 					{...triggerProps}
+					aria-label="Go to page"
 					data-testid="pagination-menu"
 					className={`text-style-body-medium-bold ${mainStyles.extendPageButton} ${mainStyles.paginationButton} ${mainStyles.paginationIconButton}`}
 					dangerouslySetInnerHTML={{ __html: more }}

--- a/src/components/post-card/post-card-grid.tsx
+++ b/src/components/post-card/post-card-grid.tsx
@@ -18,12 +18,14 @@ export function PostCardGrid({
 }: PostGridProps) {
 	return (
 		<ul {...props} class={style.list} role="list" id="post-list-container">
-			{postsToDisplay.map((post) => {
+			{postsToDisplay.map((post, i) => {
 				return expanded && post.bannerImg ? (
 					<PostCardExpanded
 						class={style.expanded}
 						post={post}
 						unicornProfilePicMap={unicornProfilePicMap}
+						// images should be loaded eagerly when presented above-the-fold
+						imageLoading={i < 4 ? "eager" : "lazy"}
 					/>
 				) : (
 					<PostCard post={post} unicornProfilePicMap={unicornProfilePicMap} />

--- a/src/components/post-card/post-card.tsx
+++ b/src/components/post-card/post-card.tsx
@@ -74,7 +74,8 @@ export const PostCardExpanded = ({
 	post,
 	class: className = "",
 	unicornProfilePicMap,
-}: PostCardProps) => {
+	imageLoading = "lazy",
+}: PostCardProps & { imageLoading?: "eager" | "lazy" }) => {
 	return (
 		<li
 			{...getHrefContainerProps(`/posts/${post.slug}`)}
@@ -82,7 +83,7 @@ export const PostCardExpanded = ({
 		>
 			<div className={style.extendedPostImageContainer}>
 				<img
-					loading="lazy"
+					loading={imageLoading}
 					className={style.extendedPostImage}
 					src={post.bannerImg}
 					alt="Computer code and text on a computer screen"

--- a/src/components/search-section/search-section.astro
+++ b/src/components/search-section/search-section.astro
@@ -23,7 +23,12 @@ const tagsToDisplay = [...data.tags]
 
 	<form id="searchForm" class={style.searchbarRow}>
 		<SearchInput name="searchVal" type="text" class={style.searchbar} />
-		<IconOnlyButton tag="button" type="submit" class={style.searchButton}>
+		<IconOnlyButton
+			tag="button"
+			type="submit"
+			class={style.searchButton}
+			aria-label={translate(Astro, "title.search")}
+		>
 			<Icon width="100%" height="100%" name="arrow_right" />
 		</IconOnlyButton>
 	</form>

--- a/src/pages/[...locale]/collections/[slug].astro
+++ b/src/pages/[...locale]/collections/[slug].astro
@@ -1,5 +1,4 @@
 ---
-import { getFullRelativePath } from "utils/url-paths";
 import SEO from "src/components/seo/seo.astro";
 import Document from "src/layouts/document.astro";
 import { ExtendedCollectionInfo } from "types/CollectionInfo";
@@ -12,7 +11,7 @@ import { getLanguageFromFilename, translate } from "utils/translations";
 
 export async function getStaticPaths() {
 	const collections = await Astro.glob(
-		"../../../../content/collections/**/*.md"
+		"../../../../content/collections/**/*.md",
 	);
 
 	return collections.map((collection) => {
@@ -41,12 +40,6 @@ const { Content, collection } = Astro.props as CollectionProps;
 const { slug } = collection;
 
 const collectionPosts = getPostsByCollection(slug, collection.locale);
-
-const coverImgPath = getFullRelativePath(
-	"/content/collections",
-	slug,
-	collection.coverImg
-);
 ---
 
 <Document>
@@ -57,7 +50,8 @@ const coverImgPath = getFullRelativePath(
 		unicornsData={collection.authorsMeta}
 		publishedTime={collection.published}
 		type={collection.type}
-		shareImage={collection.socialImg || coverImgPath}
+		shareImage={collection.socialImg ||
+			collection.coverImgMeta.relativeServerPath}
 		langData={{
 			otherLangs: collection.locales.filter((t) => t != collection.locale),
 			currentLang: collection.locale,
@@ -66,7 +60,7 @@ const coverImgPath = getFullRelativePath(
 	<CollectionPage
 		Content={Content}
 		collection={collection}
-		coverImgPath={coverImgPath}
+		coverImgPath={collection.coverImgMeta.relativeServerPath}
 	/>
 	<div class="collection-post-list-container">
 		<div class="collection-post-list">

--- a/src/views/collections/collection-page.astro
+++ b/src/views/collections/collection-page.astro
@@ -32,14 +32,6 @@ interface CollectionProps {
 const { Content, collection, coverImgPath } = Astro.props as CollectionProps;
 
 const collectionMeta = collections.find((col) => col.slug === collection.slug)!;
-
-const coverImgSize = getImageSize(
-	"." + coverImgPath,
-	process.cwd(),
-	process.cwd(),
-);
-
-const coverImgAspectRatio = coverImgSize.width / coverImgSize.height;
 ---
 
 <div class={styles.collectionPageContainer}>
@@ -52,7 +44,7 @@ const coverImgAspectRatio = coverImgSize.width / coverImgSize.height;
 				widths={[480]}
 				formats={["avif", "webp", "png"]}
 				loading="eager"
-				aspectRatio={coverImgAspectRatio}
+				aspectRatio={"2:3"}
 			/>
 		</div>
 		<div class={styles.titleAndDescContainer}>

--- a/src/views/collections/collection-page.astro
+++ b/src/views/collections/collection-page.astro
@@ -11,7 +11,6 @@ import "../../styles/post-body.scss";
 import "../../styles/markdown/tabs.scss";
 import "../../styles/shiki.scss";
 import "../../styles/convertkit.scss";
-import { getImageSize } from "../../utils/get-image-size";
 
 import styles from "./collection-page.module.scss";
 import { collections } from "../../utils/data";
@@ -32,6 +31,12 @@ interface CollectionProps {
 const { Content, collection, coverImgPath } = Astro.props as CollectionProps;
 
 const collectionMeta = collections.find((col) => col.slug === collection.slug)!;
+
+const coverImgAspectRatio =
+	collection.coverImgMeta.width / collection.coverImgMeta.height;
+// adjust the image width to ensure its height=240px
+// (i.e. it shouldn't get upscaled/downscaled with `object-fit: cover`)
+const coverImgWidth = Math.max(480, Math.ceil(720 * coverImgAspectRatio));
 ---
 
 <div class={styles.collectionPageContainer}>
@@ -40,11 +45,11 @@ const collectionMeta = collections.find((col) => col.slug === collection.slug)!;
 			<Picture
 				alt=""
 				src={coverImgPath}
-				sizes={`480`}
-				widths={[480]}
+				sizes={`${coverImgWidth}px`}
+				widths={[coverImgWidth]}
 				formats={["avif", "webp", "png"]}
 				loading="eager"
-				aspectRatio={"2:3"}
+				aspectRatio={coverImgAspectRatio}
 			/>
 		</div>
 		<div class={styles.titleAndDescContainer}>

--- a/src/views/collections/collection-page.module.scss
+++ b/src/views/collections/collection-page.module.scss
@@ -141,6 +141,7 @@
 	max-width: 368px;
 	max-height: 552px;
 	width: 100%;
+	object-fit: cover;
 
 	border-radius: var(--collection-page_banner_corner-radius);
 

--- a/src/views/collections/collection-page.module.scss
+++ b/src/views/collections/collection-page.module.scss
@@ -142,6 +142,7 @@
 	max-height: 552px;
 	width: 100%;
 	object-fit: cover;
+	image-rendering: pixelated;
 
 	border-radius: var(--collection-page_banner_corner-radius);
 

--- a/src/views/collections/collection-page.module.scss
+++ b/src/views/collections/collection-page.module.scss
@@ -142,7 +142,6 @@
 	max-height: 552px;
 	width: 100%;
 	object-fit: cover;
-	image-rendering: pixelated;
 
 	border-radius: var(--collection-page_banner_corner-radius);
 
@@ -162,6 +161,7 @@
 	@include from($desktopSmall) {
 		height: 720px;
 		width: 480px;
+		image-rendering: pixelated;
 	}
 }
 

--- a/src/views/explore/homepage.astro
+++ b/src/views/explore/homepage.astro
@@ -11,6 +11,7 @@ import Hero from "../../components/hero/hero.astro";
 import SearchSection from "../../components/search-section/search-section.astro";
 import styles from "./homepage.module.scss";
 import { buildSearchQuery } from "../../utils/search";
+import { getPicture } from "@astrojs/image";
 
 export interface HomepageProps {
 	posts: PostInfo[];
@@ -20,6 +21,20 @@ export interface HomepageProps {
 const { posts, collections } = Astro.props as HomepageProps;
 
 const unicornProfilePicMap = await getUnicornProfilePicMap();
+
+const collectionsWithPictures = await Promise.all(
+	collections.map(async (collection) => {
+		const coverPicture = await getPicture({
+			src: collection.coverImgMeta.relativeServerPath,
+			alt: "",
+			widths: [160],
+			aspectRatio: "160:240",
+			formats: ["avif", "webp", "png"],
+		});
+
+		return { ...collection, coverPicture };
+	}),
+);
 ---
 
 <Hero />
@@ -50,7 +65,7 @@ const unicornProfilePicMap = await getUnicornProfilePicMap();
 		class={styles.collectionsGrid}
 	>
 		{
-			collections.map((collection) => (
+			collectionsWithPictures.map((collection) => (
 				<li>
 					<CollectionCard
 						collection={collection}

--- a/src/views/explore/homepage.astro
+++ b/src/views/explore/homepage.astro
@@ -24,11 +24,17 @@ const unicornProfilePicMap = await getUnicornProfilePicMap();
 
 const collectionsWithPictures = await Promise.all(
 	collections.map(async (collection) => {
+		const coverImgAspectRatio =
+			collection.coverImgMeta.width / collection.coverImgMeta.height;
+		// adjust the image width to ensure its height=240px
+		// (i.e. it shouldn't get upscaled/downscaled with `object-fit: cover`)
+		const coverImgWidth = Math.max(160, Math.ceil(240 * coverImgAspectRatio));
+
 		const coverPicture = await getPicture({
 			src: collection.coverImgMeta.relativeServerPath,
 			alt: "",
-			widths: [160],
-			aspectRatio: "160:240",
+			widths: [coverImgWidth],
+			aspectRatio: coverImgAspectRatio,
 			formats: ["avif", "webp", "png"],
 		});
 

--- a/src/views/search/components/filter-dialog.tsx
+++ b/src/views/search/components/filter-dialog.tsx
@@ -152,6 +152,7 @@ const FilterDialogSmallTablet = ({
 					type="button"
 					onClick={onCancel}
 					class={styles.closeButton}
+					aria-label="Close"
 				>
 					<span
 						class={styles.closeIcon}

--- a/src/views/search/components/search-topbar.tsx
+++ b/src/views/search/components/search-topbar.tsx
@@ -61,6 +61,7 @@ export const SearchTopbar = ({
 					class={style.searchButton}
 					tag="button"
 					type="submit"
+					aria-label="Search"
 					dangerouslySetInnerHTML={{ __html: forward }}
 					children={null}
 				/>

--- a/src/views/search/components/search-topbar.tsx
+++ b/src/views/search/components/search-topbar.tsx
@@ -45,6 +45,7 @@ export const SearchTopbar = ({
 			>
 				<SearchInput
 					id="search-bar"
+					data-testid="search-input"
 					aria-label="Search"
 					aria-description={"Results will update as you type"}
 					class={style.searchbar}

--- a/src/views/search/components/search-topbar.tsx
+++ b/src/views/search/components/search-topbar.tsx
@@ -46,7 +46,6 @@ export const SearchTopbar = ({
 				<SearchInput
 					id="search-bar"
 					data-testid="search-input"
-					aria-label="Search"
 					aria-description={"Results will update as you type"}
 					class={style.searchbar}
 					usedInPreact={true}
@@ -128,6 +127,7 @@ export const SearchTopbar = ({
 					tag="button"
 					type="button"
 					onClick={() => setFilterIsDialogOpen(true)}
+					aria-label="Filter"
 				>
 					<span
 						className={style.filterIconContainer}

--- a/src/views/search/search-page.spec.tsx
+++ b/src/views/search/search-page.spec.tsx
@@ -7,6 +7,7 @@ import {
 	waitFor,
 	cleanup,
 	queryByText,
+	getByTestId,
 } from "@testing-library/preact";
 import SearchPage, { ServerReturnType } from "./search-page";
 import { rest } from "msw";
@@ -72,10 +73,10 @@ describe("Search page", () => {
 			collections: [],
 		}));
 
-		const { getByText, getByLabelText } = render(
+		const { getByText, getByTestId } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, MockPost.title);
 		await user.type(searchInput, "{enter}");
 		await waitFor(() => expect(getByText(MockPost.title)).toBeInTheDocument());
@@ -89,10 +90,10 @@ describe("Search page", () => {
 			collections: [MockCollection],
 		}));
 
-		const { getByText, getByLabelText } = render(
+		const { getByText, getByTestId } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, MockCollection.title);
 		await user.type(searchInput, "{enter}");
 		await waitFor(() =>
@@ -104,10 +105,10 @@ describe("Search page", () => {
 		mockFetchWithStatus(500, () => ({
 			error: "There was an error fetching your search results.",
 		}));
-		const { getByText, getByLabelText } = render(
+		const { getByText, getByTestId } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, MockPost.title);
 		await user.type(searchInput, "{enter}");
 		await waitFor(() =>
@@ -125,10 +126,10 @@ describe("Search page", () => {
 			collections: [],
 		}));
 
-		const { getByText, getByLabelText } = render(
+		const { getByText, getByTestId } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, "Asdfasdfasdf");
 		await user.type(searchInput, "{enter}");
 		await waitFor(() =>
@@ -144,10 +145,10 @@ describe("Search page", () => {
 			collections: [],
 		}));
 
-		const { getByTestId, queryByTestId, getByLabelText } = render(
+		const { getByTestId, queryByTestId } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, MockPost.title);
 		await user.type(searchInput, "{enter}");
 		await waitFor(() =>
@@ -164,10 +165,10 @@ describe("Search page", () => {
 			collections: [MockCollection],
 		}));
 
-		const { getByTestId, queryByTestId, getByLabelText } = render(
+		const { getByTestId, queryByTestId } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, MockCollection.title);
 		await user.type(searchInput, "{enter}");
 		await waitFor(() =>
@@ -187,11 +188,11 @@ describe("Search page", () => {
 			collections: [],
 		}));
 
-		const { getByTestId, queryByTestId, getByText, getByLabelText } = render(
+		const { getByTestId, queryByTestId, getByText } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
 
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, "*");
 		await user.type(searchInput, "{enter}");
 
@@ -228,11 +229,11 @@ describe("Search page", () => {
 			collections: [],
 		}));
 
-		const { getByTestId, getByText, getByLabelText, queryByTestId } = render(
+		const { getByTestId, getByText, queryByTestId } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
 
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, "*");
 		await user.type(searchInput, "{enter}");
 
@@ -260,7 +261,7 @@ describe("Search page", () => {
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
 
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, "*");
 		await user.type(searchInput, "{enter}");
 
@@ -311,11 +312,11 @@ describe("Search page", () => {
 			collections: [],
 		}));
 
-		const { getByTestId, getByText, getByLabelText, findByText } = render(
+		const { getByTestId, getByText } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
 
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, "*");
 		await user.type(searchInput, "{enter}");
 
@@ -370,11 +371,11 @@ describe("Search page", () => {
 			collections: [],
 		}));
 
-		const { getByTestId, getByText, getByLabelText } = render(
+		const { getByTestId, getByText } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
 
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, "*");
 		await user.type(searchInput, "{enter}");
 
@@ -429,11 +430,11 @@ describe("Search page", () => {
 			collections: [],
 		}));
 
-		const { findByTestId, getByText, getByLabelText, queryByText } = render(
+		const { findByTestId, getByText, getByTestId, queryByText } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
 
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, "*");
 		await user.type(searchInput, "{enter}");
 
@@ -566,12 +567,11 @@ describe("Search page", () => {
 		const {
 			findByTestId,
 			getByText,
-			getByLabelText,
 			getByTestId,
 			queryByText,
 		} = render(<SearchPage unicornProfilePicMap={[]} />);
 
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, "*");
 		await user.type(searchInput, "{enter}");
 
@@ -726,12 +726,12 @@ describe("Search page", () => {
 
 		window.location.assign(`?${searchQuery}`);
 
-		const { getByTestId, getByText, getByLabelText, queryByText } = render(
+		const { getByTestId, getByText, queryByText } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
 
 		// Persists search query
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		expect(searchInput).toHaveValue("blog");
 
 		// Persists page
@@ -783,11 +783,11 @@ describe("Search page", () => {
 			collections: [],
 		}));
 
-		var { getByTestId, getByText, getByLabelText } = render(
+		var { getByTestId, getByText } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
 
-		var searchInput = getByLabelText("Search");
+		var searchInput = getByTestId("search-input");
 		await user.type(searchInput, "*");
 		await user.type(searchInput, "{enter}");
 
@@ -811,11 +811,11 @@ describe("Search page", () => {
 		cleanup();
 
 		// Re-render
-		var { getByTestId, getByText, getByLabelText } = render(
+		var { getByTestId, getByText } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
 
-		var searchInput = getByLabelText("Search");
+		var searchInput = getByTestId("search-input");
 		await user.type(searchInput, "*");
 		await user.type(searchInput, "{enter}");
 
@@ -961,13 +961,13 @@ describe("Search page", () => {
 
 		window.location.assign(`?${searchQuery}`);
 
-		const { getByTestId, getByText, getByLabelText, queryByText } = render(
+		const { getByTestId, getByText } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
 
 		await waitFor(() => expect(getByText("Ten blog post")).toBeInTheDocument());
 
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		expect(searchInput).toHaveValue("blog");
 
 		await user.type(searchInput, "other");
@@ -1112,13 +1112,13 @@ describe("Search page", () => {
 
 		window.location.assign(`?${searchQuery}`);
 
-		const { getByTestId, getByText, getByLabelText, queryByText } = render(
+		const { getByTestId, getByText } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
 
 		await waitFor(() => expect(getByText("Ten blog post")).toBeInTheDocument());
 
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		expect(searchInput).toHaveValue("blog");
 
 		await user.clear(searchInput);
@@ -1138,11 +1138,11 @@ describe("Search page", () => {
 			collections: [],
 		}));
 
-		const { getByTestId, getByText, getByLabelText, queryByText } = render(
+		const { getByTestId, getByText } = render(
 			<SearchPage unicornProfilePicMap={[]} />,
 		);
 
-		const searchInput = getByLabelText("Search");
+		const searchInput = getByTestId("search-input");
 		await user.type(searchInput, "blog");
 
 		await waitFor(() =>


### PR DESCRIPTION
Fixes a few things identified by lighthouse:

- Collection cards (on the homepage) now use properly optimized `<picture>` tags
- Redundant alt text on the collection card profile pictures is removed (the image is directly adjacent to the author name)
- Set expanded collection card images to `loading="eager"` when above-the-fold
- Added missing `aria-labels` to a bunch of buttons
- Use displayed cover image aspect ratio instead of the source image size (otherwise it gets stretched by the browser)