### PR TITLE
[UwU] Fix code block contrast & tabindex issues

### DIFF
--- a/src/styles/shiki.scss
+++ b/src/styles/shiki.scss
@@ -63,7 +63,7 @@ Code blocks structurally look like:
 	--shiki-token-punctuation: #24292e;
 	--shiki-token-link: #24292e;
 
-	--shiki_padding: 12px;;
+	--shiki_padding: 12px;
 
 	@include darkTheme {
 		--shiki-color-text: #e1e4e8;

--- a/src/styles/shiki.scss
+++ b/src/styles/shiki.scss
@@ -104,7 +104,6 @@ pre.shiki div.line {
 	// must be the same value as used for line-height
 	min-height: 1.7em;
 	padding: 0 var(--shiki_padding);
-	border-top: 1px solid transparent;
 }
 pre.shiki div.highlight {
 	font-weight: bold;
@@ -112,11 +111,11 @@ pre.shiki div.highlight {
 }
 
 pre.shiki div:not(.highlight) + div.highlight {
-	border-top: 1px dashed var(--primary_default);
+	border-top: 2px dashed var(--primary_default);
 }
 
 pre.shiki div.highlight + div:not(.highlight) {
-	border-top: 1px dashed var(--primary_default);
+	border-top: 2px dashed var(--primary_default);
 }
 
 /** Don't show the language identifiers */

--- a/src/styles/shiki.scss
+++ b/src/styles/shiki.scss
@@ -22,11 +22,16 @@ pre code .line::before {
 	// Otherwise, the first tab is offset by the width of the line counter,
 	// leading to inconsistent tab alignment.
 	position: absolute;
-	left: 0;
+	left: var(--shiki_padding);
 	width: 1rem;
 	display: inline-block;
 	text-align: right;
 	color: rgba(115, 138, 148, 0.4);
+	color: var(--foreground_emphasis-low);
+}
+
+pre code .line.highlight::before {
+	color: var(--foreground_emphasis-medium);
 }
 
 /*  Start of Shiki Twoslash CSS:
@@ -58,6 +63,8 @@ Code blocks structurally look like:
 	--shiki-token-punctuation: #24292e;
 	--shiki-token-link: #24292e;
 
+	--shiki_padding: 12px;;
+
 	@include darkTheme {
 		--shiki-color-text: #e1e4e8;
 		--shiki-color-background: #24292e;
@@ -82,29 +89,34 @@ pre {
 
 pre .code-container {
 	/* Give it some space to breathe */
-	padding: 12px;
+	padding: var(--shiki_padding) 0;
+	display: flex;
+
+	code {
+		flex-grow: 1;
+	}
 }
+
 pre.shiki {
 	overflow-x: auto;
-}
-pre.shiki:hover .dim {
-	opacity: 1;
-}
-pre.shiki div.dim {
-	opacity: 0.5;
-}
-pre.shiki div.dim,
-pre.shiki div.highlight {
-	margin: 0;
-	padding: 0;
-}
-pre.shiki div.highlight {
-	opacity: 1;
-	background-color: var(--surface_primary_emphasis-none);
 }
 pre.shiki div.line {
 	// must be the same value as used for line-height
 	min-height: 1.7em;
+	padding: 0 var(--shiki_padding);
+	border-top: 1px solid transparent;
+}
+pre.shiki div.highlight {
+	font-weight: bold;
+	background-color: var(--surface_primary_emphasis-none);
+}
+
+pre.shiki div:not(.highlight) + div.highlight {
+	border-top: 1px dashed var(--primary_default);
+}
+
+pre.shiki div.highlight + div:not(.highlight) {
+	border-top: 1px dashed var(--primary_default);
 }
 
 /** Don't show the language identifiers */

--- a/src/utils/markdown/index.ts
+++ b/src/utils/markdown/index.ts
@@ -19,6 +19,7 @@ import {
 import { rehypeFixTwoSlashXHTML } from "./rehype-fix-twoslash-xhtml";
 import { rehypeHeaderText } from "./rehype-header-text";
 import { rehypeFileTree } from "./file-tree/rehype-file-tree";
+import { rehypeTwoslashTabindex } from "./twoslash-tabindex/rehype-transform";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type RehypePlugin = Plugin<any[]> | [Plugin<any[]>, any];
@@ -60,6 +61,7 @@ export function createRehypePlugins(config: MarkdownConfig): RehypePlugin[] {
 					rehypeUnicornIFrameClickToRun,
 					rehypeHeadingLinks,
 					rehypeUnicornElementMap,
+					rehypeTwoslashTabindex,
 			  ]
 			: []),
 		...(config.format === "html"

--- a/src/utils/markdown/twoslash-tabindex/rehype-transform.ts
+++ b/src/utils/markdown/twoslash-tabindex/rehype-transform.ts
@@ -7,10 +7,13 @@ export const rehypeTwoslashTabindex: Plugin<[], Root> = () => {
 		visit(tree, (node: Element) => {
 			if (
 				node.tagName === "div" &&
-				node.properties.class === "code-container"
+				node.properties.className instanceof Array &&
+				node.properties.className.includes("code-container")
 			) {
 				node.properties.tabindex = "0";
 			}
 		});
+
+		return tree;
 	};
 };

--- a/src/utils/markdown/twoslash-tabindex/rehype-transform.ts
+++ b/src/utils/markdown/twoslash-tabindex/rehype-transform.ts
@@ -1,0 +1,16 @@
+import { Root, Element } from "hast";
+import { Plugin } from "unified";
+import { visit } from "unist-util-visit";
+
+export const rehypeTwoslashTabindex: Plugin<[], Root> = () => {
+	return async (tree, _) => {
+		visit(tree, (node: Element) => {
+			if (
+				node.tagName === "div" &&
+				node.properties.class === "code-container"
+			) {
+				node.properties.tabindex = "0";
+			}
+		});
+	};
+};

--- a/src/utils/markdown/twoslash-tabindex/twoslash-tabindex-script.ts
+++ b/src/utils/markdown/twoslash-tabindex/twoslash-tabindex-script.ts
@@ -1,0 +1,25 @@
+/**
+ * Scrollable code-container blocks should have tabindex="0" for keyboard accessibility.
+ *
+ * These are added in rehype-transform, but can be removed with JS on elements that
+ * cannot be horizontally scrolled.
+ *
+ * https://github.com/unicorn-utterances/unicorn-utterances/issues/738
+ */
+export const enableTwoslashTabindex = () => {
+	const codeContainerEls = document.querySelectorAll("div.code-container");
+
+	const handleResize = () => {
+		codeContainerEls.forEach((el) => {
+			const canScroll = el.scrollWidth > el.clientWidth;
+			if (canScroll) {
+				el.setAttribute("tabindex", "0");
+			} else {
+				el.removeAttribute("tabindex");
+			}
+		});
+	};
+
+	handleResize();
+	window.addEventListener("resize", handleResize);
+};

--- a/src/views/blog-post/blog-post.astro
+++ b/src/views/blog-post/blog-post.astro
@@ -57,6 +57,10 @@ if (post.collection && post.order) {
 	enableTabs();
 </script>
 <script>
+	import { enableTwoslashTabindex } from "../../utils/markdown/twoslash-tabindex/twoslash-tabindex-script";
+	enableTwoslashTabindex();
+</script>
+<script>
 	import { enableStickyObserver } from "../../utils/sticky-observer-script";
 	enableStickyObserver();
 </script>


### PR DESCRIPTION
- Removes the `opacity: 0.5;` styling for non-highlighted parts of code blocks
  * Instead, highlighted sections are bold + bordered
  * #739
- Fixes other code block styling issues (highlighted lines not expanding to the full code block width when scrollable)
- #738
  * Adds a rehype transform to add `tabindex="0"` on any `div.code-container`
  * Adds a script that sets `tabindex="0"` only if the `div.code-container` is horizontally scrollable