### PR TITLE
Fix(#972): different code font-size on iOS

### DIFF
--- a/src/styles/post-body.scss
+++ b/src/styles/post-body.scss
@@ -97,6 +97,8 @@
 	pre,
 	code {
 		@extend .text-style-code;
+		// Ensures consistent font-size within code blocks on iOS devices
+		-webkit-text-size-adjust: 100%;
 	}
 
 	code:not(pre code) {
@@ -165,7 +167,10 @@
 		//
 		// - this prevents elements targeted by the URL hash (e.g. "/some-page#Heading-ID")
 		//   from being obscured by the header
-		scroll-margin-top: calc(var(--header_logo_size) + var(--header_padding-vertical)*2 + 1px + var(--site-spacing));
+		scroll-margin-top: calc(
+			var(--header_logo_size) + var(--header_padding-vertical) * 2 + 1px +
+				var(--site-spacing)
+		);
 
 		code {
 			display: inline-flex;


### PR DESCRIPTION
Closes [#972](https://github.com/unicorn-utterances/unicorn-utterances/issues/972)

On iOS devices (Safari, Chrome) code font-size inside markdown files was bigger.

Before: 
![before](https://github.com/unicorn-utterances/unicorn-utterances/assets/26119440/a930123f-1b29-4404-9ee6-12ef0b519f19)

After:
![after](https://github.com/unicorn-utterances/unicorn-utterances/assets/26119440/ae0042e1-521e-4b73-9fd1-65c08c9c2fa3)

