### PR TITLE
Revert "apply overflow-anchor only to the tab panels"

### DIFF
--- a/src/styles/markdown/tabs.scss
+++ b/src/styles/markdown/tabs.scss
@@ -27,6 +27,10 @@
 }
 
 .tabs {
+	// This prevents the browser from choosing a scroll anchor within
+	// a tab container - which can cause page jumps when the selected
+	// tab is changed
+	overflow-anchor: none;
 	margin: var(--site-spacing) 0;
 }
 
@@ -72,11 +76,6 @@
 }
 
 .tabs__tab-panel {
-	// This prevents the browser from choosing a scroll anchor within
-	// a tab container - which can cause page jumps when the selected
-	// tab is changed
-	overflow-anchor: none;
-
 	padding: var(--tabbed-wrapper_padding);
 	border-radius: 0 var(--tabbed-wrapper_corner-radius_outer)
 		var(--tabbed-wrapper_corner-radius_outer)


### PR DESCRIPTION
This reverts commit 9e9a714739177bcf22ff262c3d0850d8dac75322.

Applying this specifically to the tab panel still allows the browser to choose the tabs element as a scroll anchor, which can apparently still cause scroll jumps.