### PR TITLE
Fix table & inline code formatting

### DIFF
--- a/content/blog/intro-to-web-accessibility/index.md
+++ b/content/blog/intro-to-web-accessibility/index.md
@@ -25,10 +25,10 @@ Something to keep in mind is that these disabilities may not be permanent. For i
 
 |       | Permanent | Temporary | Situational |
 |-------|-----------|-----------|-------------|
-| Touch | <img height="200" src="./one_arm.png" alt=""> One arm | <img height="200" src="./arm_injury.png" alt=""> Arm injury | <img height="200" src="./new_parent.png" alt=""> New parent |
-| See   | <img height="200" src="./blind.png" alt=""> Blind | <img height="200" src="./cataract.png" alt=""> Cataract | <img height="200" src="./distracted_driver.png" alt=""> Distracted driver |
-| Hear  | <img height="200" src="./deaf.png" alt=""> Deaf | <img height="200" src="./ear_infection.png" alt=""> Ear infection | <img height="200" src="./bartender.png" alt=""> Bartender |
-| Speak | <img height="200" src="./non_verbal.png" alt=""> Non-verbal | <img height="200" src="./laryngitis.png" alt=""> Laryngitis | <img height="200" src="./heavy_accent.png" alt=""> Heavy accent |
+| Touch | <img height="200" src="./one_arm.png" alt=""><br> One arm | <img height="200" src="./arm_injury.png" alt=""><br> Arm injury | <img height="200" src="./new_parent.png" alt=""><br> New parent |
+| See   | <img height="200" src="./blind.png" alt=""><br> Blind | <img height="200" src="./cataract.png" alt=""><br> Cataract | <img height="200" src="./distracted_driver.png" alt=""><br> Distracted driver |
+| Hear  | <img height="200" src="./deaf.png" alt=""><br> Deaf | <img height="200" src="./ear_infection.png" alt=""><br> Ear infection | <img height="200" src="./bartender.png" alt=""><br> Bartender |
+| Speak | <img height="200" src="./non_verbal.png" alt=""><br> Non-verbal | <img height="200" src="./laryngitis.png" alt=""><br> Laryngitis | <img height="200" src="./heavy_accent.png" alt=""><br> Heavy accent |
 
 > Microsoft originally created this chart as part of their [Inclusive Toolkit](https://download.microsoft.com/download/b/0/d/b0d4bf87-09ce-4417-8f28-d60703d672ed/inclusive_toolkit_manual_final.pdf) manual
 

--- a/content/blog/intro-to-web-accessibility/index.md
+++ b/content/blog/intro-to-web-accessibility/index.md
@@ -23,38 +23,12 @@ Another example is users with limited mobility who utilize specialty hardware, s
 
 Something to keep in mind is that these disabilities may not be permanent. For instance, if you fall and break your arm, you may be only using one arm while healing. Likewise, there are situational impairments as well. If you're holding a cup of coffee in one hand, you'll only be using the other for device usage. Here's a chart that outlines a few more of these examples:
 
-<table>
-	<tr>
-	  <th></th>
-		<th scope="col">Permanent</th>
-		<th scope="col">Temporary</th>
-		<th scope="col">Situational</th>
-	</tr>
-	<tr>
-		<th scope="row">Touch</th>
-		<td><img src="./one_arm.png" style="height: 200px"/><br/>One arm</td>
-		<td><img src="./arm_injury.png" style="height: 200px"/><br/>Arm injury</td>
-		<td><img src="./new_parent.png" style="height: 200px"/><br/>New parent</td>
-	</tr>
-	<tr>
-		<th scope="row">See</th>
-		<td><img src="./blind.png" style="height: 200px"/><br/>Blind</td>
-		<td><img src="./cataract.png" style="height: 200px"/><br/>Cataract</td>
-		<td><img src="./distracted_driver.png" style="height: 200px"/><br/>Distracted driver</td>
-	</tr>
-	<tr>
-		<th scope="row">Hear</th>
-		<td><img src="./deaf.png" style="height: 200px"/><br/>Deaf</td>
-		<td><img src="./ear_infection.png" style="height: 200px"/><br/>Ear infection</td>
-		<td><img src="./bartender.png" style="height: 200px"/><br/>Bartender</td>
-	</tr>
-	<tr>
-		<th scope="row">Speak</th>
-		<td><img src="./non_verbal.png" style="height: 200px"/><br/>Non-verbal</td>
-		<td><img src="./laryngitis.png" style="height: 200px"/><br/>Laryngitis</td>
-		<td><img src="./heavy_accent.png" style="height: 200px"/><br/>Heavy accent</td>
-	</tr>
-</table>
+|       | Permanent | Temporary | Situational |
+|-------|-----------|-----------|-------------|
+| Touch | <img height="200" src="./one_arm.png" alt=""> One arm | <img height="200" src="./arm_injury.png" alt=""> Arm injury | <img height="200" src="./new_parent.png" alt=""> New parent |
+| See   | <img height="200" src="./blind.png" alt=""> Blind | <img height="200" src="./cataract.png" alt=""> Cataract | <img height="200" src="./distracted_driver.png" alt=""> Distracted driver |
+| Hear  | <img height="200" src="./deaf.png" alt=""> Deaf | <img height="200" src="./ear_infection.png" alt=""> Ear infection | <img height="200" src="./bartender.png" alt=""> Bartender |
+| Speak | <img height="200" src="./non_verbal.png" alt=""> Non-verbal | <img height="200" src="./laryngitis.png" alt=""> Laryngitis | <img height="200" src="./heavy_accent.png" alt=""> Heavy accent |
 
 > Microsoft originally created this chart as part of their [Inclusive Toolkit](https://download.microsoft.com/download/b/0/d/b0d4bf87-09ce-4417-8f28-d60703d672ed/inclusive_toolkit_manual_final.pdf) manual
 

--- a/content/blog/web-components-101-framework-comparison/index.md
+++ b/content/blog/web-components-101-framework-comparison/index.md
@@ -24,8 +24,9 @@ To showcase this, let’s walk through some of these frameworks and compare and 
 While web frameworks are the hot new jazz - it’s not like we couldn’t make web applications before them. With the advent of W3C standardized web components (without Lit), doing so today is better than it’s ever been.
 
 Here are some pros and cons of Vanilla JavaScript web components:
-
-<table class="wp-block-table">     <tbody>         <tr>             <th>                 Pros             </th>             <th>                 Cons             </th>         </tr>         <tr>             <td>                 <ul>                     <li><span>No framework knowledge required</span></li>                     <li><span>Less reliance on framework</span></li>                 </ul>                 <ul>                     <li><span>Maintenance</span></li>                     <li><span>Bugs</span></li>                     <li><span>Security issues</span></li>                 </ul>                 <ul>                     <li><span>Smaller “hello world” size</span></li>                     <li><span>More control over render behavior</span></li>                 </ul>             </td>             <td>                 <ul>                     <li><span>Re-rendering un-needed elements is slow</span></li>                     <li><span>Handling event passing is tricky</span></li>                     <li><span>Creating elements can be overly verbose</span></li>                     <li><span>Binding to props requires element query</span></li>                     <li><span>You’ll end up building Lit, anyway</span></li>                 </ul>             </td>         </tr>     </tbody> </table>
+|    Pros    |    Cons    |
+|------------|------------|
+| <ul><li>No framework knowledge required</li><li>Less reliance on framework</li></ul><ul><li>Maintenance</li><li>Bugs</li><li>Security issues</li></ul><ul><li>Smaller “hello world” size</li><li>More control over render behavior</li></ul> | <ul><li>Re-rendering un-needed elements is slow</li><li>Handling event passing is tricky</li><li>Creating elements can be overly verbose</li><li>Binding to props requires element query</li><li>You’ll end up building Lit, anyway</li></ul> |
 
 To the vanilla way of doing things’ credit, there’s a bit of catharsis knowing that you’re relying on a smaller pool of upstream resources. There’s also a lessened likelihood of some bad push to NPM from someone on the Lit team breaking your build.
 
@@ -170,7 +171,9 @@ You could work on fixing these, but ultimately, you’ve created a basis of what
 
 With the downsides (and upsides) of vanilla web components in mind, let’s compare the pros and cons of what building components using Lit looks like:
 
-<table class="wp-block-table">     <tbody>         <tr>             <th>                 Pros             </th>             <th>                 Cons             </th>         </tr>         <tr>             <td>                 <ul>                     <li><span>Faster re-renders* that are automatically                             handled</span></li>                     <li><span>More consolidated UI/logic</span></li>                     <li><span>More advanced tools after mastery</span></li>                     <li><span>Smaller footprint than other frameworks</span></li>                 </ul>             </td>             <td>                 <ul>                     <li><span>Framework knowledge required</span></li>                     <li><span>Future breaking changes</span></li>                     <li><span>Not as widely known/used as other frameworks (Vue,                             React, Angular)</span></li>                 </ul>                 <p><span></span></p>             </td>         </tr>     </tbody> </table>
+|    Pros    |    Cons    |
+|------------|------------|
+| <ul><li>Faster re-renders* that are automatically handled</li><li>More consolidated UI/logic</li><li>More advanced tools after mastery</li><li>Smaller footprint than other frameworks</li></ul> | <ul><li>Framework knowledge required</li><li>Future breaking changes</li><li>Not as widely known/used as other frameworks (Vue, React, Angular)</li></ul> |
 
 While there is some overlap between this list of pros and cons and the one for avoiding Lit in favor of home-growing, there’s a few other items here.
 

--- a/content/blog/web-components-101-lit-framework/index.md
+++ b/content/blog/web-components-101-lit-framework/index.md
@@ -71,7 +71,7 @@ There are two primary differences from the vanilla JavaScript example. First, we
 
 That said, Lit components fully support the same lifecycle methods as a vanilla custom elements.
 
-The second, easier-to-miss change from the vanilla JavaScript component to the Lit implementation, is that when we set our HTML, we don’t simply use a basic template literal (`<p>test</p>`): we pass the function `html` to the template literal (`html\`<p>test</p>\``).
+The second, easier-to-miss change from the vanilla JavaScript component to the Lit implementation, is that when we set our HTML, we don’t simply use a basic template literal (`<p>test</p>`): we pass the function `html` to the template literal (``html`<p>test</p>`;``).
 
 This leverages [a somewhat infrequently used feature of template literals called tagged templates](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates). Tagged templates allow a template literal to be passed to a function. This function can then transform the output based on the string input and expected interpolated placeholders.
 


### PR DESCRIPTION
Fixes various posts using formatting that resulted in styling issues:
- [Intro to Web Accessibility](https://unicorn-utterances-git-uwu-inline-styling-oceanbit.vercel.app/posts/intro-to-web-accessibility) (HTML table missing a `<thead>` / `<tbody>`)
- [Web Components 101: Framework Comparison](https://unicorn-utterances-git-uwu-inline-styling-oceanbit.vercel.app/posts/web-components-101-framework-comparison) (HTML table missing a `<thead>` / `<tbody>`)
- [Web Components 101: Lit Framework](https://unicorn-utterances-git-uwu-inline-styling-oceanbit.vercel.app/posts/web-components-101-lit-framework) (unescaped inline code backticks)