### PR TITLE
Add `scrollbar-gutter: stable` to prevent layout shift

### DIFF
--- a/src/global.scss
+++ b/src/global.scss
@@ -17,6 +17,7 @@
 @import "./styles/utilities";
 
 :root {
+	scrollbar-gutter: stable;
 	scrollbar-color: var(--focus-outline_primary) transparent;
 	transition: scrollbar-color $animStyle $animSpeed;
 


### PR DESCRIPTION
[`scrollbar-gutter: stable`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter) reserves space for the scrollbar even if the page content is not scrollable.

AFAIK this really only has an effect on Chromium browsers - Safari doesn't support it, and Firefox has an overlay / zero-width scrollbar for which this has no effect.

However, this does prevent the search page content from jumping around before/after the search results have loaded.