### PR TITLE
chore: add missing pathName to pages

### DIFF
--- a/src/components/seo/shared.ts
+++ b/src/components/seo/shared.ts
@@ -12,7 +12,7 @@ export interface SEOProps {
 	publishedTime?: string;
 	editedTime?: string;
 	type?: "article" | "profile" | "book";
-	pathName?: string;
+	pathName: string;
 	canonical?: string;
 	isbn?: string;
 	shareImage?: string;

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -8,7 +8,7 @@ const locale = "en";
 ---
 
 <Document lang={locale}>
-	<SEO slot="head" title="404: Not Found" />
+	<SEO slot="head" title="404: Not Found" pathName={``} />
 
 	<main class="listViewContent">
 		<Picture

--- a/src/pages/collections/[slug].astro
+++ b/src/pages/collections/[slug].astro
@@ -67,6 +67,7 @@ const coverImgAspectRatio = coverImgSize.width / coverImgSize.height;
 <Document>
 	<SEO
 		slot="head"
+		pathName={`/collections/${collection.slug}`}
 		title={collection.title}
 		description={collection.description}
 		unicornsData={collection.authorsMeta}

--- a/src/pages/collections/framework-field-guide/index.astro
+++ b/src/pages/collections/framework-field-guide/index.astro
@@ -42,6 +42,7 @@ import WhatDoIGet from "src/page-components/collections/framework-field-guide/se
 <Barebones>
 	<SEO
 		slot="head"
+		pathName={`/collections/framework-field-guide`}
 		title={"The Framework Field Guide"}
 		description={"A practical and free way to teach Angular, React, and Vue all at once, so you can choose the right tool for the job and learn the underlying concepts in depth."}
 		unicornsData={[unicorns.find((uni) => uni.id === "crutchcorn")]}

--- a/src/pages/confirm.astro
+++ b/src/pages/confirm.astro
@@ -8,7 +8,7 @@ const locale = "en";
 ---
 
 <Document lang={locale}>
-	<SEO title="Confirm Your Email" slot="head" />
+	<SEO title="Confirm Your Email" slot="head" pathName={`/confirm`} />
 
 	<main class="listViewContent">
 		<Picture

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ const page = {
 ---
 
 <Document>
-	<SEO slot="head" title="Homepage" />
+	<SEO slot="head" title="Homepage" pathName={``} />
 	<div class="listViewContent">
 		<PostListTemplate posts={postsToDisplay} page={page} rootURL={"/"} />
 	</div>

--- a/src/pages/page/[page].astro
+++ b/src/pages/page/[page].astro
@@ -22,7 +22,7 @@ const SEOTitle = `Post page ${pageIndex}`;
 ---
 
 <Document>
-	<SEO slot="head" title={SEOTitle} />
+	<SEO slot="head" title={SEOTitle} pathName={`/page/${page.currentPage}`} />
 	<div class="listViewContent">
 		<PostListTemplate posts={page.data} page={page} rootURL={"/"} />
 	</div>

--- a/src/pages/thanks.astro
+++ b/src/pages/thanks.astro
@@ -8,7 +8,7 @@ const locale = "en";
 ---
 
 <Document lang={locale}>
-	<SEO title="Thank You!" slot="head" />
+	<SEO title="Thank You!" slot="head" pathName={`/thanks`} />
 
 	<main class="listViewContent">
 		<Picture

--- a/src/pages/unicorns/[unicornid]/index.astro
+++ b/src/pages/unicorns/[unicornid]/index.astro
@@ -40,6 +40,7 @@ const rootURL = `/unicorns/${unicorn.id}/`;
 		description={unicorn.description}
 		unicornsData={[unicorn]}
 		type="profile"
+		pathName={`/unicorns/${unicorn.id}`}
 	/>
 	<div class="listViewContent">
 		<UnicornsPage

--- a/src/pages/unicorns/[unicornid]/page/[page].astro
+++ b/src/pages/unicorns/[unicornid]/page/[page].astro
@@ -42,6 +42,7 @@ const rootURL = `/unicorns/${unicorn.id}/`;
 		description={unicorn.description}
 		unicornsData={[unicorn]}
 		type="profile"
+		pathName={`/unicorns/${unicorn.id}/page/${page.currentPage}`}
 	/>
 	<div class="listViewContent">
 		<UnicornsPage


### PR DESCRIPTION
This should fix some pretty big SEO and scraping issues (IE: Facebook/LinkedIn's image preview tag) with our pages