### PR TITLE
[UwU] Fix article nav

### DIFF
--- a/src/utils/href-container-script.ts
+++ b/src/utils/href-container-script.ts
@@ -13,7 +13,6 @@
  * - Right clicks (used for context menus)
  * - Alt clicks (used for downloading)
  * - Default prevented events
- * - Nested elements with data-navigation-path
  * - Elements with [data-dont-bind-navigate-click]
  * - <a> tags and <button>s
  */

--- a/src/views/blog-post/article-nav/article-nav.module.scss
+++ b/src/views/blog-post/article-nav/article-nav.module.scss
@@ -93,7 +93,7 @@
 	}
 
 	&--previous {
-		&:not(:only-child) {
+		&:where(:not(:only-child)) {
 			grid-row: 2;
 		}
 

--- a/src/views/blog-post/article-nav/article-nav.tsx
+++ b/src/views/blog-post/article-nav/article-nav.tsx
@@ -3,6 +3,7 @@ import style from "./article-nav.module.scss";
 import arrow_left from "../../../icons/arrow_left.svg?raw";
 import arrow_right from "../../../icons/arrow_right.svg?raw";
 import { getShortTitle } from "../series/base";
+import { getHrefContainerProps } from "utils/href-container-script";
 
 type ArticleNavItemProps = {
 	post: PostInfo;
@@ -14,7 +15,7 @@ function ArticleNavItem({ post, type }: ArticleNavItemProps) {
 	return (
 		<div
 			class={`${style.item} ${style[`item--${type}`]}`}
-			data-navigation-path={href}
+			{...getHrefContainerProps(href)}
 		>
 			{type === "previous" ? (
 				<span class={`${style.item__overline} text-style-button-regular`}>


### PR DESCRIPTION
- Removes the obsolete `data-navigation-path=` attribute, uses `getHrefContainerProps()` to get the correct props for nav items
- Fixes a specificity issue causing the previous/next article buttons to be placed on different grid rows in the desktop layout:

| Current Behavior | Expected|
|------|-------|
| ![2023-09-09-111242_889x696_scrot](https://github.com/unicorn-utterances/unicorn-utterances/assets/13000407/fc92e834-81c9-478b-b9f2-cd8c1c54329e) | ![2023-09-09-111209_855x578_scrot](https://github.com/unicorn-utterances/unicorn-utterances/assets/13000407/d353dac2-037a-4d38-93a8-e37bafbb6f93) |
