### PR TITLE
[UwU] Fix invalid <Select> popover IDs

### DIFF
--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -135,6 +135,11 @@ function ListBox(props: ListBoxProps) {
 	const { listBoxRef = ref, state } = props;
 	const { listBoxProps } = useListBox(props, state, listBoxRef);
 
+	// As this is inside a portal (within <Popover>), nothing from Preact's useId can be trusted
+	// ...but nothing should be using these IDs anyway.
+	listBoxProps["id"] = undefined;
+	listBoxProps["aria-labelledby"] = undefined;
+
 	return (
 		<ul {...listBoxProps} ref={listBoxRef} class={styles.optionsList}>
 			{[...state.collection].map((item) => (
@@ -158,6 +163,11 @@ export function Option({ item, state }: OptionProps) {
 		state,
 		ref,
 	);
+
+	// As this is inside a portal (within <Popover>), nothing from Preact's useId can be trusted
+	// ...but nothing should be using these IDs anyway.
+	optionProps["aria-labelledby"] = undefined;
+	optionProps["aria-describedby"] = undefined;
 
 	return (
 		<li


### PR DESCRIPTION
- Removes `id`, `aria-labelledby`, and `aria-describedby` attributes from the props returned from `react-aria` within its `<Popover>` component
  #741 