### PR TITLE
[UwU] Inline <code> / <kbd> styling

### DIFF
--- a/src/styles/markdown/hints.scss
+++ b/src/styles/markdown/hints.scss
@@ -86,12 +86,10 @@
 
 			& > *:first-child {
 				margin-top: 0;
-				padding-top: 0;
 			}
 
 			& > *:last-child {
 				margin-bottom: 0;
-				padding-bottom: 0;
 			}
 		}
 

--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -143,13 +143,24 @@
 		font-family: var(--uu-font-family-code);
 		font-size: 0.8em;
 		font-weight: 500;
+
 		color: var(--secondary_on-variant);
-		background-color: var(--surface_secondary_emphasis-none);
-		padding-bottom: 0.15em;
-		padding-left: 0.15em;
-		padding-right: 0.15em;
-		border: 0.075em solid var(--secondary_default);
-		border-radius: 0.25em;
+
+		&:not(td > code:only-child) {
+			background-color: var(--surface_secondary_emphasis-none);
+			padding-bottom: 0.15em;
+			padding-left: 0.15em;
+			padding-right: 0.15em;
+			border: 0.075em solid var(--secondary_default);
+			border-radius: 0.25em;
+
+			// the table header has a primary background...
+			&:where(thead code) {
+				color: var(--white);
+				background-color: var(--primary30);
+				border-color: var(--primary60);
+			}
+		}
 	}
 
 	a code {

--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -180,6 +180,25 @@
 		border-radius: 0.25em;
 		box-shadow: var(--shadow_sticker);
 	}
+
+	// <code> and <kbd> styling will overlap other lines in header elements
+	// because their containers expand past the available line-height.
+	// - `display: inline-flex` forces the line to expand to fit these elements.
+	//   while centering its contents (`align-items: center`)
+	// - albeit with the caveat of not being able to wrap its contents between lines
+	h1, h2, h3, h4, h5, h6 {
+		code {
+			display: inline-flex;
+			height: calc(1.2em + 0.15em);
+			align-items: center;
+		}
+
+		kbd {
+			display: inline-flex;
+			height: calc(1.2em + 2*0.15em);
+			align-items: center;
+		}
+	}
 }
 
 @import "src/styles/markdown/blockquote";

--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -139,29 +139,35 @@
 		@extend .text-style-code;
 	}
 
-	p > code {
-		display: inline;
-		padding: 0 0.4em;
-		font-size: 85%;
-		color: var(--black);
-		background-color: var(--codeInlineBackground);
-		border-radius: 4px;
+	code:not(pre code) {
+		font-family: var(--uu-font-family-code);
+		font-size: 0.8em;
+		font-weight: 500;
+		color: var(--secondary_on-variant);
+		background-color: var(--surface_secondary_emphasis-none);
+		padding-bottom: 0.15em;
+		padding-left: 0.15em;
+		padding-right: 0.15em;
+		border: 0.075em solid var(--secondary_default);
+		border-radius: 0.25em;
+	}
+
+	a code {
+		text-decoration: underline;
 	}
 
 	kbd {
-		background-color: #eee;
-		border-radius: 3px;
-		border: 1px solid #b4b4b4;
-		box-shadow:
-			0 1px 1px rgba(0, 0, 0, 0.2),
-			0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
-		color: #333;
-		display: inline-block;
-		font-size: 0.85em;
-		font-weight: 700;
+		font-family: var(--uu-font-family-code);
+		font-size: .8em;
+		font-weight: 500;
+		color: var(--black);
+		background-color: #eaeaea;
+		text-shadow: 0px 0.075em var(--white);
 		line-height: 1;
-		padding: 2px 4px;
-		white-space: nowrap;
+		padding: 0.15em;
+		border: 0.075em solid var(--white);
+		border-radius: 0.25em;
+		box-shadow: var(--shadow_sticker);
 	}
 }
 

--- a/src/utils/markdown/file-tree/file-list.tsx
+++ b/src/utils/markdown/file-tree/file-list.tsx
@@ -1,9 +1,8 @@
 /** @jsxRuntime automatic */
-import { Node, Element } from "hast";
+import { Element } from "hast";
 import type { Child as HChild } from "hastscript";
 import { fromHtml } from "hast-util-from-html";
 import { getIcon } from "./file-tree-icons";
-import { toString } from "hast-util-to-string";
 
 /** Convert an HTML string containing an SVG into a HAST element node. */
 const makeSVGIcon = (svgString: string) => {
@@ -30,7 +29,7 @@ const FolderIcon = makeSVGIcon(
 );
 
 export interface File {
-	name: Node;
+	name: string;
 	comment?: HChild[];
 	filetype: string;
 	isDirectory: false;
@@ -39,7 +38,7 @@ export interface File {
 }
 
 export interface Directory {
-	name: Node;
+	name: string;
 	comment?: HChild[];
 	isDirectory: true;
 	items: Array<Directory | File>;
@@ -53,8 +52,6 @@ interface FileProps {
 
 /** @jsxImportSource hastscript */
 function File({ item }: FileProps) {
-	const rawName = toString(item.name as never);
-
 	return (
 		<>
 			<span
@@ -63,7 +60,7 @@ function File({ item }: FileProps) {
 				} text-style-body-small`}
 			>
 				<span class="docs-file-tree-file-icon">
-					{item.isPlaceholder ? null : FileIcon(rawName)}
+					{item.isPlaceholder ? null : FileIcon(item.name)}
 				</span>
 				{item.name}
 			</span>

--- a/src/utils/markdown/file-tree/rehype-file-tree.ts
+++ b/src/utils/markdown/file-tree/rehype-file-tree.ts
@@ -26,7 +26,6 @@ import replaceAllBetween from "unist-util-replace-all-between";
 import { Node } from "unist";
 import JSON5 from "json5";
 import { FileList, Directory, File } from "./file-list";
-import { fromHtml } from "hast-util-from-html";
 
 interface DirectoryMetadata {
 	open?: boolean;
@@ -118,7 +117,7 @@ export const rehypeFileTree = () => {
 					if (!isDirectory) {
 						listItems.push({
 							isDirectory: false,
-							name: firstChild,
+							name: toString(firstChild as never),
 							filetype: fileExtension,
 							comment,
 							isHighlighted,
@@ -131,7 +130,7 @@ export const rehypeFileTree = () => {
 					const dirItems: Array<File | Directory> = [];
 					listItems.push({
 						isDirectory: true,
-						name: firstChild,
+						name: toString(firstChild as never),
 						isHighlighted,
 						items: dirItems,
 						comment,
@@ -142,7 +141,7 @@ export const rehypeFileTree = () => {
 					if (!hasContents) {
 						dirItems.push({
 							isDirectory: false,
-							name: fromHtml("..."),
+							name: "...",
 							filetype: "",
 							isHighlighted: false,
 							isPlaceholder: true,


### PR DESCRIPTION
Adds the inline markdown styling for `<code>` and `<kbd>` elements from #676 