### PR TITLE
[UwU] Fix wrapping behavior of article header metadata

### DIFF
--- a/src/views/blog-post/post-title-header/post-title-header.astro
+++ b/src/views/blog-post/post-title-header/post-title-header.astro
@@ -21,15 +21,18 @@ const editedStr = post.edited && dayjs(post.edited).format("MMMM D, YYYY");
 
 	<div class={style.details}>
 		<div class={style.date}>
-			<Icon width="24" height="24" name="date" />
-			<p class="text-style-button-regular">
-				{publishedStr}
-				{
-					editedStr && editedStr !== publishedStr ? (
-						<span class={style.date__edited}>Last updated: {editedStr}</span>
-					) : null
-				}
-			</p>
+			<div class={style.date__published}>
+				<Icon width="24" height="24" name="date" />
+				<p class="text-style-button-regular">{publishedStr}</p>
+			</div>
+
+			{
+				editedStr && editedStr !== publishedStr ? (
+					<p class={`text-style-button-regular ${style.date__edited}`}>
+						Last updated: {editedStr}
+					</p>
+				) : null
+			}
 		</div>
 
 		<div class={style.authors}>

--- a/src/views/blog-post/post-title-header/post-title-header.module.scss
+++ b/src/views/blog-post/post-title-header/post-title-header.module.scss
@@ -67,6 +67,11 @@
 		}
 
 		&__edited {
+			//  I don't like it when
+			// Auto-formatting plugins
+			//  Put bugs in my code.
+			display: flex;
+
 			color: var(--article-header_details_date_edited_color);
 			margin-left: calc(var(--article-header_details_icon_size) + var(--article-header_details_icon_margin-end));
 			position: relative;

--- a/src/views/blog-post/post-title-header/post-title-header.module.scss
+++ b/src/views/blog-post/post-title-header/post-title-header.module.scss
@@ -36,7 +36,7 @@
 	.date,
 	.authors {
 		display: flex;
-		align-items: center;
+		align-items: top;
 
 		svg {
 			width: var(--article-header_details_icon_size);
@@ -44,25 +44,49 @@
 			padding: var(--icon-size-dense-padding);
 			color: var(--article-header_details_icon_color);
 			margin-right: var(--article-header_details_icon_margin-end);
+			flex-shrink: 0;
 		}
 	}
 
 	.date {
 		color: var(--article-header_details_date_color);
+		flex-wrap: wrap;
 
-		p {
-			display: flex;
+		flex-direction: column;
+		gap: var(--article-header_details_gap);
+
+		@include from($mobile) {
 			flex-direction: row;
-			flex-wrap: wrap;
+			gap: 0;
+		}
+
+		&__published {
+			display: flex;
+			align-items: top;
+			flex-direction: row;
 		}
 
 		&__edited {
 			color: var(--article-header_details_date_edited_color);
+			margin-left: calc(var(--article-header_details_icon_size) + var(--article-header_details_icon_margin-end));
+			position: relative;
+
+			@include from($mobile) {
+				margin-left: 0;
+			}
 
 			&::before {
+				position: absolute;
 				content: "•";
-				margin-left: var(--article-header_details_date-gap);
-				padding-right: var(--article-header_details_date-gap);
+				left: calc(-0.5*var(--article-header_details_icon_size) + -1*var(--article-header_details_icon_margin-end));
+    			transform: translateX(-50%);
+
+				@include from($mobile) {
+					position: unset;
+					transform: none;
+					margin-left: var(--article-header_details_date-gap);
+					padding-right: var(--article-header_details_date-gap);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Fixes icons shrinking at small viewports (due to `flex-shrink`)
- Changes flex alignment to `top` instead of `center` (so the icons stay aligned with the first line when wrapping)
- Splits "last updated" text onto a separate line on mobile, to match mockups

| Before | After |
|----|----|
| ![2023-09-09-121842_221x370_scrot](https://github.com/unicorn-utterances/unicorn-utterances/assets/13000407/cadf413f-6ec3-4f9f-af84-d3817aac4b52) | ![2023-09-09-115247_243x376_scrot](https://github.com/unicorn-utterances/unicorn-utterances/assets/13000407/6cd2dc1b-9bc9-45e3-a4de-165dacdbd39d) |
