### PR TITLE
fix(#966) toggling checkboxes was not working on safari

### DIFF
--- a/src/views/search/components/filter-section-item.tsx
+++ b/src/views/search/components/filter-section-item.tsx
@@ -31,7 +31,7 @@ export const FilterSectionItem = ({
 	const ref = useRef(null);
 	const labelRef = useRef<HTMLLabelElement>(null);
 
-	const { inputProps } = useCheckbox(props, state, ref);
+	const { inputProps, labelProps } = useCheckbox(props, state, ref);
 	const { isFocusVisible, focusProps } = useFocusRing();
 	const isSelected = state.isSelected;
 
@@ -51,6 +51,7 @@ export const FilterSectionItem = ({
 				selected={isSelected}
 				wrapper={(children) => (
 					<label
+						{...labelProps}
 						ref={labelRef}
 						class={`${style.containerLabel} ${
 							isSelected ? style.selected : ""


### PR DESCRIPTION
[Closes](https://github.com/unicorn-utterances/unicorn-utterances/issues/966)

Toggling checkboxes was not working on Safari both on mobile and desktop.

Before:

https://github.com/unicorn-utterances/unicorn-utterances/assets/26119440/5b6f7aef-ab26-4d51-9640-a373192828e7

After:

https://github.com/unicorn-utterances/unicorn-utterances/assets/26119440/7a6aa716-a95c-4779-b637-faaba2bc42b4

