### PR TITLE
[UwU] Use :focus-visible for filter select focus state

### DIFF
--- a/src/components/select/select.module.scss
+++ b/src/components/select/select.module.scss
@@ -62,7 +62,7 @@
 	min-width: var(--popup_min-width);
 }
 
-.option:focus-within {
+.option:focus-visible {
 	background-color: var(--popup_item_background-color_focused);
 }
 


### PR DESCRIPTION

![NVIDIA_Share_EV9Zi5gkx8](https://github.com/unicorn-utterances/unicorn-utterances/assets/13000407/76329b42-b6dc-4f06-af85-55dbaad79fea)
Attempt to fix the select filter boxes retaining their focus background after being hovered over.