### PR TITLE
[UwU] Search page styling changes

### DIFF
--- a/src/components/input/input.module.scss
+++ b/src/components/input/input.module.scss
@@ -67,6 +67,15 @@
 	color: var(--foreground_disabled);
 }
 
+.input input:-webkit-autofill,
+.input input:-webkit-autofill:hover,
+.input input:-webkit-autofill:focus,
+.input input:-webkit-autofill:active {
+	color: var(--foreground_emphasis-high);
+	-webkit-text-fill-color: var(--foreground_emphasis-high);
+	-webkit-box-shadow: 0 0 0 var(--form-field_min-height) var(--form-field_background_focused) inset;
+}
+
 .labelContainer {
 	display: flex;
 	flex-direction: column;
@@ -203,8 +212,8 @@
 
 .searchContainer.dense .clearButton {
 	min-height: calc(100% - var(--spc-2x)) !important;
-    min-width: calc(100% - var(--spc-2x)) !important;
-    padding: 0 !important;
+	min-width: calc(100% - var(--spc-2x)) !important;
+	padding: 0 !important;
 }
 
 .closeButtonContainer,

--- a/src/tokens/_breakpoints.scss
+++ b/src/tokens/_breakpoints.scss
@@ -12,7 +12,7 @@ $mobile: 400px;
 }
 
 @mixin from($breakpoint) {
-	@media screen and (min-width: $breakpoint) {
+	@media screen and (min-width: ($breakpoint + 1)) {
 		@content;
 	}
 }

--- a/src/views/collections/framework-field-guide/tokens/_utils.scss
+++ b/src/views/collections/framework-field-guide/tokens/_utils.scss
@@ -5,7 +5,7 @@
 }
 
 @mixin from($breakpoint) {
-	@media screen and (min-width: $breakpoint) {
+	@media screen and (min-width: ($breakpoint + 1)) {
 		@content;
 	}
 }

--- a/src/views/search/components/filter-dialog.tsx
+++ b/src/views/search/components/filter-dialog.tsx
@@ -331,7 +331,9 @@ export const FilterDialog = ({
 	 */
 	const windowSize = useWindowSize();
 
-	const isMobile = windowSize.width < mobile;
+	// Adding 100px as a workaround since the mobile breakpoint is too small for this layout
+	// https://github.com/unicorn-utterances/unicorn-utterances/issues/655
+	const isMobile = windowSize.width <= mobile + 100;
 
 	return (
 		<dialog onClose={onFormConfirm} ref={dialogRef} class={styles.dialog}>

--- a/src/views/search/components/filter-display.tsx
+++ b/src/views/search/components/filter-display.tsx
@@ -124,7 +124,7 @@ export const FilterDisplay = ({
 
 	const windowSize = useWindowSize();
 
-	const shouldShowDialog = windowSize.width < tabletLarge;
+	const shouldShowDialog = windowSize.width <= tabletLarge;
 
 	if (shouldShowDialog) {
 		return (

--- a/src/views/search/components/filter-section-item.module.scss
+++ b/src/views/search/components/filter-section-item.module.scss
@@ -13,6 +13,10 @@
 	--search-page_filter_list_item_background-color_hovered: var(--surface_primary_emphasis-low);
 	--search-page_filter_list_item_background-color_pressed: var(--surface_primary_emphasis-medium);
 	--search-page_filter_list_item_background-color_selected: var(--surface_primary_emphasis-none);
+	--search-page_filter_list_item_background-color_focused: var(--background_focus);
+
+	--search-page_filter_list_item_focus-outline_color: var(--focus-outline_primary);
+	--search-page_filter_list_item_focus-outline_width: var(--border-width_focus);
 }
 
 .containerLabel {
@@ -46,13 +50,19 @@
 }
 
 .containerLabel.selected {
-	background: var(--search-page_filter_list_item_background-color_selected);
+	background-color: var(--search-page_filter_list_item_background-color_selected);
 }
 
 .containerLabel:hover {
-	background: var(--search-page_filter_list_item_background-color_hovered);
+	background-color: var(--search-page_filter_list_item_background-color_hovered);
 }
 
 .containerLabel:active {
-	background: var(--search-page_filter_list_item_background-color_pressed);
+	background-color: var(--search-page_filter_list_item_background-color_pressed);
+}
+
+.containerLabel[data-focus-visible="true"] {
+	background-color: var(--search-page_filter_list_item_background-color_focused);
+	outline: var(--search-page_filter_list_item_focus-outline_width) solid var(--search-page_filter_list_item_focus-outline_color);
+	outline-offset: calc(-1 * var(--search-page_filter_list_item_focus-outline_width));
 }

--- a/src/views/search/components/filter-section-item.tsx
+++ b/src/views/search/components/filter-section-item.tsx
@@ -37,7 +37,8 @@ export const FilterSectionItem = ({
 
 	useEffect(() => {
 		// this does not happen automatically, so we need to manually scroll to the focused item
-		labelRef.current?.scrollIntoView({ block: "nearest" });
+		if (labelRef.current && typeof labelRef.current.scrollIntoView !== "undefined")
+			labelRef.current.scrollIntoView({ block: "nearest" });
 	}, [isFocusVisible]);
 
 	return (

--- a/src/views/search/components/filter-section-item.tsx
+++ b/src/views/search/components/filter-section-item.tsx
@@ -1,12 +1,12 @@
 import { VNode } from "preact";
 import { CheckboxBox } from "components/checkbox-box/checkbox-box";
-import { useCheckbox, VisuallyHidden } from "react-aria";
+import { useCheckbox, useFocusRing, VisuallyHidden } from "react-aria";
 import style from "./filter-section-item.module.scss";
 import { useToggleState } from "react-stately";
-import { useRef } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 
 interface FilterSectionItemProps {
-	icon: VNode<any>;
+	icon: VNode<unknown>;
 	label: string;
 	count: number;
 	selected: boolean;
@@ -29,15 +29,25 @@ export const FilterSectionItem = ({
 	const state = useToggleState(props);
 
 	const ref = useRef(null);
+	const labelRef = useRef<HTMLLabelElement>(null);
+
 	const { inputProps } = useCheckbox(props, state, ref);
+	const { isFocusVisible, focusProps } = useFocusRing();
 	const isSelected = state.isSelected;
+
+	useEffect(() => {
+		// this does not happen automatically, so we need to manually scroll to the focused item
+		labelRef.current?.scrollIntoView({ block: "nearest" });
+	}, [isFocusVisible]);
 
 	return (
 		<CheckboxBox
 			selected={isSelected}
 			wrapper={(children) => (
 				<label
+					ref={labelRef}
 					class={`${style.containerLabel} ${isSelected ? style.selected : ""}`}
+					data-focus-visible={isFocusVisible}
 				>
 					<span aria-hidden={true} class={style.iconContainer}>
 						{icon}
@@ -50,7 +60,7 @@ export const FilterSectionItem = ({
 					</span>
 					{children}
 					<VisuallyHidden>
-						<input {...inputProps} ref={ref} />
+						<input {...inputProps} {...focusProps} ref={ref} />
 					</VisuallyHidden>
 				</label>
 			)}

--- a/src/views/search/components/filter-section-item.tsx
+++ b/src/views/search/components/filter-section-item.tsx
@@ -37,7 +37,7 @@ export const FilterSectionItem = ({
 
 	useEffect(() => {
 		// this does not happen automatically, so we need to manually scroll to the focused item
-		if (labelRef.current && typeof labelRef.current.scrollIntoView !== "undefined")
+		if (isFocusVisible && labelRef.current && typeof labelRef.current.scrollIntoView !== "undefined")
 			labelRef.current.scrollIntoView({ block: "nearest" });
 	}, [isFocusVisible]);
 

--- a/src/views/search/components/filter-section.module.scss
+++ b/src/views/search/components/filter-section.module.scss
@@ -38,26 +38,43 @@
 }
 
 .sectionTitle {
+	// Stop being a button 😡
+	all: unset;
+
 	grid-column: 1 / span 2;
 	grid-row: 1;
 
 	display: flex;
 	align-items: center;
 	gap: var(--search-page_filter_list_header_gap);
-	width: 100%;
+
 	// Replace with tokens
 	padding-top: var(--spc-2x);
 	padding-bottom: var(--spc-2x);
 	padding-left: var(--search-page_filter_list_header_padding-start);
 	padding-right: var(--search-page_filter_list_header_padding-end);
 
-	// Stop being a button 😡
-	background: unset;
-	border: unset;
-	outline: unset;
-	font-weight: unset;
-	font-size: unset;
-	line-height: unset;
+	border-radius: var(--corner-radius_l);
+	&[aria-expanded="true"] {
+		border-bottom-left-radius: 0;
+		border-bottom-right-radius: 0;
+	}
+
+	@include transition(background-color border-radius);
+
+	&:hover {
+		background-color: var(--search-page_filter_list_header_background-color_hovered);
+	}
+
+	&:active {
+		background-color: var(--search-page_filter_list_header_background-color_pressed);
+	}
+
+	&:focus-visible {
+		background-color: var(--search-page_filter_list_header_background-color_focused);
+		outline: var(--search-page_filter_list_header_focus-outline_width) solid var(--search-page_filter_list_header_focus-outline_color);
+		outline-offset: calc(-1 * var(--search-page_filter_list_header_focus-outline_width));
+	}
 }
 
 .collapseIcon {

--- a/src/views/search/components/filter-sidebar-props.scss
+++ b/src/views/search/components/filter-sidebar-props.scss
@@ -24,6 +24,12 @@
 	--search-page_filter_list_header_icon_color: var(--primary_default);
 	--search-page_filter_list_header_icon_size: var(--icon-size_regular);
 
+	--search-page_filter_list_header_background-color_hovered: var(--surface_primary_emphasis-none);
+	--search-page_filter_list_header_background-color_pressed: var(--surface_primary_emphasis-low);
+	--search-page_filter_list_header_background-color_focused: var(--background_focus);
+	--search-page_filter_list_header_focus-outline_width: var(--border-width_focus);
+	--search-page_filter_list_header_focus-outline_color: var(--focus-outline_primary);
+
 	--search-page_filter_list_divider_color: var(--background_disabled);
 	--search-page_filter_list_divider_width: var(--border-width_s);
 

--- a/src/views/search/components/filter-sidebar.module.scss
+++ b/src/views/search/components/filter-sidebar.module.scss
@@ -15,7 +15,14 @@
 	padding-right: calc(var(--search-page_filter_sidebar_padding-end) + var(--spc-1x));
 	margin-right: calc(-1 * var(--spc-1x));
 
-	transition: margin-left 300ms ease-in-out;
+	flex-basis: 100%;
+
+	transition: transform 300ms ease-in-out, opacity 300ms ease-in-out;
+}
+
+.sidebarContainer[inert] {
+	transform: translateX(-100%);
+	opacity: 0;
 }
 
 .jumpToContents {

--- a/src/views/search/components/filter-sidebar.module.scss
+++ b/src/views/search/components/filter-sidebar.module.scss
@@ -3,6 +3,7 @@
 
 .sidebarContainer {
 	max-width: var(--search-page_filter_sidebar_max-width);
+	min-width: var(--search-page_filter_sidebar_max-width);
 	width: 100%;
 	display: flex;
 	flex-direction: column;

--- a/src/views/search/components/filter-sidebar.tsx
+++ b/src/views/search/components/filter-sidebar.tsx
@@ -1,7 +1,5 @@
-import { UnicornInfo } from "types/UnicornInfo";
 import styles from "./filter-sidebar.module.scss";
-import { SearchInput } from "components/input/input";
-import { Button, LargeButton } from "components/button/button";
+import { LargeButton } from "components/button/button";
 import { ProfilePictureMap } from "utils/get-unicorn-profile-pic-map";
 import { CSSProperties } from "preact/compat";
 import { FilterSection } from "./filter-section";
@@ -9,11 +7,6 @@ import { FilterSectionItem } from "./filter-section-item";
 import { Picture as UUPicture } from "components/image/picture";
 import { ExtendedTag, ExtendedUnicorn, SortType } from "./types";
 import { DEFAULT_TAG_EMOJI } from "./constants";
-import {
-	RadioButton,
-	RadioButtonGroup,
-} from "components/button-radio-group/button-radio-group";
-import { useElementSize } from "../../../hooks/use-element-size";
 import { Item, Select } from "components/select/select";
 
 interface FilterSidebar {
@@ -47,16 +40,12 @@ export const FilterSidebar = ({
 	unicornProfilePicMap,
 	searchString,
 }: FilterSidebar) => {
-	const { setEl, size } = useElementSize({ includeMargin: false });
-
 	const hideSearchbar = !searchString;
 	return (
 		<div
-			ref={setEl}
 			className={`${styles.sidebarContainer}`}
 			style={{
 				...desktopStyle,
-				marginLeft: hideSearchbar ? `calc(0px - ${size.width}px)` : "",
 			}}
 			inert={hideSearchbar}
 		>

--- a/src/views/search/search-page.module.scss
+++ b/src/views/search/search-page.module.scss
@@ -1,9 +1,19 @@
 @import "src/tokens/index";
 
 .fullPageContainer {
-	display: flex;
 	max-width: var(--max-width_xl);
 	margin: 0 auto;
+
+	transition: 300ms grid-template-columns ease-in-out;
+
+	@include from($tabletLarge) {
+		display: grid;
+		grid-template-columns: var(--search-page_filter_sidebar_max-width) 1fr;
+
+		&[data-hide-sidebar="true"] {
+			grid-template-columns: 0 1fr;
+		}
+	}
 }
 
 .mainContents {

--- a/src/views/search/search-page.module.scss
+++ b/src/views/search/search-page.module.scss
@@ -2,6 +2,8 @@
 
 .fullPageContainer {
 	display: flex;
+	max-width: var(--max-width_xl);
+	margin: 0 auto;
 }
 
 .mainContents {

--- a/src/views/search/search-page.tsx
+++ b/src/views/search/search-page.tsx
@@ -349,7 +349,11 @@ function SearchPageBase({ unicornProfilePicMap }: SearchPageProps) {
 	const [isResultsFocused, setIsResultsFocused] = useState(false);
 
 	return (
-		<div className={style.fullPageContainer} role="search">
+		<div
+			className={style.fullPageContainer}
+			role="search"
+			data-hide-sidebar={!search}
+		>
 			<h1 className={"visually-hidden"}>Search</h1>
 			<FilterDisplay
 				isFilterDialogOpen={isFilterDialogOpen}


### PR DESCRIPTION
- Sets the `max-width` of the search page layout to match the "xl" page size.
- Adds `opacity: 0;` to make the sidebar invisible when hidden
- Changes the layout to `display: grid` in order to perform the sidebar transition when hidden
  * This fixes the issue where the page would briefly show the sidebar and then perform the hidden transition when the page first loads
- Adds hover/focus styling to filter elements:
  * #645 
  * #643
- Adds styling to override the input autofill color/background
- Fixes breakpoint comparisons to use separate ranges; so that usage does not overlap at breakpoint values
  * `until(x)` is now `[0, x]` (inclusive) or `width <= x`
  * `from(x)` is now `[x+1, inf]` or `width > x`
- Increases the filter dialog breakpoint by 100px to prevent overflow
  * #655 