### PR TITLE
[UwU] Fix replaced achievement button span

### DIFF
--- a/src/views/unicorn/unicorn-page.astro
+++ b/src/views/unicorn/unicorn-page.astro
@@ -96,9 +96,11 @@ const showPostsToggle = posts.length > postsToDisplay.length;
 </div>
 
 <script>
-	const viewAllAchievementsButton = document.getElementById(
-		"view-all-achievements",
-	) as HTMLElement;
+	const viewAllAchievementsButton: HTMLElement = document.querySelector(
+		"#view-all-achievements",
+	);
+	const viewAllAchievementsText: HTMLElement =
+		viewAllAchievementsButton.querySelector(".innerText");
 
 	if (viewAllAchievementsButton) {
 		const hiddenAchievements: HTMLElement[] = Array.from(
@@ -113,14 +115,14 @@ const showPostsToggle = posts.length > postsToDisplay.length;
 				hiddenAchievements.forEach((achievement) => {
 					achievement.style.display = "";
 				});
-				viewAllAchievementsButton.innerText = "View less";
+				viewAllAchievementsText.innerText = "View less";
 				return;
 			}
 
 			hiddenAchievements.forEach((achievement) => {
 				achievement.style.display = "none";
 			});
-			viewAllAchievementsButton.innerText = "View all";
+			viewAllAchievementsText.innerText = "View all";
 		});
 	}
 </script>


### PR DESCRIPTION
- Sets the button's inner `<span>` text instead of the button `innerText` to avoid overwriting its `<span>` element. Fixes #797