### PR TITLE
Fix header search bar focus causing the page to scroll upwards

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -27,15 +27,6 @@
 	box-sizing: inherit;
 }
 
-html, body {
-	// offset scroll snap positions by the size of the sticky header + spacing
-	// (tokens in src/views/base/navigation/header.module.scss)
-	//
-	// - this prevents elements targeted by the URL hash (e.g. "/some-page#Heading-ID")
-	//   from being obscured by the header
-	scroll-padding-top: calc(var(--header_logo_size) + var(--header_padding-vertical)*2 + 1px + var(--site-spacing));
-}
-
 h1,
 h2,
 h3,

--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -156,6 +156,13 @@
 	h6 {
 		position: relative;
 
+		// offset scroll snap positions by the size of the sticky header + spacing
+		// (tokens in src/views/base/navigation/header.module.scss)
+		//
+		// - this prevents elements targeted by the URL hash (e.g. "/some-page#Heading-ID")
+		//   from being obscured by the header
+		scroll-margin-top: calc(var(--header_logo_size) + var(--header_padding-vertical)*2 + 1px + var(--site-spacing));
+
 		code {
 			display: inline-flex;
 			height: calc(1.2em + 0.15em);


### PR DESCRIPTION
Replaces `scroll-padding-top` with a `scroll-margin-top` style on all heading elements.

Fixes #845 