### PR TITLE
Update MC wiki links to point to "minecraft.wiki"

### DIFF
--- a/content/blog/minecraft-data-packs-cmd-syntax/index.md
+++ b/content/blog/minecraft-data-packs-cmd-syntax/index.md
@@ -3,6 +3,7 @@
 	title: "Minecraft Data Pack Programming: Command Syntax",
 	description: "Learn the beginnings of data pack development in Minecraft - using positions, entity selectors, and conditional logic in commands!",
 	published: '2022-06-15T21:12:03.284Z',
+	edited: '2023-09-27',
 	authors: ['fennifith'],
 	tags: [],
 	attached: [],

--- a/content/blog/minecraft-data-packs-cmd-syntax/index.md
+++ b/content/blog/minecraft-data-packs-cmd-syntax/index.md
@@ -12,7 +12,7 @@
 }
 ---
 
-> Please note: this guide specifically covers the **Java Edition** version of Minecraft. Bedrock Edition does not use data packs, but provides customization through [add-ons](https://minecraft.fandom.com/wiki/Add-on).
+> Please note: this guide specifically covers the **Java Edition** version of Minecraft. Bedrock Edition does not use data packs, but provides customization through [add-ons](https://minecraft.wiki/w/Add-on).
 
 The data packs built in this series can be found in the [unicorn-utterances/mc-datapacks-tutorial](https://github.com/unicorn-utterances/mc-datapacks-tutorial/tree/main/2-command-syntax) repository. Feel free to use it for reference as you read through these articles!
 
@@ -26,7 +26,7 @@ I use the [Visual Studio Code](https://code.visualstudio.com) editor with the [l
 
 In the previous post, we ended on an interesting question &mdash; how do we write a command that only executes if the player is standing on a particular block?
 
-Well, Minecraft actually has a specific command for checking preconditions and other attributes of a command before running it - the [`/execute`](https://minecraft.fandom.com/wiki/Commands/execute) command!
+Well, Minecraft actually has a specific command for checking preconditions and other attributes of a command before running it - the [`/execute`](https://minecraft.wiki/w/Commands/execute) command!
 
 This command can be used with an indefinite number of arguments, which might make it confusing to understand by reading its documentation &mdash; but this effectively means that you can add any number of preconditions to this command.
 
@@ -57,7 +57,7 @@ You could also change the block identifier to look for a different type of block
 So what do the tildes (`~ ~ ~`) mean in the previous command? This is referring to *the current position* (in the X, Y, and Z axes) of the player that is executing the command. There are a few different ways to write positions like these in Minecraft, which I'll explain here:
 
 - ###### Absolute coordinates
-  Coordinates can be written as a fixed position in the world - say, `32 60 -94` (these coordinates can be obtained by opening the [F3 debug screen](https://minecraft.fandom.com/wiki/Debug_screen) and finding the "Targeted block" position.
+  Coordinates can be written as a fixed position in the world - say, `32 60 -94` (these coordinates can be obtained by opening the [F3 debug screen](https://minecraft.wiki/w/Debug_screen) and finding the "Targeted block" position.
 - ###### Current coordinates (tilde notation)
   Using the tilde symbols (`~ ~ ~`) will reference *the current position* that the command is executed at. This can also be mixed with static values, such as `32 ~ -94`, which will reference the block at (x: 32, z: -94) using the player's current y-axis.
 - ###### Relative coordinates
@@ -244,6 +244,6 @@ execute as @e[type=pig] at @e[type=pig] run say hi
 
 So far, we've started using conditional logic and covered most of the syntax you'll see in Minecraft commands.
 
-Between articles, feel free to experiment with [other commands](https://minecraft.fandom.com/wiki/Commands), such as `/setblock` or `/playsound`. Most of these won't be directly mentioned in the rest of this series, so it'll be useful to read through this list to figure out what each command can do.
+Between articles, feel free to experiment with [other commands](https://minecraft.wiki/w/Commands), such as `/setblock` or `/playsound`. Most of these won't be directly mentioned in the rest of this series, so it'll be useful to read through this list to figure out what each command can do.
 
 In the next post, we'll cover an entirely different feature of Minecraft: *player scoreboards!* These will allow us to keep count of different variables, detect certain in-game actions, and store a player-specific or global state in our data packs.

--- a/content/blog/minecraft-data-packs-introduction/index.md
+++ b/content/blog/minecraft-data-packs-introduction/index.md
@@ -13,7 +13,7 @@
 }
 ---
 
-> Please note: this guide specifically covers the **Java Edition** version of Minecraft. Bedrock Edition does not use data packs, but provides customization through [add-ons](https://minecraft.fandom.com/wiki/Add-on).
+> Please note: this guide specifically covers the **Java Edition** version of Minecraft. Bedrock Edition does not use data packs, but provides customization through [add-ons](https://minecraft.wiki/w/Add-on).
 
 The data packs built in this series can be found in the [unicorn-utterances/mc-datapacks-tutorial](https://github.com/unicorn-utterances/mc-datapacks-tutorial/tree/main/1-introduction) repository. Feel free to use it for reference as you read through these articles!
 
@@ -184,7 +184,7 @@ If you didn't use the same folder names, autocomplete should help you figure out
 
 # Specifying a function tag
 
-In order to run a function automatically, Minecraft provides two built-in [function tags](https://minecraft.fandom.com/wiki/Tag#Function_tags) that run during specific events: `load` (when the world is opened) and `tick` (every game tick).
+In order to run a function automatically, Minecraft provides two built-in [function tags](https://minecraft.wiki/w/Tag#Function_tags) that run during specific events: `load` (when the world is opened) and `tick` (every game tick).
 
 ## Using the "load" event
 

--- a/content/blog/minecraft-data-packs-introduction/index.md
+++ b/content/blog/minecraft-data-packs-introduction/index.md
@@ -3,7 +3,7 @@
 	title: "Minecraft Data Pack Programming: Introduction",
 	description: "Learn the beginnings of data pack development in Minecraft - using commands and functions to add custom behavior from scratch!",
 	published: '2022-06-14T21:12:03.284Z',
-	edited: '2023-09-12',
+	edited: '2023-09-27',
 	authors: ['fennifith'],
 	tags: [],
 	attached: [],

--- a/content/blog/minecraft-data-packs-scoreboards/index.md
+++ b/content/blog/minecraft-data-packs-scoreboards/index.md
@@ -3,6 +3,7 @@
 	title: "Minecraft Data Pack Programming: Scoreboard Usage",
 	description: "Learn data pack development in Minecraft - using player scoreboards, variables, and operations!",
 	published: '2022-08-20T19:10:03.284Z',
+	edited: '2023-09-27',
 	authors: ['fennifith'],
 	tags: [],
 	attached: [],

--- a/content/blog/minecraft-data-packs-scoreboards/index.md
+++ b/content/blog/minecraft-data-packs-scoreboards/index.md
@@ -12,7 +12,7 @@
 }
 ---
 
-> Please note: this guide specifically covers the **Java Edition** version of Minecraft. Bedrock Edition does not use data packs, but provides customization through [add-ons](https://minecraft.fandom.com/wiki/Add-on).
+> Please note: this guide specifically covers the **Java Edition** version of Minecraft. Bedrock Edition does not use data packs, but provides customization through [add-ons](https://minecraft.wiki/w/Add-on).
 
 The data packs built in this series can be found in the [unicorn-utterances/mc-datapacks-tutorial](https://github.com/unicorn-utterances/mc-datapacks-tutorial/tree/main/3-scoreboards) repository. Feel free to use it for reference as you read through these articles!
 
@@ -149,7 +149,7 @@ execute store result score $global_2 fennifith.animals_spawned run scoreboard pl
 
 > While this example will successfully copy our `$global` variable to `$global_2`, there is somewhat shorter way to achieve that using [scoreboard operations](#Scoreboard-operations)...
 
-It might not always be obvious what value a command returns as its "result", as this is sometimes different from what it prints in the game chat. However, all commands can be looked up on the [Minecraft wiki](https://minecraft.fandom.com/wiki/Commands) to see what values and behavior they should provide.
+It might not always be obvious what value a command returns as its "result", as this is sometimes different from what it prints in the game chat. However, all commands can be looked up on the [Minecraft wiki](https://minecraft.wiki/w/Commands) to see what values and behavior they should provide.
 
 ## Scoreboard operations
 
@@ -331,7 +331,7 @@ execute unless score $nonexistent fennifith.animals_spawned matches -2147483648.
 
 # Tracking statistics
 
-Scoreboards can also be created to track *game statistics*, such as the number of blocks mined or number of times an item has been used. These can be found in the game by opening the pause menu in any world or server and clicking the "Statistics" button — and the names used to reference them can be found [on the Minecraft wiki](https://minecraft.fandom.com/wiki/Scoreboard#Criteria).
+Scoreboards can also be created to track *game statistics*, such as the number of blocks mined or number of times an item has been used. These can be found in the game by opening the pause menu in any world or server and clicking the "Statistics" button — and the names used to reference them can be found [on the Minecraft wiki](https://minecraft.wiki/w/Scoreboard#Criteria).
 
 We can use any statistic as the second argument of `/scoreboard objectives add` when we create a new objective — for example:
 


### PR DESCRIPTION
As per https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom; the previous links are no longer maintained.