### PR TITLE
[UwU] Preserve iframe flags

### DIFF
--- a/src/utils/markdown/iframes/iframe-placeholder.tsx
+++ b/src/utils/markdown/iframes/iframe-placeholder.tsx
@@ -11,6 +11,7 @@ export interface IFramePlaceholderProps {
 	width: string;
 	height: string;
 	src: string;
+	propsToPreserve: string;
 	pageTitle: string;
 	pageIcon: GetPictureResult;
 }
@@ -19,6 +20,7 @@ export interface IFramePlaceholderProps {
 export function IFramePlaceholder({
 	height,
 	width,
+	propsToPreserve,
 	...props
 }: IFramePlaceholderProps): Element {
 	return (
@@ -64,6 +66,7 @@ export function IFramePlaceholder({
 			<div
 				class="embed__placeholder"
 				data-iframeurl={props.src}
+				data-iframeprops={propsToPreserve}
 				style={`height: ${Number(height) ? `${height}px` : height};`}
 			>
 				<button class="button regular primary-emphasized text-style-button-regular">

--- a/src/utils/markdown/iframes/iframe-script.ts
+++ b/src/utils/markdown/iframes/iframe-script.ts
@@ -12,6 +12,19 @@ export const iFrameClickToRun = () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			(iframe as any).loading = "lazy";
 			iframe.src = el.parentElement.dataset.iframeurl;
+			const propsToPreserve = JSON.parse(
+				el.parentElement.dataset.iframeprops || "{}",
+			);
+			for (const prop in propsToPreserve) {
+				const val = propsToPreserve[prop];
+				// Handle array props per hast spec:
+				// @see https://github.com/syntax-tree/hast#propertyvalue
+				if (Array.isArray(val)) {
+					iframe.setAttribute(prop, val.join(" "));
+					continue;
+				}
+				iframe.setAttribute(prop, propsToPreserve[prop]);
+			}
 			iframe.style.width = el.parentElement.style.width;
 			iframe.style.height = el.parentElement.style.height;
 			el.parentElement.replaceWith(iframe);

--- a/src/utils/markdown/iframes/rehype-transform.ts
+++ b/src/utils/markdown/iframes/rehype-transform.ts
@@ -154,8 +154,11 @@ export const rehypeUnicornIFrameClickToRun: Plugin<
 
 		await Promise.all(
 			iframeNodes.map(async (iframeNode) => {
-				const width = iframeNode.properties.width ?? EMBED_SIZE.w;
-				let height = iframeNode.properties.height ?? EMBED_SIZE.h;
+				// eslint-disable-next-line prefer-const
+				let { height, width, src, ...propsToPreserve } = iframeNode.properties;
+
+				width = width ?? EMBED_SIZE.w;
+				height = height ?? EMBED_SIZE.h;
 				const info: PageInfo = (await fetchPageInfo(
 					iframeNode.properties.src.toString(),
 				).catch(() => null)) || { icon: await fetchDefaultPageIcon() };
@@ -166,9 +169,10 @@ export const rehypeUnicornIFrameClickToRun: Plugin<
 				const iframeReplacement = IFramePlaceholder({
 					width: width.toString(),
 					height: height.toString(),
-					src: iframeNode.properties.src.toString(),
+					src: src.toString(),
 					pageTitle: info.title || "",
 					pageIcon: info.icon,
+					propsToPreserve: JSON.stringify(propsToPreserve),
 				});
 
 				Object.assign(iframeNode, iframeReplacement);


### PR DESCRIPTION
When adding an iframe in a blog post, we might want to have flags akin to this:

```html
<iframe src="https://example.com" sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin" allow="cross-origin-isolated"></iframe>
```

But today we do not preserve the `sandbox` or `allow` flag. This PR fixes that behavior.