### PR TITLE
Fix picture images not sizing correctly in tab containers

### DIFF
--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -75,6 +75,10 @@
 		color: var(--foreground_emphasis-high);
 	}
 
+	picture {
+		display: block;
+	}
+
 	img:not([data-dont-round]):not([src$=".svg"]),
 	video:not([data-dont-round]) {
 		border-radius: var(--corner-radius_m);

--- a/src/utils/markdown/rehype-astro-image-md.ts
+++ b/src/utils/markdown/rehype-astro-image-md.ts
@@ -17,7 +17,7 @@ import { getLargestSourceSetSrc } from "../get-largest-source-set-src";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const MAX_WIDTH = 768;
+const MAX_WIDTH = 896;
 const MAX_HEIGHT = 768;
 
 /**


### PR DESCRIPTION
- Adds a `display: block; on picture tags to fix #1017 
- Fixes the image max_width (used for image compression) to match the max page content size (which is now 896px)