### PR TITLE
[UwU] Add heading selectors for text spacing within tab contents

### DIFF
--- a/src/styles/markdown/tabs.scss
+++ b/src/styles/markdown/tabs.scss
@@ -101,6 +101,12 @@
 	margin-bottom: 0;
 }
 
+.tabs__tab-panel__inner > h1,
+.tabs__tab-panel__inner > h2,
+.tabs__tab-panel__inner > h3,
+.tabs__tab-panel__inner > h4,
+.tabs__tab-panel__inner > h5,
+.tabs__tab-panel__inner > h6,
 .tabs__tab-panel__inner > p,
 .tabs__tab-panel__inner > blockquote,
 .tabs__tab-panel__inner > ul,


### PR DESCRIPTION
Applies the tab content margin to headings as well as other text content within tabs, so that they're aligned properly.

Prevents issues like this:
![2023-09-18-162552_460x288_scrot](https://github.com/unicorn-utterances/unicorn-utterances/assets/13000407/0b7afe1c-bfe0-4842-9576-534e0e4c142e)
