### PR TITLE
Removes duplicate "Custom hooks" in TagList.

### DIFF
--- a/src/views/collections/framework-field-guide/segments/fundamentals.astro
+++ b/src/views/collections/framework-field-guide/segments/fundamentals.astro
@@ -36,7 +36,6 @@ const tags: TagList = [
 	"Side effects",
 	"Event bubbling",
 	"Pipes",
-	"Custom hooks",
 ] as const;
 ---
 


### PR DESCRIPTION
Custom hooks is listed twice in the TagList which results in it showing twice on the home page:

<img width="630" alt="image" src="https://github.com/unicorn-utterances/unicorn-utterances/assets/3433130/4b6d5baf-708b-49d6-bb35-64d7e6fee467">

I'm hoping this will resolve that.