### PR TITLE
[UwU] Remove duplicate homepage links

### DIFF
--- a/content/data/i18n/en.json
+++ b/content/data/i18n/en.json
@@ -30,6 +30,7 @@
 	"action.search_for": "Search for...",
 	"action.view_all_chapters": "View all %s chapters",
 	"action.view_less_chapters": "View less chapters",
+	"action.switch_theme": "Switch theme",
 	"label.toggle_dark_mode": "Toggle dark mode",
 	"alt.unicorn_utterances_logo": "Smiling cartoon unicorn with a bowtie",
 	"title.looking_for_more": "Looking for more?",

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -148,13 +148,19 @@ for (const key of i18n.en?.keys() || []) {
 	}
 }
 
+type TranslationKey = keyof typeof import("../../content/data/i18n/en.json");
+
 /**
  * Translate a key into the associated value, according to /data/i18n
  *
  * If the key is untranslated, returns the "en" value and logs a warning.
  * If the key is entirely missing, throws an error.
  */
-export function translate(astro: { url: URL }, key: string, ...args: string[]) {
+export function translate(
+	astro: { url: URL },
+	key: TranslationKey,
+	...args: string[]
+) {
 	const lang = getPrefixLanguageFromPath(astro.url.pathname);
 	let value = i18n[lang]?.get(key);
 

--- a/src/views/base/navigation/dark-light-button/dark-light-button.astro
+++ b/src/views/base/navigation/dark-light-button/dark-light-button.astro
@@ -1,25 +1,64 @@
 ---
 import { Icon } from "astro-icon";
-import { IconOnlyButton } from "components/index";
+import { Button, IconOnlyButton } from "components/index";
 import { translate } from "utils/translations";
+
+const props = Astro.props as {
+	variant: "iconOnly" | "large";
+	class?: string;
+};
 ---
 
-<IconOnlyButton
-	tag="button"
-	id="theme-toggle-button"
-	aria-pressed="false"
-	aria-label={translate(Astro, "label.toggle_dark_mode")}
->
-	<Icon name="dark_mode" height="100%" width="100%" id="dark-icon" />
-	<Icon
-		name="light_mode"
-		height="100%"
-		width="100%"
-		id="light-icon"
-		style="display: none;"
-	/>
-</IconOnlyButton>
-
+{
+	props.variant === "iconOnly" ? (
+		<IconOnlyButton
+			tag="button"
+			data-theme-toggle
+			aria-pressed="false"
+			aria-label={translate(Astro, "label.toggle_dark_mode")}
+			class={props.class}
+		>
+			<Icon
+				name="dark_mode"
+				height="100%"
+				width="100%"
+				data-theme-toggle-icon="dark"
+			/>
+			<Icon
+				name="light_mode"
+				height="100%"
+				width="100%"
+				data-theme-toggle-icon="light"
+				style="display: none;"
+			/>
+		</IconOnlyButton>
+	) : (
+		<Button
+			tag="button"
+			data-theme-toggle
+			aria-pressed="false"
+			aria-label={translate(Astro, "label.toggle_dark_mode")}
+			class={props.class}
+		>
+			<Icon
+				slot="leftIcon"
+				name="dark_mode"
+				height="100%"
+				width="100%"
+				data-theme-toggle-icon="dark"
+			/>
+			<Icon
+				slot="leftIcon"
+				name="light_mode"
+				height="100%"
+				width="100%"
+				data-theme-toggle-icon="light"
+				style="display: none;"
+			/>
+			{translate(Astro, "action.switch_theme")}
+		</Button>
+	)
+}
 <script>
 	import { themeToggle } from "./theme-toggle";
 	themeToggle();

--- a/src/views/base/navigation/dark-light-button/theme-toggle.ts
+++ b/src/views/base/navigation/dark-light-button/theme-toggle.ts
@@ -5,21 +5,24 @@ import {
 } from "constants/theme";
 
 export const themeToggle = () => {
-	const themeToggleBtn: HTMLElement = document.querySelector(
-		"#theme-toggle-button",
+	const themeToggleBtns = document.querySelectorAll<HTMLButtonElement>(
+		"[data-theme-toggle]",
 	);
-	if (!themeToggleBtn) return;
-	const darkIconEl: HTMLElement = document.querySelector("#dark-icon");
-	const lightIconEl: HTMLElement = document.querySelector("#light-icon");
+
+	const darkIconEls = document.querySelectorAll<HTMLElement>(
+		"[data-theme-toggle-icon='dark']",
+	);
+	const lightIconEls = document.querySelectorAll<HTMLElement>(
+		"[data-theme-toggle-icon='light']",
+	);
 	function toggleButton(theme) {
-		themeToggleBtn.ariaPressed = `${theme === "dark"}`;
-		if (theme === "light") {
-			lightIconEl.style.display = null;
-			darkIconEl.style.display = "none";
-		} else {
-			lightIconEl.style.display = "none";
-			darkIconEl.style.display = null;
-		}
+		themeToggleBtns.forEach((el) => (el.ariaPressed = `${theme === "dark"}`));
+		lightIconEls.forEach((el) => {
+			el.style.display = theme === "light" ? null : "none";
+		});
+		darkIconEls.forEach((el) => {
+			el.style.display = theme === "light" ? "none" : null;
+		});
 
 		// update the meta theme-color attribute(s) based on the user preference
 		const bgColor = theme === "light" ? THEME_COLOR_LIGHT : THEME_COLOR_DARK;
@@ -32,7 +35,8 @@ export const themeToggle = () => {
 	// TODO: Migrate to `classList`
 	const initialTheme = document.documentElement.className;
 	toggleButton(initialTheme);
-	themeToggleBtn.addEventListener("click", () => {
+
+	const handleClick = () => {
 		const currentTheme = document.documentElement.className;
 		document.documentElement.className =
 			currentTheme === "light" ? "dark" : "light";
@@ -40,5 +44,7 @@ export const themeToggle = () => {
 		const newTheme = document.documentElement.className;
 		toggleButton(newTheme);
 		localStorage.setItem(COLOR_MODE_STORAGE_KEY, newTheme);
-	});
+	};
+
+	themeToggleBtns.forEach((el) => el.addEventListener("click", handleClick));
 };

--- a/src/views/base/navigation/header.astro
+++ b/src/views/base/navigation/header.astro
@@ -44,7 +44,7 @@ const props = Astro.props as {
 
 		<div class={`d-flex ${style.nav}`}>
 			{
-				!isAbout && (
+				!isHome && !isAbout && (
 					<Button href="/about" variant="primary">
 						{translate(Astro, "title.about_us")}
 					</Button>
@@ -73,28 +73,42 @@ const props = Astro.props as {
 				]
 			}
 
-			<Button
-				href={data.about.links.Discord.url}
-				aria-label={translate(Astro, "action.join_discord")}
-				class={style.discordLarge}
-			>
-				<Icon
-					slot="leftIcon"
-					height="100%"
-					width="100%"
-					name={data.about.links.Discord.icon}
-				/>
-				{translate(Astro, "action.join_discord")}
-			</Button>
-			<IconOnlyButton
-				href={data.about.links.Discord.url}
-				aria-label={translate(Astro, "action.join_discord")}
-				class={style.discordSmall}
-			>
-				<Icon height="100%" width="100%" name={data.about.links.Discord.icon} />
-			</IconOnlyButton>
+			{
+				!isHome && [
+					<Button
+						href={data.about.links.Discord.url}
+						aria-label={translate(Astro, "action.join_discord")}
+						class={style.discordLarge}
+					>
+						<Icon
+							slot="leftIcon"
+							height="100%"
+							width="100%"
+							name={data.about.links.Discord.icon}
+						/>
+						{translate(Astro, "action.join_discord")}
+					</Button>,
 
-			<DarkLightButton />
+					<IconOnlyButton
+						href={data.about.links.Discord.url}
+						aria-label={translate(Astro, "action.join_discord")}
+						class={style.discordSmall}
+					>
+						<Icon
+							height="100%"
+							width="100%"
+							name={data.about.links.Discord.icon}
+						/>
+					</IconOnlyButton>,
+				]
+			}
+
+			{
+				isHome ? (
+					<DarkLightButton variant="large" class={style.themeToggleLarge} />
+				) : undefined
+			}
+			<DarkLightButton variant="iconOnly" class={style.themeToggleSmall} />
 		</div>
 	</nav>
 </header>

--- a/src/views/base/navigation/header.module.scss
+++ b/src/views/base/navigation/header.module.scss
@@ -10,7 +10,7 @@
 	--header_end-items_max-width: var(--max-width_xxs);
 
 	@include from($desktopSmall) {
-		--header_end-items_max-width: var(--max-width_s);
+		--header_end-items_max-width: calc(var(--max-width_l) / 2 - var(--site-spacing) * 1.5);
 		--header_logo_size: 56px;
 	}
 }
@@ -110,6 +110,10 @@
 		min-width: 0;
 	}
 
+	.themeToggleLarge {
+		display: none;
+	}
+
 	@include from($tabletLarge) {
 		.searchSmall {
 			display: none;
@@ -137,6 +141,14 @@
 
 		.discordLarge {
 			display: flex;
+		}
+
+		.themeToggleLarge {
+			display: flex;
+		}
+
+		.themeToggleLarge + .themeToggleSmall {
+			display: none;
 		}
 	}
 }


### PR DESCRIPTION
- Removes "Join our Discord" header link on the homepage
- Removes "About us" header link on the homepage (duplicated by "Learn more")
- Fixes the `--header_end-items_max-width` token to align the header items with the page content
- Adds a large theme toggle variant (with "Switch theme" text) on the homepage to make up for the lack of space