### PR TITLE
[UwU] Fix post metadata wrapping behavior

### DIFF
--- a/src/components/post-card/post-card.module.scss
+++ b/src/components/post-card/post-card.module.scss
@@ -128,7 +128,7 @@
 	display: flex;
 	flex-direction: row;
 	gap: var(--card_detail-row_gap);
-	align-items: center;
+	align-items: flex-start;
 }
 
 .cardIcon {
@@ -136,6 +136,7 @@
 	color: var(--card_detail-row_icon_color);
 	height: var(--card_detail-row_icon_size);
 	width: var(--card_detail-row_icon_size);
+	flex-shrink: 0;
 }
 
 .cardIcon > svg {
@@ -147,7 +148,7 @@
 	display: flex;
 	flex-direction: row;
 	gap: var(--card_detail-row_gap);
-	align-items: center;
+	align-items: flex-start;
 	margin: 0;
 }
 
@@ -157,7 +158,7 @@
 }
 
 .separatorDot {
-	margin: 0;
+	margin: 0 var(--card_detail-row_gap);
 	color: var(--card_detail-row_dot_color);
 }
 

--- a/src/components/post-card/post-card.tsx
+++ b/src/components/post-card/post-card.tsx
@@ -41,14 +41,16 @@ function PostCardMeta({ post, unicornProfilePicMap }: PostCardProps) {
 						className={style.cardIcon}
 						dangerouslySetInnerHTML={{ __html: date }}
 					/>
-					<span className={`text-style-body-small-bold ${style.publishedDate}`}>
-						{post.publishedMeta}
-					</span>
-					<span className={`text-style-body-small ${style.separatorDot}`}>
-						•
-					</span>
-					<span className={`text-style-body-small ${style.wordCount}`}>
-						{post.wordCount} words
+					<span>
+						<span className={`text-style-body-small-bold ${style.publishedDate}`}>
+							{post.publishedMeta}
+						</span>
+						<span className={`text-style-body-small ${style.separatorDot}`}>
+							•
+						</span>
+						<span className={`text-style-body-small ${style.wordCount}`}>
+							{post.wordCount} words
+						</span>
 					</span>
 				</p>
 			</div>

--- a/src/views/blog-post/post-title-header/post-title-header.module.scss
+++ b/src/views/blog-post/post-title-header/post-title-header.module.scss
@@ -37,7 +37,7 @@
 	.authors,
 	.originalLink {
 		display: flex;
-		align-items: top;
+		align-items: flex-start;
 
 		svg {
 			width: var(--article-header_details_icon_size);
@@ -71,7 +71,7 @@
 
 		&__published {
 			display: flex;
-			align-items: top;
+			align-items: flex-start;
 			flex-direction: row;
 		}
 


### PR DESCRIPTION
- Prevents post card metadata icons from shrinking with `flex-shrink`
- Fixes wrapping behavior / icon alignment to match post header
- Fixes the post header `align-items:` properties not having a valid value (`align-items: top` does not exist! oops.) 