### PR TITLE
Various fixes for tabs

### DIFF
--- a/src/styles/markdown/tabs.scss
+++ b/src/styles/markdown/tabs.scss
@@ -27,10 +27,6 @@
 }
 
 .tabs {
-	// This prevents the browser from choosing a scroll anchor within
-	// a tab container - which can cause page jumps when the selected
-	// tab is changed
-	overflow-anchor: none;
 	margin: var(--site-spacing) 0;
 }
 
@@ -76,6 +72,11 @@
 }
 
 .tabs__tab-panel {
+	// This prevents the browser from choosing a scroll anchor within
+	// a tab container - which can cause page jumps when the selected
+	// tab is changed
+	overflow-anchor: none;
+
 	padding: var(--tabbed-wrapper_padding);
 	border-radius: 0 var(--tabbed-wrapper_corner-radius_outer)
 		var(--tabbed-wrapper_corner-radius_outer)

--- a/src/styles/markdown/tabs.scss
+++ b/src/styles/markdown/tabs.scss
@@ -27,6 +27,9 @@
 }
 
 .tabs {
+	// This prevents the browser from choosing a scroll anchor within
+	// a tab container - which can cause page jumps when the selected
+	// tab is changed
 	overflow-anchor: none;
 	margin: var(--site-spacing) 0;
 }

--- a/src/styles/markdown/tabs.scss
+++ b/src/styles/markdown/tabs.scss
@@ -27,6 +27,7 @@
 }
 
 .tabs {
+	overflow-anchor: none;
 	margin: var(--site-spacing) 0;
 }
 
@@ -114,6 +115,8 @@
 	margin-right: var(--tab-content_margin) !important;
 }
 
+// Small tab sections have bottom "spacing" (hack using grid layout) to prevent content jumps on large screens
+//   - this should be turned off at small widths where the tab content can wrap.
 @include from($tabletLarge) {
 	.tabs-small {
 		display: grid;
@@ -127,6 +130,7 @@
 		.tabs__tab-panel {
 			grid-row-start: 2;
 			grid-column: 1 / 3;
+			height: 100%;
 
 			&[aria-hidden="true"],
 			&[aria-hidden=""] {

--- a/src/utils/markdown/tabs/rehype-transform.ts
+++ b/src/utils/markdown/tabs/rehype-transform.ts
@@ -42,12 +42,14 @@ const getApproxLineCount = (nodes: Node[], inParagraph?: boolean): number => {
 			["div", "p", "br"].includes((n as Element).tagName)
 		)
 			lines++;
-		// assume that any image or embed could add ~10 lines
+		// assume that any image or embed could add ~20 lines
 		if (
 			n.type === "element" &&
-			["img", "svg", "iframe"].includes((n as Element).tagName)
+			["picture", "img", "svg", "iframe", "video"].includes(
+				(n as Element).tagName,
+			)
 		)
-			lines += 10;
+			lines += 20;
 		// approximate line wraps in <p> tag, assuming ~100 chars per line
 		if (
 			isInParagraph &&


### PR DESCRIPTION
Fixes #1053 

This makes a few changes to tabbed containers:
- When reserving space for tabs, the tab background now extends to the full height of the container
- Added back `overflow-anchor: none;`, which was missing from the tab containers
  * This prevents page jumps when the selected tab is changed by forcing the browser to pick a scroll anchor outside
     of the tab content
- Increased the line count that an image adds to the estimate
  * Each image is now equivalent to 20 lines, where the space-reservation limit is 30 lines - so a tab with multiple images cannot reserve space (this prevents the empty space mentioned in the issue)