### PR TITLE
[UwU] Fix pagination popup hydration order

### DIFF
--- a/src/components/pagination/pagination.tsx
+++ b/src/components/pagination/pagination.tsx
@@ -56,7 +56,9 @@ function PaginationMenuWrapper(
 		setShouldRender(true);
 	});
 
-	if (!shouldRender) return null;
+	// if this is a static render, this still needs to return an <li> node so that
+	// it hydrates in the correct order
+	if (!shouldRender) return <li hidden></li>;
 
 	return <PaginationMenuAndPopover {...props} />;
 }
@@ -102,6 +104,7 @@ export const Pagination = ({
 					{pages.map((pageNum) => {
 						return typeof pageNum === "number" ? (
 							<PaginationButton
+								key={pageNum}
 								pageInfo={page}
 								pageNum={pageNum}
 								selected={pageNum === page.currentPage}
@@ -110,6 +113,7 @@ export const Pagination = ({
 							/>
 						) : (
 							<PaginationMenuWrapper
+								key={pageNum}
 								page={page}
 								getPageHref={getPageHref}
 								softNavigate={softNavigate}

--- a/src/views/explore/page.astro
+++ b/src/views/explore/page.astro
@@ -23,4 +23,10 @@ const unicornProfilePicMap = await getUnicornProfilePicMap();
 	unicornProfilePicMap={unicornProfilePicMap}
 />
 
-<Pagination page={page} client:load />
+{
+	/* We shouldn't pass the whole "page" object here, as this generates a huge JSON attribute for hydration */
+}
+<Pagination
+	page={{ currentPage: page.currentPage, lastPage: page.lastPage }}
+	client:load
+/>


### PR DESCRIPTION
- Changes the `<PaginationMenuWrapper>` behavior to return an `<li hidden>` in its default case so that it hydrates in the correct order
- Specifies prop keys to avoid generating a huge JSON object for the pagination in the HTML

Fixes #807 
