### PR TITLE
Fix headings from tab containers appearing in table of contents

### DIFF
--- a/src/utils/markdown/rehype-header-text.ts
+++ b/src/utils/markdown/rehype-header-text.ts
@@ -2,7 +2,7 @@ import { headingRank } from "hast-util-heading-rank";
 import { hasProperty } from "hast-util-has-property";
 import { toString } from "hast-util-to-string";
 import { Root, Parent } from "hast";
-import { visit } from "unist-util-visit";
+import { visit, SKIP } from "unist-util-visit";
 
 /**
  * Plugin to add `data-header-text`s to headings.
@@ -12,6 +12,14 @@ export const rehypeHeaderText = () => {
 		const headingsWithId = (file.data.astro.frontmatter.headingsWithId = []);
 
 		visit(tree, "element", (node: Parent["children"][number]) => {
+			// Don't descend into tab containers or collapsible <details> elements
+			if (
+				"properties" in node &&
+				(node.properties["role"] === "tabpanel" || node.tagName === "details")
+			) {
+				return SKIP;
+			}
+
 			if (
 				headingRank(node) &&
 				"properties" in node &&


### PR DESCRIPTION
This fixes #1016, which caused duplicate ToC headings to be created for tab containers. Headings are no longer counted if they are inside tab contents or inside a `<details>` element.