### PR TITLE
[UwU] Add noindex frontmatter property for test posts

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -45,6 +45,15 @@ export default defineConfig({
 					return prev;
 				}, {}),
 			},
+			filter(page) {
+				// return true, unless lart part of the URL ends with "_noindex"
+				// in which case it should not be in the sitemap
+				return !page
+					.split("/")
+					.filter((part) => !!part.length)
+					.at(-1)
+					.endsWith("_noindex");
+			},
 			serialize({ url, ...rest }) {
 				return {
 					// remove trailing slash from sitemap URLs

--- a/content/blog/example/index.md
+++ b/content/blog/example/index.md
@@ -7,7 +7,7 @@
 	tags: [],
 	attached: [],
 	license: 'cc-by-nc-sa-4',
-  noindex: true
+	noindex: true
 }
 ---
 

--- a/content/blog/example/index.md
+++ b/content/blog/example/index.md
@@ -1,12 +1,13 @@
 ---
 {
-	title: "Test Content: Edge Cases",
+	title: "Example Post",
 	description: "Look at all those edge cases!",
 	published: '1999-09-18',
 	authors: ['fennifith'],
 	tags: [],
 	attached: [],
-	license: 'cc-by-nc-sa-4'
+	license: 'cc-by-nc-sa-4',
+  noindex: true
 }
 ---
 

--- a/content/data/achievements.ts
+++ b/content/data/achievements.ts
@@ -1,4 +1,4 @@
-import { posts } from "utils/data";
+import { getPostsByUnicorn } from "utils/api";
 
 interface Achievement {
 	id: string;
@@ -32,9 +32,7 @@ export const achievements: Achievement[] = [
 ];
 
 function getWordCount(userId: string) {
-	const authoredPosts = posts.filter(
-		(post) => post.authors.includes(userId) && post.locale === "en",
-	);
+	const authoredPosts = getPostsByUnicorn(userId, "en");
 
 	const wordCount = authoredPosts.reduce((acc, post) => {
 		return acc + (post.wordCount ?? 0);

--- a/src/components/seo/seo.astro
+++ b/src/components/seo/seo.astro
@@ -25,6 +25,7 @@ const {
 	isbn,
 	providedLangs,
 	shareImage,
+	noindex,
 } = Astro.props as SEOProps;
 
 const lang = getPrefixLanguageFromPath(Astro.url.pathname);
@@ -50,6 +51,11 @@ const currentPath = siteMetadata.siteUrl + (pathName || "");
 <meta property="name" content={siteMetadata.title} />
 <meta name="description" content={metaDescription} />
 <meta property="keywords" content={metaKeywords} />
+
+<!-- If the page is non-indexed, exclude it from any search results with the "robots" tag -->
+<!-- https://developers.google.com/search/docs/crawling-indexing/block-indexing -->
+<>{noindex ? <meta name="robots" content="noindex, nofollow" /> : null}</>
+
 <Analytics />
 <Twitter
 	title={title}

--- a/src/components/seo/seo.astro
+++ b/src/components/seo/seo.astro
@@ -52,9 +52,11 @@ const currentPath = siteMetadata.siteUrl + (pathName || "");
 <meta name="description" content={metaDescription} />
 <meta property="keywords" content={metaKeywords} />
 
-<!-- If the page is non-indexed, exclude it from any search results with the "robots" tag -->
-<!-- https://developers.google.com/search/docs/crawling-indexing/block-indexing -->
-<>{noindex ? <meta name="robots" content="noindex, nofollow" /> : null}</>
+{
+	// If the page is non-indexed, exclude it from any search results with the "robots" tag
+	// https://developers.google.com/search/docs/crawling-indexing/block-indexing
+	noindex ? <meta name="robots" content="noindex, nofollow" /> : null
+}
 
 <Analytics />
 <Twitter

--- a/src/components/seo/shared.ts
+++ b/src/components/seo/shared.ts
@@ -12,4 +12,5 @@ export interface SEOProps {
 	canonical?: string;
 	isbn?: string;
 	shareImage?: string;
+	noindex?: boolean;
 }

--- a/src/pages/[...locale]/posts/[postid].astro
+++ b/src/pages/[...locale]/posts/[postid].astro
@@ -20,7 +20,11 @@ export async function getStaticPaths() {
 					post.frontmatter.locale !== "en"
 						? post.frontmatter.locale
 						: undefined,
-				postid: post.frontmatter.slug,
+				postid:
+					post.frontmatter.slug +
+					// "_noindex" appended here to filter affected URLs
+					// from the sitemap
+					(post.frontmatter.noindex ? "_noindex" : ""),
 			},
 			props: {
 				locale: post.frontmatter.locale,

--- a/src/pages/[...locale]/posts/[postid].astro
+++ b/src/pages/[...locale]/posts/[postid].astro
@@ -55,6 +55,7 @@ const locales = post?.locales || [];
 		canonical={post.originalLink}
 		providedLangs={locales}
 		shareImage={post.socialImg}
+		noindex={post.noindex}
 	/>
 	<BlogPost Content={Content} post={post} posts={posts} />
 </Document>

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -27,6 +27,7 @@ export const get = () => {
 	});
 
 	posts
+		.filter((post) => !post.frontmatter.noindex)
 		.sort((a, b) =>
 			new Date(b.frontmatter.published) > new Date(a.frontmatter.published)
 				? 1

--- a/src/types/PostInfo.ts
+++ b/src/types/PostInfo.ts
@@ -15,7 +15,7 @@ export interface RawPostInfo {
 	collection?: string;
 	order?: number;
 	originalLink?: string;
-	noindex: boolean;
+	noindex?: boolean;
 }
 
 export interface PostInfo extends RawPostInfo {

--- a/src/types/PostInfo.ts
+++ b/src/types/PostInfo.ts
@@ -15,6 +15,7 @@ export interface RawPostInfo {
 	collection?: string;
 	order?: number;
 	originalLink?: string;
+	noindex: boolean;
 }
 
 export interface PostInfo extends RawPostInfo {

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -3,7 +3,9 @@ import { Languages } from "types/index";
 import { posts, collections } from "./data";
 
 export function getPostsByLang(language: Languages): PostInfo[] {
-	return posts.filter((p) => p.locale === language);
+	return posts
+		.filter((p) => p.locale === language)
+		.filter((post) => !post.noindex);
 }
 
 export function getPostsByUnicorn(

--- a/src/utils/get-all-posts.ts
+++ b/src/utils/get-all-posts.ts
@@ -46,6 +46,7 @@ export function getExtendedPost(
 
 export function* getAllExtendedPosts(lang: Languages) {
 	for (const post of posts) {
+		if (post.noindex) continue;
 		if (post.locale !== lang) continue;
 
 		yield getExtendedPost(post.slug, lang);


### PR DESCRIPTION
Fixes #699 - Adds an "example post" that should be excluded from the rest of the site.

- Any `utils/api` queries (and `getAllExtendedPosts`) exclude posts with the `noindex: true` frontmatter.
  * This should result in them being excluded from all post lists and the generated search index
- `noindex` posts are filtered from the RSS feed
- A `<meta name="robots" content="noindex, nofollow" />` is added to the header of any noindex post page.
  According to Google's [developer docs](https://developers.google.com/search/docs/crawling-indexing/block-indexing), the page should still be accessible from `robots.txt`; i.e. adding this tag alone should be sufficient.

TODO: not sure if anything needs to be done to the sitemap