### PR TITLE
[UwU] Fix non-circular nav buttons in tablet mode

### DIFF
--- a/src/views/base/navigation/header.module.scss
+++ b/src/views/base/navigation/header.module.scss
@@ -96,6 +96,10 @@
 		max-width: var(--header_end-items_max-width);
 	}
 
+	> :global(.button) {
+		flex-shrink: 0;
+	}
+
 	.discordLarge {
 		display: none;
 	}


### PR DESCRIPTION
- Sets `flex-shrink: 0;` on buttons in the nav header to fix #703 