### PR TITLE
[UwU] Fix series heading behaving as a "copy link" target

### DIFF
--- a/src/views/blog-post/blog-post-layout/blog-post-layout.module.scss
+++ b/src/views/blog-post/blog-post-layout/blog-post-layout.module.scss
@@ -7,7 +7,7 @@
 	max-width: var(--max-width_xl);
 	margin: 0 auto;
 
-	&:not([data-hide-left-sidebar]) {
+	&:where(:not([data-hide-left-sidebar])) {
 		@include from($tabletLarge) {
 			grid-template-columns: 25% 1fr;
 		}

--- a/src/views/blog-post/blog-post-layout/blog-post-layout.module.scss
+++ b/src/views/blog-post/blog-post-layout/blog-post-layout.module.scss
@@ -5,6 +5,20 @@
 	grid-template-columns: 0fr 1fr;
 	width: 100%;
 	max-width: var(--max-width_xl);
+	margin: 0 auto;
+
+	&:not([data-hide-left-sidebar]) {
+		@include from($tabletLarge) {
+			grid-template-columns: 25% 1fr;
+		}
+	}
+
+	// in tablet view, when the sidebar is hidden, the "content" column needs to be centered
+	&[data-hide-left-sidebar] {
+		@include until($desktopSmall) {
+			max-width: var(--max-width_m);
+		}
+	}
 
 	@include from($desktopSmall) {
 		grid-template-columns: 25% 1fr 25%;

--- a/src/views/blog-post/blog-post-layout/blog-post-layout.module.scss
+++ b/src/views/blog-post/blog-post-layout/blog-post-layout.module.scss
@@ -5,14 +5,6 @@
 	grid-template-columns: 0fr 1fr;
 	width: 100%;
 	max-width: var(--max-width_xl);
-	margin: 0 auto;
-	justify-items: center;
-
-	&:not([data-hide-left-sidebar]) {
-		@include from($tabletLarge) {
-			grid-template-columns: 25% 1fr;
-		}
-	}
 
 	@include from($desktopSmall) {
 		grid-template-columns: 25% 1fr 25%;
@@ -22,7 +14,6 @@
 .header {
 	grid-column: 2;
 	max-width: var(--max-width_m);
-	width: 100%;
 	min-width: 1px;
 	padding: var(--site-spacing);
 	padding-bottom: 0;
@@ -31,7 +22,6 @@
 .content {
 	grid-column: 2;
 	max-width: var(--max-width_m);
-	width: 100%;
 	min-width: 1px;
 	padding: var(--site-spacing);
 	padding-top: 0;

--- a/src/views/blog-post/blog-post.astro
+++ b/src/views/blog-post/blog-post.astro
@@ -73,20 +73,7 @@ if (post.collection && post.order) {
 
 <main>
 	<BlogPostLayout hideLeftSidebar={!post.headingsWithId?.length}>
-		<PostTitleHeader slot="header" post={post} />
-		{
-			post.headingsWithId?.length ? (
-				<TableOfContents slot="left" headingsWithId={post.headingsWithId} />
-			) : null
-		}
-		<section
-			class="post-body"
-			data-testid="post-body-div"
-			aria-labelledby="blog-post-contents"
-		>
-			<h2 id="blog-post-contents" class="visually-hidden" data-no-heading-link>
-				Post contents
-			</h2>
+		<PostTitleHeader slot="header" post={post}>
 			{
 				post.collection ? (
 					<SeriesToC
@@ -101,6 +88,20 @@ if (post.collection && post.order) {
 					<TranslationsHeader locales={post.locales} />
 				) : null
 			}
+		</PostTitleHeader>
+		{
+			post.headingsWithId?.length ? (
+				<TableOfContents slot="left" headingsWithId={post.headingsWithId} />
+			) : null
+		}
+		<section
+			class="post-body"
+			data-testid="post-body-div"
+			aria-labelledby="blog-post-contents"
+		>
+			<h2 id="blog-post-contents" class="visually-hidden" data-no-heading-link>
+				Post contents
+			</h2>
 			<Content />
 			{
 				post.collection ? (

--- a/src/views/blog-post/post-title-header/post-title-header.astro
+++ b/src/views/blog-post/post-title-header/post-title-header.astro
@@ -19,77 +19,81 @@ const editedStr = post.edited && dayjs(post.edited).format("MMMM D, YYYY");
 const originalLinkStr = post.originalLink && new URL(post.originalLink).host;
 ---
 
-<section class={style.container} aria-labelledby="post-title-header">
-	<h1 id="post-title-header" class={`text-style-headline-1 ${style.title}`}>
-		{title}
-	</h1>
+<section aria-labelledby="post-title-header">
+	<div class={style.container}>
+		<h1 id="post-title-header" class={`text-style-headline-1 ${style.title}`}>
+			{title}
+		</h1>
 
-	<div class={style.details}>
-		<div class={style.date}>
-			<div class={style.date__published}>
-				<Icon width="24" height="24" name="date" aria-hidden="true" />
-				<p class="text-style-button-regular">{publishedStr}</p>
+		<div class={style.details}>
+			<div class={style.date}>
+				<div class={style.date__published}>
+					<Icon width="24" height="24" name="date" aria-hidden="true" />
+					<p class="text-style-button-regular">{publishedStr}</p>
+				</div>
+
+				{
+					editedStr && editedStr !== publishedStr ? (
+						<p class={`text-style-button-regular ${style.date__edited}`}>
+							Last updated: {editedStr}
+						</p>
+					) : null
+				}
+			</div>
+
+			<div class={style.authors}>
+				<Icon width="24" height="24" name="authors" aria-hidden="true" />
+				<ul aria-label="Post authors" role="list" class={style.authors__list}>
+					{
+						post.authorsMeta.map((author, i) => (
+							<li class="text-style-button-regular">
+								<a href={`/unicorns/${author.id}`}>
+									{[author.name, i + 1 < post.authorsMeta.length ? "," : ""]}
+								</a>
+							</li>
+						))
+					}
+				</ul>
+			</div>
+
+			<div class={style.wordCount}>
+				<Icon width="24" height="24" name="words" aria-hidden="true" />
+				<p class="text-style-button-regular">
+					{translate(Astro, "title.n_words", post.wordCount.toString())}
+				</p>
 			</div>
 
 			{
-				editedStr && editedStr !== publishedStr ? (
-					<p class={`text-style-button-regular ${style.date__edited}`}>
-						Last updated: {editedStr}
-					</p>
+				post.originalLink ? (
+					<div class={style.originalLink}>
+						<Icon width="24" height="24" name="website" aria-hidden="true" />
+						<p class="text-style-button-regular">
+							{translate(Astro, "desc.original_link")}
+							<a
+								href={post.originalLink}
+								target="_blank"
+								rel="nofollow noopener noreferrer"
+							>
+								{originalLinkStr}
+							</a>
+						</p>
+					</div>
 				) : null
 			}
 		</div>
 
-		<div class={style.authors}>
-			<Icon width="24" height="24" name="authors" aria-hidden="true" />
-			<ul aria-label="Post authors" role="list" class={style.authors__list}>
-				{
-					post.authorsMeta.map((author, i) => (
-						<li class="text-style-button-regular">
-							<a href={`/unicorns/${author.id}`}>
-								{[author.name, i + 1 < post.authorsMeta.length ? "," : ""]}
-							</a>
-						</li>
-					))
-				}
-			</ul>
-		</div>
-
-		<div class={style.wordCount}>
-			<Icon width="24" height="24" name="words" aria-hidden="true" />
-			<p class="text-style-button-regular">
-				{translate(Astro, "title.n_words", post.wordCount.toString())}
-			</p>
-		</div>
-
-		{
-			post.originalLink ? (
-				<div class={style.originalLink}>
-					<Icon width="24" height="24" name="website" aria-hidden="true" />
-					<p class="text-style-button-regular">
-						{translate(Astro, "desc.original_link")}
-						<a
-							href={post.originalLink}
-							target="_blank"
-							rel="nofollow noopener noreferrer"
-						>
-							{originalLinkStr}
-						</a>
-					</p>
-				</div>
-			) : null
-		}
+		<ul aria-label="Post tags" role="list" class={style.tags}>
+			{
+				tags?.map((tag) => (
+					<li>
+						<Chip href={`/search?${buildSearchQuery({ filterTags: [tag] })}`}>
+							{tag}
+						</Chip>
+					</li>
+				))
+			}
+		</ul>
 	</div>
 
-	<ul aria-label="Post tags" role="list" class={style.tags}>
-		{
-			tags?.map((tag) => (
-				<li>
-					<Chip href={`/search?${buildSearchQuery({ filterTags: [tag] })}`}>
-						{tag}
-					</Chip>
-				</li>
-			))
-		}
-	</ul>
+	<slot />
 </section>

--- a/src/views/blog-post/post-title-header/post-title-header.astro
+++ b/src/views/blog-post/post-title-header/post-title-header.astro
@@ -59,7 +59,13 @@ const originalLinkStr = post.originalLink && new URL(post.originalLink).host;
 			<div class={style.wordCount}>
 				<Icon width="24" height="24" name="words" aria-hidden="true" />
 				<p class="text-style-button-regular">
-					{translate(Astro, "title.n_words", post.wordCount.toString())}
+					{
+						translate(
+							Astro,
+							"title.n_words",
+							post.wordCount.toLocaleString("en"),
+						)
+					}
 				</p>
 			</div>
 

--- a/src/views/blog-post/series/series-toc.astro
+++ b/src/views/blog-post/series/series-toc.astro
@@ -20,7 +20,7 @@ const activePostsMeta = findActivePost(post, postSeries);
 const showMoreText = translate(
 	Astro,
 	"action.view_all_chapters",
-	"" + activePostsMeta.length
+	"" + activePostsMeta.length,
 );
 ---
 
@@ -28,7 +28,11 @@ const showMoreText = translate(
 	<div class={styles.seriesHeader}>
 		{
 			(
-				<h2 class={styles.titleContainer} id="series-header">
+				<h3
+					class={styles.titleContainer}
+					id="series-header"
+					data-no-heading-link
+				>
 					<span class={`text-style-body-medium-bold ${styles.partOfSeries}`}>
 						This article is part of a series:
 					</span>
@@ -44,7 +48,7 @@ const showMoreText = translate(
 							{post.collection}
 						</span>
 					)}
-				</h2>
+				</h3>
 			)
 		}
 	</div>
@@ -95,7 +99,7 @@ const showMoreText = translate(
 >
 	const showMore = document.querySelector("#toggleAllButton");
 	const showHideChapters = Array.from(
-		document.querySelectorAll("[data-dont-show-initially]")
+		document.querySelectorAll("[data-dont-show-initially]"),
 	);
 
 	let expanded = false;

--- a/src/views/blog-post/series/series-toc.astro
+++ b/src/views/blog-post/series/series-toc.astro
@@ -28,7 +28,7 @@ const showMoreText = translate(
 	<div class={styles.seriesHeader}>
 		{
 			(
-				<h3
+				<h2
 					class={styles.titleContainer}
 					id="series-header"
 					data-no-heading-link
@@ -48,7 +48,7 @@ const showMoreText = translate(
 							{post.collection}
 						</span>
 					)}
-				</h3>
+				</h2>
 			)
 		}
 	</div>


### PR DESCRIPTION
- Fixes the series title heading order (`h2` -> `h3`)
- Prevents it from acting as a "copy link" heading, which overrode the `<a>` click behavior:

![2023-10-19-115155_770x459_scrot](https://github.com/unicorn-utterances/unicorn-utterances/assets/13000407/21a9b800-d90d-4b70-aaf9-099654a37c9e)
