### PR TITLE
[UwU] Various accessibility fixes

### DIFF
--- a/content/data/i18n/en.json
+++ b/content/data/i18n/en.json
@@ -23,7 +23,7 @@
 	"action.search_for": "Search for...",
 	"action.view_all_chapters": "View all %s chapters",
 	"action.view_less_chapters": "View less chapters",
-	"action.is_dark_mode_enabled": "Is dark mode enabled?",
+	"label.toggle_dark_mode": "Toggle dark mode",
 	"alt.unicorn_utterances_logo": "Smiling cartoon unicorn with a bowtie",
 	"title.looking_for_more": "Looking for more?",
 	"desc.looking_for_more": "Search for your favorite framework or most loved language; we'll share what we know."

--- a/src/components/related-posts/related-posts.astro
+++ b/src/components/related-posts/related-posts.astro
@@ -17,11 +17,13 @@ const { post, headingId } = Astro.props as RelatedPostsProps;
 <ul class={style.suggestedPostList}>
 	{
 		post.suggestedArticles.map((suggestedPost) => (
-			<RelatedPostsCard
-				title={suggestedPost.title}
-				slug={suggestedPost.slug}
-				authors={suggestedPost.authorsMeta.map((author) => author.name)}
-			/>
+			<li>
+				<RelatedPostsCard
+					title={suggestedPost.title}
+					slug={suggestedPost.slug}
+					authors={suggestedPost.authorsMeta.map((author) => author.name)}
+				/>
+			</li>
 		))
 	}
 </ul>

--- a/src/components/search-section/search-section.astro
+++ b/src/components/search-section/search-section.astro
@@ -37,7 +37,11 @@ const tagsToDisplay = [...data.tags]
 		</IconOnlyButton>
 	</form>
 
-	<ul class="unlist-inline gap-2 text-center">
+	<ul
+		class="unlist-inline gap-2 text-center"
+		aria-label="Post tags"
+		role="list"
+	>
 		{
 			tagsToDisplay.map((tag) => (
 				<li>

--- a/src/views/base/navigation/dark-light-button/dark-light-button.astro
+++ b/src/views/base/navigation/dark-light-button/dark-light-button.astro
@@ -8,7 +8,7 @@ import { translate } from "utils/translations";
 	tag="button"
 	id="theme-toggle-button"
 	aria-pressed="false"
-	aria-label={translate(Astro, "action.is_dark_mode_enabled")}
+	aria-label={translate(Astro, "label.toggle_dark_mode")}
 >
 	<Icon name="dark_mode" height="100%" width="100%" id="dark-icon" />
 	<Icon

--- a/src/views/search/components/filter-section-item.tsx
+++ b/src/views/search/components/filter-section-item.tsx
@@ -56,7 +56,7 @@ export const FilterSectionItem = ({
 					<span className={`text-style-body-small-bold ${style.label}`}>
 						{label}
 					</span>
-					<span className={`text-style-body-small-bold ${style.count}`}>
+					<span className={`text-style-body-small-bold ${style.count}`} aria-label={`${count} post${count > 1 ? 's' : ''}`}>
 						{count}
 					</span>
 					{children}

--- a/src/views/search/components/filter-section.tsx
+++ b/src/views/search/components/filter-section.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from "components/types";
-import { useState } from "preact/hooks";
+import { useState, useRef } from "preact/hooks";
 import { useElementSize } from "../../../hooks/use-element-size";
 import styles from "./filter-section.module.scss";
 import { Chip } from "components/chip/chip";
@@ -36,6 +36,15 @@ export const FilterSection = ({
 		target.classList.remove("scrolled");
 	};
 
+	// When cleared, the focus needs to be passed to the heading button
+	// to avoid resetting to <body> when the clear button is removed from the DOM.
+	// https://github.com/unicorn-utterances/unicorn-utterances/issues/742
+	const buttonRef = useRef();
+	const handleClear = (e: Event) => {
+		onClear();
+		buttonRef.current?.focus();
+	};
+
 	return (
 		<div
 			{...props}
@@ -52,6 +61,7 @@ export const FilterSection = ({
 					}}
 					aria-expanded={!collapsed}
 					onClick={() => setCollapsed(!collapsed)}
+					ref={buttonRef}
 				>
 					<span
 						className={`${styles.collapseIcon} ${
@@ -75,7 +85,7 @@ export const FilterSection = ({
 							tag="button"
 							type="button"
 							className={styles.clearChip}
-							onClick={onClear}
+							onClick={handleClear}
 						>
 							Clear
 						</Chip>

--- a/src/views/search/components/filter-section.tsx
+++ b/src/views/search/components/filter-section.tsx
@@ -39,10 +39,12 @@ export const FilterSection = ({
 	// When cleared, the focus needs to be passed to the heading button
 	// to avoid resetting to <body> when the clear button is removed from the DOM.
 	// https://github.com/unicorn-utterances/unicorn-utterances/issues/742
-	const buttonRef = useRef();
-	const handleClear = (e: Event) => {
+	const buttonRef = useRef<HTMLButtonElement>();
+	const handleClear = () => {
 		onClear();
-		buttonRef.current?.focus();
+
+		if (typeof buttonRef.current !== "undefined")
+			buttonRef.current?.focus();
 	};
 
 	return (

--- a/src/views/search/search-page.tsx
+++ b/src/views/search/search-page.tsx
@@ -420,7 +420,7 @@ function SearchPageBase({ unicornProfilePicMap }: SearchPageProps) {
 						</div>
 					</>
 				)}
-				<div aria-live="assertive" aria-atomic="true">
+				<div aria-live="polite" aria-atomic="true">
 					{!isError && !isContentLoading && noResults && (
 						<SearchHero
 							imageSrc={sadUnicorn.src}


### PR DESCRIPTION
Fixes most of the smaller a11y issues that could fit in a single PR:

- Clarify the "toggle dark mode" button label (#735)
- Fix `<li>` elements missing from the related posts list (#737)
- Adds the "Post tags" label missing from the search section tag list (#740)
- Move focus to the search filter heading button when the "Clear" button is pressed (#742)
- Describe search filter post counts with an aria-label (#743)
- Use aria-live `polite` instead of `assertive` on the search status message (#744)