### PR TITLE
[UwU] Fix button outline styling to match spec

### DIFF
--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -88,11 +88,10 @@
 	white-space: nowrap;
 	text-decoration: none;
 	border: none;
-	outline: none !important;
 	cursor: pointer;
 	box-sizing: border-box;
 
-	@include transition(color background-color box-shadow);
+	@include transition(color background-color);
 }
 
 .button.regular {
@@ -172,8 +171,8 @@
 
 	&:focus-visible,
 	&.focusVisible {
-		box-shadow: 0 0 0 var(--btn_primary_focus-outline_width)
-			var(--btn_primary_focus-oultine_color);
+		outline: var(--btn_primary_focus-outline_width) solid var(--btn_primary_focus-oultine_color);
+		outline-offset: var(--btn_primary_focus-outline_gap);
 	}
 
 	&:active {
@@ -191,8 +190,8 @@
 
 	&:focus-visible,
 	&.focusVisible {
-		box-shadow: 0 0 0 var(--btn_secondary_focus-outline_width)
-			var(--btn_secondary_focus-oultine_color);
+		outline: var(--btn_secondary_focus-outline_width) solid var(--btn_secondary_focus-oultine_color);
+		outline-offset: var(--btn_secondary_focus-outline_gap);
 	}
 
 	&:active {
@@ -210,8 +209,8 @@
 
 	&:focus-visible,
 	&.focusVisible {
-		box-shadow: 0 0 0 var(--btn_primary_focus-outline_width)
-			var(--btn_primary_focus-oultine_color);
+		outline: var(--btn_primary_focus-outline_width) solid var(--btn_primary_focus-oultine_color);
+		outline-offset: var(--btn_primary_focus-outline_gap);
 	}
 
 	&:active {
@@ -229,8 +228,8 @@
 
 	&:focus-visible,
 	&.focusVisible {
-		box-shadow: 0 0 0 var(--btn_secondary_focus-outline_width)
-			var(--btn_secondary_focus-oultine_color);
+		outline: var(--btn_secondary_focus-outline_width) solid var(--btn_secondary_focus-oultine_color);
+		outline-offset: var(--btn_secondary_focus-outline_gap);
 	}
 
 	&:active {

--- a/src/views/search/components/filter-sidebar.module.scss
+++ b/src/views/search/components/filter-sidebar.module.scss
@@ -13,8 +13,8 @@
 	padding-left: var(--search-page_filter_sidebar_padding-start);
 
 	// ensure the minimum padding to not clip focus states (#666)
-	padding-right: calc(var(--search-page_filter_sidebar_padding-end) + var(--spc-1x));
-	margin-right: calc(-1 * var(--spc-1x));
+	padding-right: calc(var(--search-page_filter_sidebar_padding-end) + var(--spc-2x));
+	margin-right: calc(-1 * var(--spc-2x));
 
 	flex-basis: 100%;
 


### PR DESCRIPTION
Button focus states were previously implemented with `box-shadow`, which did not match the specs. Implementing with `outline-offset` separates the outline from the button background to maintain contrast.

- Fixes #736 
- Doubles the negative sidebar margin/padding on the search page to accommodate the increased outline size