### PR TITLE
[UwU] Set scrollbar track background to transparent

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -17,7 +17,7 @@
 @import "./styles/utilities";
 
 :root {
-	scrollbar-color: var(--focus-outline_primary) var(--background_primary);
+	scrollbar-color: var(--focus-outline_primary) transparent;
 	transition: scrollbar-color $animStyle $animSpeed;
 
 	box-sizing: border-box;
@@ -53,7 +53,7 @@ h6 {
 }
 
 *::-webkit-scrollbar-track {
-	background: var(--background_primary);
+	background-color: transparent;
 	border-radius: 10px;
 }
 


### PR DESCRIPTION
This fixes situations where scrollbars are displayed on a container with a different background color and look out of place:

![2023-09-28-211840_909x192_scrot](https://github.com/unicorn-utterances/unicorn-utterances/assets/13000407/3d10ffe0-e2ff-4ec4-8475-cf815fb5bb2d)

Result:
![2023-09-28-212005_906x167_scrot](https://github.com/unicorn-utterances/unicorn-utterances/assets/13000407/4c6a5f97-06b6-48d5-adeb-766e850cdcf3)

Tested on Chrome & Firefox; might need testing on Safari.