### PR TITLE
Fix collection chapter onclick opening an undefined link

### DIFF
--- a/src/utils/href-container-script.ts
+++ b/src/utils/href-container-script.ts
@@ -99,6 +99,9 @@ globalThis.handleHrefContainerClick = (e: MouseEvent) => {
 };
 
 export function getHrefContainerProps(href: string) {
+	// If the href is null or empty, no props should be added
+	if (!href) return {};
+
 	// hack to detect whether the function is in an Astro or Preact environment,
 	// assuming that Preact is only used outside of a node environment
 	if (

--- a/src/views/collections/collection-chapter.astro
+++ b/src/views/collections/collection-chapter.astro
@@ -10,9 +10,10 @@ interface CollectionChapter {
 }
 
 const { num, title, description, href } = Astro.props as CollectionChapter;
+const hrefProps = href ? getHrefContainerProps(href) : {};
 ---
 
-<div class={styles.container} {...getHrefContainerProps(href)}>
+<div class={styles.container} {...hrefProps}>
 	<div class={styles.numAndTitleContainer}>
 		<div class={styles.numContainer}>
 			<p class={`text-style-headline-6 ${styles.num}`} aria-hidden="true">


### PR DESCRIPTION
Fixes the "? Coming soon..." link on collections opening a `/undefined` link due to its onclick event handler.

https://unicorn-utterances.com/collections/minecraft-data-packs