### PR TITLE
Fix highlight border missing when at the last/first index in a codeblock

### DIFF
--- a/src/styles/shiki.scss
+++ b/src/styles/shiki.scss
@@ -109,11 +109,13 @@ pre.shiki div.highlight {
 	background-color: var(--surface_primary_emphasis-none);
 }
 
-pre.shiki div:not(.highlight) + div.highlight {
+pre.shiki div:not(.highlight) + div.highlight,
+pre.shiki div:first-child.highlight {
 	border-top: 2px dashed var(--primary_default);
 }
 
-pre.shiki div.highlight + div:not(.highlight) {
+pre.shiki div.highlight + div:not(.highlight),
+pre.shiki div:last-child.highlight {
 	border-top: 2px dashed var(--primary_default);
 }
 

--- a/src/styles/shiki.scss
+++ b/src/styles/shiki.scss
@@ -114,9 +114,12 @@ pre.shiki div:first-child.highlight {
 	border-top: 2px dashed var(--primary_default);
 }
 
-pre.shiki div.highlight + div:not(.highlight),
-pre.shiki div:last-child.highlight {
+pre.shiki div.highlight + div:not(.highlight) {
 	border-top: 2px dashed var(--primary_default);
+}
+
+pre.shiki div:last-child.highlight {
+	border-bottom: 2px dashed var(--primary_default);
 }
 
 /** Don't show the language identifiers */


### PR DESCRIPTION
Fixes CSS for code blocks missing the top/bottom border styling when at the start or end of a code block.