### PR TITLE
[UwU] Use width/height attributes on `<img>` tags when provided

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -72,6 +72,11 @@ body {
 		background-color $animStyle $animSpeed;
 }
 
+.medium-zoom-overlay,
+.medium-zoom-image--opened {
+  z-index: 999;
+}
+
 .medium-zoom-overlay {
 	background: var(--background_primary) !important;
 }

--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -128,6 +128,7 @@
 
 	img {
 		max-width: 100%;
+		height: auto;
 	}
 
 	img[src$=".svg"] {

--- a/src/utils/markdown/rehype-astro-image-md.ts
+++ b/src/utils/markdown/rehype-astro-image-md.ts
@@ -20,6 +20,16 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const MAX_WIDTH = 768;
 const MAX_HEIGHT = 768;
 
+/**
+ * parse a height/width attribute value (e.g. "20px" or "20") and
+ * return the value in pixel units, or undefined if it cannot be
+ * parsed.
+ */
+function getPixelValue(attr: unknown): number {
+	const [, pxValue] = /^([0-9]+)(px)?$/.exec(attr + "") || [];
+	return typeof pxValue !== "undefined" ? Number(pxValue) : undefined;
+}
+
 export const rehypeAstroImageMd: Plugin<[], Root> = () => {
 	return async (tree, file) => {
 		const imgNodes: Element[] = [];
@@ -47,15 +57,6 @@ export const rehypeAstroImageMd: Plugin<[], Root> = () => {
 				const nodeSrc = node.properties.src as string;
 				const nodeAlt = node.properties.alt as string;
 
-				// TODO: How should remote images be handled?
-				const dimensions = getImageSize(nodeSrc, filePathDir, rootFileDir) || {
-					height: undefined,
-					width: undefined,
-				};
-
-				// TODO: Remote images?
-				if (!dimensions.height || !dimensions.width) return;
-
 				let src: string;
 				if (nodeSrc.startsWith("/")) {
 					src = nodeSrc;
@@ -71,30 +72,50 @@ export const rehypeAstroImageMd: Plugin<[], Root> = () => {
 					return;
 				}
 
-				const originalDimensions = { ...dimensions };
-				const imgRatioHeight = dimensions.height / dimensions.width;
-				const imgRatioWidth = dimensions.width / dimensions.height;
+				// TODO: How should remote images be handled?
+				const srcSize = getImageSize(nodeSrc, filePathDir, rootFileDir) || {
+					height: undefined,
+					width: undefined,
+				};
+
+				// TODO: Remote images?
+				if (!srcSize.height || !srcSize.width) return;
+
+				const imageRatio = srcSize.width / srcSize.height;
+
+				const nodeWidth = getPixelValue(node.properties.width);
+				const nodeHeight = getPixelValue(node.properties.height);
+
+				const dimensions = { ...srcSize };
+				if (nodeHeight) {
+					dimensions.height = nodeHeight;
+					dimensions.width = Math.floor(nodeHeight * imageRatio);
+				} else if (nodeWidth) {
+					dimensions.width = nodeWidth;
+					dimensions.height = Math.floor(nodeWidth / imageRatio);
+				}
+
 				if (dimensions.height > MAX_HEIGHT) {
 					dimensions.height = MAX_HEIGHT;
-					dimensions.width = Math.floor(MAX_HEIGHT * imgRatioWidth);
+					dimensions.width = Math.floor(MAX_HEIGHT * imageRatio);
 				}
 
 				if (dimensions.width > MAX_WIDTH) {
 					dimensions.width = MAX_WIDTH;
-					dimensions.height = Math.floor(MAX_WIDTH * imgRatioHeight);
+					dimensions.height = Math.floor(MAX_WIDTH / imageRatio);
 				}
 
 				const pictureResult = await getPicture({
 					src: src,
 					widths: [dimensions.width],
 					formats: ["avif", "webp", "png"],
-					aspectRatio: imgRatioWidth,
+					aspectRatio: imageRatio,
 					alt: nodeAlt || "",
 				});
 
 				let pngSource = {
 					src: src,
-					size: originalDimensions.width,
+					size: srcSize.width,
 				};
 
 				if (
@@ -106,9 +127,9 @@ export const rehypeAstroImageMd: Plugin<[], Root> = () => {
 				) {
 					const originalPictureResult = await getPicture({
 						src: src,
-						widths: [originalDimensions.width],
+						widths: [srcSize.width],
 						formats: ["png"],
-						aspectRatio: imgRatioWidth,
+						aspectRatio: imageRatio,
 						alt: nodeAlt || "",
 					});
 
@@ -156,7 +177,8 @@ export const rehypeAstroImageMd: Plugin<[], Root> = () => {
 							loading: "lazy",
 							decoding: "async",
 							"data-zoom-src": pngSource.src,
-							style: `width: ${pngSource.size}px`,
+							width: dimensions.width,
+							height: dimensions.height,
 						}),
 					]),
 				);

--- a/src/utils/markdown/rehype-astro-image-md.ts
+++ b/src/utils/markdown/rehype-astro-image-md.ts
@@ -25,7 +25,7 @@ const MAX_HEIGHT = 768;
  * return the value in pixel units, or undefined if it cannot be
  * parsed.
  */
-function getPixelValue(attr: unknown): number {
+function getPixelValue(attr: unknown): number | undefined {
 	const [, pxValue] = /^([0-9]+)(px)?$/.exec(attr + "") || [];
 	return typeof pxValue !== "undefined" ? Number(pxValue) : undefined;
 }
@@ -89,20 +89,20 @@ export const rehypeAstroImageMd: Plugin<[], Root> = () => {
 				const dimensions = { ...srcSize };
 				if (nodeHeight) {
 					dimensions.height = nodeHeight;
-					dimensions.width = Math.floor(nodeHeight * imageRatio);
+					dimensions.width = Math.ceil(nodeHeight * imageRatio);
 				} else if (nodeWidth) {
 					dimensions.width = nodeWidth;
-					dimensions.height = Math.floor(nodeWidth / imageRatio);
+					dimensions.height = Math.ceil(nodeWidth / imageRatio);
 				}
 
 				if (dimensions.height > MAX_HEIGHT) {
 					dimensions.height = MAX_HEIGHT;
-					dimensions.width = Math.floor(MAX_HEIGHT * imageRatio);
+					dimensions.width = Math.ceil(MAX_HEIGHT * imageRatio);
 				}
 
 				if (dimensions.width > MAX_WIDTH) {
 					dimensions.width = MAX_WIDTH;
-					dimensions.height = Math.floor(MAX_WIDTH / imageRatio);
+					dimensions.height = Math.ceil(MAX_WIDTH / imageRatio);
 				}
 
 				const pictureResult = await getPicture({
@@ -177,8 +177,8 @@ export const rehypeAstroImageMd: Plugin<[], Root> = () => {
 							loading: "lazy",
 							decoding: "async",
 							"data-zoom-src": pngSource.src,
-							width: dimensions.width,
-							height: dimensions.height,
+							width: pictureResult.image.width,
+							height: pictureResult.image.height,
 						}),
 					]),
 				);

--- a/src/utils/markdown/rehype-astro-image-md.ts
+++ b/src/utils/markdown/rehype-astro-image-md.ts
@@ -179,6 +179,7 @@ export const rehypeAstroImageMd: Plugin<[], Root> = () => {
 							"data-zoom-src": pngSource.src,
 							width: pictureResult.image.width,
 							height: pictureResult.image.height,
+							style: node.properties.style,
 						}),
 					]),
 				);

--- a/src/utils/markdown/rehype-astro-image-md.ts
+++ b/src/utils/markdown/rehype-astro-image-md.ts
@@ -89,20 +89,20 @@ export const rehypeAstroImageMd: Plugin<[], Root> = () => {
 				const dimensions = { ...srcSize };
 				if (nodeHeight) {
 					dimensions.height = nodeHeight;
-					dimensions.width = Math.ceil(nodeHeight * imageRatio);
+					dimensions.width = Math.floor(nodeHeight * imageRatio);
 				} else if (nodeWidth) {
 					dimensions.width = nodeWidth;
-					dimensions.height = Math.ceil(nodeWidth / imageRatio);
+					dimensions.height = Math.floor(nodeWidth / imageRatio);
 				}
 
 				if (dimensions.height > MAX_HEIGHT) {
 					dimensions.height = MAX_HEIGHT;
-					dimensions.width = Math.ceil(MAX_HEIGHT * imageRatio);
+					dimensions.width = Math.floor(MAX_HEIGHT * imageRatio);
 				}
 
 				if (dimensions.width > MAX_WIDTH) {
 					dimensions.width = MAX_WIDTH;
-					dimensions.height = Math.ceil(MAX_WIDTH / imageRatio);
+					dimensions.height = Math.floor(MAX_WIDTH / imageRatio);
 				}
 
 				const pictureResult = await getPicture({


### PR DESCRIPTION
- Uses the `width` or `height` attributes as the image size, if present
  * If only one is provided, the other is inferred from the aspect ratio
  * If both are present, `height` takes precedence, and the width is inferred
- Sets both `height=` and `width=` attributes in the output html
- Adds a `z-index: 999;` for the medium-zoom overlay to prevent it from colliding with the navbar