### PR TITLE
[UwU] More A11Y Fixes

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -69,9 +69,17 @@ const ButtonWrapper = forwardRef(
 					.join(" ")}
 				ref={ref}
 			>
-				{leftIcon && <div class="buttonIcon">{leftIcon}</div>}
+				{leftIcon && (
+					<div aria-hidden="true" class="buttonIcon">
+						{leftIcon}
+					</div>
+				)}
 				<span className="innerText">{children}</span>
-				{rightIcon && <div class="buttonIcon">{rightIcon}</div>}
+				{rightIcon && (
+					<div aria-hidden="true" class="buttonIcon">
+						{rightIcon}
+					</div>
+				)}
 			</Wrapper>
 		);
 	},
@@ -123,7 +131,9 @@ export const IconOnlyButton = forwardRef(
 				class={`iconOnly regular ${className}`}
 				ref={ref}
 			>
-				<div class="iconOnlyButtonIcon">{children}</div>
+				<div class="iconOnlyButtonIcon" aria-hidden="true">
+					{children}
+				</div>
 			</ButtonWrapper>
 		);
 	},
@@ -136,7 +146,9 @@ export const LargeIconOnlyButton = forwardRef(
 	) => {
 		return (
 			<ButtonWrapper {...props} class={`iconOnly large ${className}`} ref={ref}>
-				<div class="iconOnlyButtonIcon">{children}</div>
+				<div class="iconOnlyButtonIcon" aria-hidden="true">
+					{children}
+				</div>
 			</ButtonWrapper>
 		);
 	},

--- a/src/components/hero/hero.astro
+++ b/src/components/hero/hero.astro
@@ -7,7 +7,7 @@ import { translate } from "../../utils";
 import * as data from "src/utils/data";
 ---
 
-<header class={`${style.header}`}>
+<section class={`${style.header}`}>
 	<BannerStickersGroup class={style.bannerLogo} />
 	<div class="text-center">
 		<h1 class={`text-style-headline-2 ${style.bannerTextShadow}`}>
@@ -35,4 +35,4 @@ import * as data from "src/utils/data";
 			</LargeButton>
 		</div>
 	</div>
-</header>
+</section>

--- a/src/components/post-card/post-card.tsx
+++ b/src/components/post-card/post-card.tsx
@@ -57,7 +57,7 @@ function PostCardMeta({ post, unicornProfilePicMap }: PostCardProps) {
 				dangerouslySetInnerHTML={{ __html: post.description }}
 			></p>
 			<div className={style.spacer}></div>
-			<ul className={style.cardList}>
+			<ul className={style.cardList} aria-label={"Post tags"} role="list">
 				{post.tags.map((tag) => (
 					<li>
 						<Chip href={`/search?${buildSearchQuery({ filterTags: [tag] })}`}>

--- a/src/views/base/navigation/header.astro
+++ b/src/views/base/navigation/header.astro
@@ -20,13 +20,8 @@ const props = Astro.props as {
 };
 ---
 
-<nav
-	id="header-bar"
-	class={style.headerBorder}
-	aria-label="Toolbar for primary action buttons"
-	data-sticky-observer
->
-	<div
+<header id="header-bar" class={style.headerBorder} data-sticky-observer>
+	<nav
 		class={`${style.header} ${
 			props.size === "xl" ? style.header_xl : ""
 		} d-flex`}
@@ -101,5 +96,5 @@ const props = Astro.props as {
 
 			<DarkLightButton />
 		</div>
-	</div>
-</nav>
+	</nav>
+</header>

--- a/src/views/blog-post/blog-post.astro
+++ b/src/views/blog-post/blog-post.astro
@@ -69,28 +69,30 @@ if (post.collection && post.order) {
 	<aside slot="right" aria-labelledby="related-posts-heading">
 		<RelatedPosts post={post} headingId="related-posts-heading" />
 	</aside>
-	<PostTitleHeader post={post} />
-	<main class="post-body" data-testid={"post-body-div"}>
-		{
-			post.collection ? (
-				<SeriesToC
-					post={post}
-					postSeries={seriesPosts}
-					collection={post.collectionMeta}
-				/>
-			) : null
-		}
-		{
-			post.locales && post.locales.length > 1 ? (
-				<TranslationsHeader locales={post.locales} />
-			) : null
-		}
-		<Content />
-		{
-			post.collection ? (
-				<ArticleNav post={post} postSeries={seriesPosts} />
-			) : null
-		}
+	<main>
+		<PostTitleHeader post={post} />
+		<div class="post-body" data-testid={"post-body-div"}>
+			{
+				post.collection ? (
+					<SeriesToC
+						post={post}
+						postSeries={seriesPosts}
+						collection={post.collectionMeta}
+					/>
+				) : null
+			}
+			{
+				post.locales && post.locales.length > 1 ? (
+					<TranslationsHeader locales={post.locales} />
+				) : null
+			}
+			<Content />
+			{
+				post.collection ? (
+					<ArticleNav post={post} postSeries={seriesPosts} />
+				) : null
+			}
+		</div>
 	</main>
 	<footer role="contentinfo" class={styles.footer}>
 		{

--- a/src/views/blog-post/post-title-header/post-title-header.astro
+++ b/src/views/blog-post/post-title-header/post-title-header.astro
@@ -19,7 +19,7 @@ const editedStr = post.edited && dayjs(post.edited).format("MMMM D, YYYY");
 const originalLinkStr = post.originalLink && new URL(post.originalLink).host;
 ---
 
-<header role="banner" class={style.container}>
+<section class={style.container}>
 	<h1 class={`text-style-headline-1 ${style.title}`}>{title}</h1>
 
 	<div class={style.details}>
@@ -83,4 +83,4 @@ const originalLinkStr = post.originalLink && new URL(post.originalLink).host;
 			))
 		}
 	</ul>
-</header>
+</section>


### PR DESCRIPTION
After speaking with @evelynhathaway and @colabottles, it became clear that we should migrate to roughly this markup:

```html
<body>
  <header>
    <nav id="1"></nav>
  </header>
  <main>
    <section id="2"></section>
    <section id="3"></section>
    <section id="4"></section>
    <section id="5"></section>
  </main>
  <footer>
    Any copyright info, links, social media icons, etc. can go here.
  </footer>
</body>
```

For this homepage outline:

![The homepage with outlines between each section labelled 1-5](https://github.com/unicorn-utterances/unicorn-utterances/assets/9100169/12518671-a9f8-49fc-9fd2-66f0a72a39d9)

Content that changes on a per-page basis should use a `section` rather than a `header` and our header nav should have both: `header` (which has `role="banner"`) and `nav`

In addition, this PR fixes #720, fixes #721