### PR TITLE
[UwU] Conditionally hide TOC

### DIFF
--- a/src/views/blog-post/blog-post-layout/blog-post-layout.astro
+++ b/src/views/blog-post/blog-post-layout/blog-post-layout.astro
@@ -1,8 +1,14 @@
 ---
 import style from "./blog-post-layout.module.scss";
+
+interface BlogPostLayoutProps {
+	hideLeftSidebar?: boolean;
+}
+
+const { hideLeftSidebar } = Astro.props as BlogPostLayoutProps;
 ---
 
-<article class={style.container}>
+<article class={style.container} data-hide-left-sidebar={hideLeftSidebar}>
 	<div class={style.header}>
 		<slot name="header" />
 	</div>

--- a/src/views/blog-post/blog-post-layout/blog-post-layout.module.scss
+++ b/src/views/blog-post/blog-post-layout/blog-post-layout.module.scss
@@ -5,10 +5,13 @@
 	grid-template-columns: 0fr 1fr;
 	width: 100%;
 	max-width: var(--max-width_xl);
-    margin: 0 auto;
+	margin: 0 auto;
+	justify-items: center;
 
-	@include from($tabletLarge) {
-		grid-template-columns: 25% 1fr;
+	&:not([data-hide-left-sidebar]) {
+		@include from($tabletLarge) {
+			grid-template-columns: 25% 1fr;
+		}
 	}
 
 	@include from($desktopSmall) {
@@ -19,6 +22,7 @@
 .header {
 	grid-column: 2;
 	max-width: var(--max-width_m);
+	width: 100%;
 	min-width: 1px;
 	padding: var(--site-spacing);
 	padding-bottom: 0;
@@ -27,6 +31,7 @@
 .content {
 	grid-column: 2;
 	max-width: var(--max-width_m);
+	width: 100%;
 	min-width: 1px;
 	padding: var(--site-spacing);
 	padding-top: 0;
@@ -49,7 +54,9 @@
 
 	position: sticky;
 
-	$headerSize: calc(var(--header_logo_size) + var(--header_padding-vertical)*2 + 1px);
+	$headerSize: calc(
+		var(--header_logo_size) + var(--header_padding-vertical) * 2 + 1px
+	);
 	top: $headerSize;
 	max-height: calc(100vh - $headerSize);
 

--- a/src/views/blog-post/blog-post.astro
+++ b/src/views/blog-post/blog-post.astro
@@ -72,9 +72,13 @@ if (post.collection && post.order) {
 <HeadingLinkScript />
 
 <main>
-	<BlogPostLayout>
+	<BlogPostLayout hideLeftSidebar={!post.headingsWithId?.length}>
 		<PostTitleHeader slot="header" post={post} />
-		<TableOfContents slot="left" headingsWithId={post.headingsWithId} />
+		{
+			post.headingsWithId?.length ? (
+				<TableOfContents slot="left" headingsWithId={post.headingsWithId} />
+			) : null
+		}
 		<section
 			class="post-body"
 			data-testid="post-body-div"


### PR DESCRIPTION
This PR fixes an issue of empty space when there are no headings to display in the TOC

# Before

## Desktop

<img width="1218" alt="image" src="https://github.com/unicorn-utterances/unicorn-utterances/assets/9100169/a1ffe6f6-8f01-4f49-8775-59d0ea0d407f">

## Tablet Large

<img width="627" alt="image" src="https://github.com/unicorn-utterances/unicorn-utterances/assets/9100169/65064da4-041f-46a3-9c00-7c0ae3b306a5">

# After

## Desktop
<img width="1085" alt="image" src="https://github.com/unicorn-utterances/unicorn-utterances/assets/9100169/186b7fc9-5dc9-444c-9683-101bd27b15f7">


## Tablet Large
<img width="619" alt="image" src="https://github.com/unicorn-utterances/unicorn-utterances/assets/9100169/cc313b04-2ad4-4434-a852-bafc165600a9">

