### PR TITLE
[Markdown Deastroify] Move FFG Angular Syntax to Fix Highlighting Issues

### DIFF
--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/index.md
@@ -132,7 +132,7 @@ In our previous example, we used them to conditionally render content using `ngI
 
 `ContentChild` is a way to query the projected content within [`ng-content`](/posts/ffg-fundamentals-passing-children) from JavaScript.
 
-```typescript
+```angular-ts
 import {
 	Component,
 	AfterContentInit,
@@ -187,7 +187,7 @@ Then you're asking the right questions!
 
 See, if we replace our usage of `ngAfterContentInit` with a `ngOnInit`, then we get `undefined` in place of `this.child`:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "parent-list",
 	standalone: true,
@@ -219,7 +219,7 @@ While `ContentChild` is useful for querying against a single item being projecte
 
 This is where [`ContentChildren`](https://angular.io/api/core/ContentChildren) comes into play:
 
-```typescript
+```angular-ts
 import {
 	Component,
 	AfterContentInit,
@@ -378,7 +378,7 @@ Since Angular's `ContentChildren` gives us an `HTMLElement` reference when using
 
 Instead, let's change our elements to `ng-template`s and render them in an `ngFor`, [similarly to what we did in our "Directives" chapter](/posts/ffg-fundamentals-directives#using-viewcontainer-to-render-a-template):
 
-```typescript
+```angular-ts
 @Component({
 	selector: "parent-list",
 	standalone: true,
@@ -480,7 +480,7 @@ const App = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "parent-list",
 	standalone: true,
@@ -686,7 +686,7 @@ const App = () => {
 
 Let's use the [ability to pass values to an ngTemplate using context](/posts/ffg-fundamentals-directives#passing-data-to-ng-template) to provide the background color to the passed template to our `ParentList` component:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "parent-list",
 	standalone: true,
@@ -900,7 +900,7 @@ function App() {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "table-comp",
 	standalone: true,

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/index.md
@@ -99,7 +99,7 @@ function App() {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "context-menu",
 	standalone: true,
@@ -587,7 +587,7 @@ useImperativeHandle(ref, () => someVal, [someVal]);
 
 Just as we can use `ViewChild` to access an underlying DOM node, we can do the same thing with a component reference. In fact, we can use a template reference variable just like we would to access the DOM node.
 
-```typescript {1,24,27}
+```angular-ts {1,24,27}
 import { AfterViewInit, Component, ViewChild } from "@angular/core";
 
 @Component({
@@ -631,13 +631,13 @@ Doing this, we'll see the console output:
 
 But how do we know that this is properly the `ChildComponent` instance? Simple! We'll `console.log` `childComp.constructor` and we'll see:
 
-```typescript
+```angular-ts
 class ChildComponent {}
 ```
 
 This means that, as a result, we can also call the `sayHi` method:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "parent-comp",
 	standalone: true,
@@ -877,7 +877,7 @@ function App() {
 
 ## Angular
 
-```typescript {7,14,22-24,38,47,68}
+```angular-ts {7,14,22-24,38,47,68}
 @Component({
 	selector: "context-menu",
 	standalone: true,
@@ -1112,7 +1112,7 @@ const App = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-layout",
 	standalone: true,
@@ -1271,7 +1271,7 @@ const App = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-sidebar",
 	standalone: true,
@@ -1536,7 +1536,7 @@ const App = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-sidebar",
 	standalone: true,

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/index.md
@@ -186,7 +186,7 @@ While React and Vue both have minimal APIs to handle dependency injection, Angul
 
 In Angular, it all starts with an `InjectionToken` of some kind. We'll start by importing Angular `InjectionToken` API and creating a new token we can use later.
 
-```typescript
+```angular-ts
 import { InjectionToken } from "@angular/core";
 
 const WELCOME_MESSAGE_TOKEN = new InjectionToken<string>("WELCOME_MESSAGE");
@@ -194,7 +194,7 @@ const WELCOME_MESSAGE_TOKEN = new InjectionToken<string>("WELCOME_MESSAGE");
 
 We'll then use this token to create a `provider` that we pass to a component's `providers` list:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -209,7 +209,7 @@ This API uses `useValue` to provide the value associated with the token we pass.
 
 Finally, we use an `inject` function in our component class to tell Angular, "We want this value in our component."
 
-```typescript
+```angular-ts
 import { inject } from "@angular/core";
 
 @Component({
@@ -313,7 +313,7 @@ const Parent = () => {
 
 Because Angular's `useValue` accepts any arbitrary value, we can pass it an object to move away from a string injection:
 
-```typescript {4,16}
+```angular-ts {4,16}
 @Component({
 	selector: "child-comp",
 	standalone: true,
@@ -348,7 +348,7 @@ Luckily for us, Angular provides a better solution for this problem than `useVal
 
 Instead, let's create a class that we mark with an `@Injectable` decorator:
 
-```typescript
+```angular-ts
 import { Injectable } from "@angular/core";
 
 @Injectable()
@@ -359,7 +359,7 @@ class InjectedValue {
 
 Here, we're telling Angular to treat our `InjectedValue` class as a `InjectionToken` that we can use by name in our `providers`.
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -372,7 +372,7 @@ class AppComponent {}
 
 Now that our `InjectedValue` is a known type, we can remove our explicit type declaration to our consuming `inject` function in `ChildComponent`
 
-```typescript
+```angular-ts
 @Component({
 	selector: "child-comp",
 	standalone: true,
@@ -474,7 +474,7 @@ When we update the `message` value, it will trigger a re-render on the `Child` c
 
 Because we've marked our `InjectedValue` class as an `Injectable`, we can have the parent component request access in the `constructor` to mutate the class instance.
 
-```typescript
+```angular-ts
 @Injectable()
 class InjectedValue {
 	message = "Initial value";
@@ -816,7 +816,7 @@ function Child() {
 
 Because we can inject a whole class instance into a child component, we can use methods in said class to mutate data of the injected class instance.
 
-```typescript
+```angular-ts
 @Injectable()
 class InjectedValue {
 	message = "Hello, world";
@@ -945,7 +945,7 @@ When this is done, `useContext` is `undefined` if no value is injected for a par
 
 In Angular, we provide values to be injected using the `providers` array on a component.
 
-```typescript
+```angular-ts
 @Injectable()
 class InjectedValue {
 	message = "Initial value";
@@ -972,7 +972,7 @@ class ParentComponent {}
 
 However, if we remove the `providers` from `ParentComponent` to test our application without any user data, like so:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -997,7 +997,7 @@ This is because our `inject` function inside `ChildComponent` is marked as a req
 
 Fortunately, there's a way to tell Angular to mark that dependency as "optional" by passing a second argument to the `inject` function:
 
-```typescript
+```angular-ts
 @Injectable()
 class InjectedValue {
 	message = "Hello, world";
@@ -1114,7 +1114,7 @@ When an `inject` function is marked as `{optional: true}`, the default value (wh
 
 As such, we can use [JavaScript's built-in "OR" operator (`||`)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR) to default to a different value as our default:
 
-```typescript
+```angular-ts
 @Injectable()
 class InjectedValue {
 	message = "Initial value";
@@ -1312,7 +1312,7 @@ Remember when we used `@Injectable` to mark a class as an injectable class insta
 
 When you pass `{providedIn: 'root'}` to the `@Injectable` decorator, you no longer have to explicitly place the class inside a `providers` array; instead, Angular will simply provide this class to the root of your application.
 
-```typescript
+```angular-ts
 @Injectable({ providedIn: "root" })
 class InjectedValue {
 	message = "Hello, world";
@@ -1490,7 +1490,7 @@ function GreatGrandChild() {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Injectable()
 class NameValue {
 	name = "";
@@ -1688,7 +1688,7 @@ function GreatGrandChild() {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Injectable()
 class NameValue {
 	name = "";
@@ -1917,7 +1917,7 @@ function GreatGrandChild() {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Injectable()
 class UserValue {
 	name = "";
@@ -2123,7 +2123,7 @@ function GreatGrandChild() {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Injectable({ providedIn: "root" })
 class MessageValue {
 	greeting = "";
@@ -2460,7 +2460,7 @@ export const FileList = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 // app.component.ts
 import { Component } from "@angular/core";
 import { LayoutComponent } from "./layout.component";
@@ -2481,7 +2481,7 @@ import { FileListComponent } from "./file-list.component";
 export class AppComponent {}
 ```
 
-```typescript
+```angular-ts
 // layout.component.ts
 import { Component } from "@angular/core";
 
@@ -2508,7 +2508,7 @@ import { Component } from "@angular/core";
 export class LayoutComponent {}
 ```
 
-```typescript
+```angular-ts
 // file-list.component.ts
 import { Component } from "@angular/core";
 
@@ -2524,7 +2524,7 @@ import { Component } from "@angular/core";
 export class FileListComponent {}
 ```
 
-```typescript
+```angular-ts
 // sidebar.component.ts
 import { Component } from "@angular/core";
 
@@ -2706,7 +2706,7 @@ export const FileList = () => {
 
 Let's start by building out our `File` component with a button and a `name` input:
 
-```typescript
+```angular-ts
 // file.component.ts
 import { Component, Input } from "@angular/core";
 
@@ -2726,7 +2726,7 @@ export class FileComponent {
 
 Then, we can this component into our `Sidebar` and `FileList` components to display a static list of directories and files:
 
-```typescript
+```angular-ts
 // file-list.component.ts
 import { Component } from "@angular/core";
 import { FileComponent } from "./file.component";
@@ -2761,7 +2761,7 @@ export class FileListComponent {
 }
 ```
 
-```typescript
+```angular-ts
 // sidebar.component.ts
 import { Component } from "@angular/core";
 import { NgFor } from "@angular/common";
@@ -3133,7 +3133,7 @@ export const Sidebar = () => {
 
 Just like we did with React, let's take our previous context menu and add in the `"contextmenu"` listener and action array:
 
-```typescript {46-55,66-69,73-86}
+```angular-ts {46-55,66-69,73-86}
 @Component({
 	selector: "context-menu",
 	standalone: true,
@@ -3237,7 +3237,7 @@ export class ContextMenuComponent implements OnInit, OnDestroy, OnChanges {
 
 We'll then use this new component in our `File` component:
 
-```typescript
+```angular-ts
 // file.component.ts
 import { Component, Input, ViewChild } from "@angular/core";
 import { ContextMenuComponent } from "./context-menu.component";
@@ -3294,7 +3294,7 @@ export class FileComponent {
 
 And, again, pass the `file.id` to `<file-item [id]="file.id"/>` component:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-list",
 	standalone: true,
@@ -3311,7 +3311,7 @@ export class FileListComponent {
 }
 ```
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-sidebar",
 	standalone: true,
@@ -3627,7 +3627,7 @@ const FileList = () => {
 
 Let's use an `Injectable` to provide and inject the values between parts of our app:
 
-```typescript
+```angular-ts
 // context.ts
 import { Injectable } from "@angular/core";
 
@@ -3639,7 +3639,7 @@ export class ActionTypes {
 
 Then, we can use this service in our `ContextMenu` component:
 
-```typescript
+```angular-ts
 // context-menu.component.ts
 function injectAndGetActions() {
 	const context = inject(ActionTypes);
@@ -3662,7 +3662,7 @@ export class ContextMenuComponent implements OnInit, OnDestroy, OnChanges {
 
 Finally, we need to make sure to set up our `ActionTypes` provider in each of our landmarks:
 
-```typescript
+```angular-ts
 // sidebar.component.ts
 
 // ...
@@ -3701,7 +3701,7 @@ export class SidebarComponent {
 }
 ```
 
-```typescript
+```angular-ts
 // file-list.component.ts
 
 // ...
@@ -3973,7 +3973,7 @@ const FileList = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 // sidebar.component.ts
 
 // ...
@@ -4022,7 +4022,7 @@ export class SidebarComponent {
 }
 ```
 
-```typescript
+```angular-ts
 // file-list.component.ts
 
 // ...

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/index.md
@@ -28,7 +28,7 @@ const FileDate = ({ inputDate }) => {
 
 # Angular
 
-```typescript
+```angular-ts
 import { Component, OnInit } from "@angular/core";
 
 @Component({
@@ -111,7 +111,7 @@ const File = ({ href, fileName, isSelected, onSelected, isFolder }) => {
 
 # Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-item",
 	standalone: true,
@@ -233,7 +233,7 @@ While we didn't touch on this lifecycle method in our previous chapter, Angular 
 
 We can use this new lifecycle method to update the value of a component's state based off of the parent's props:
 
-```typescript {1,8,14-24}
+```angular-ts {1,8,14-24}
 import { Component, OnChanges, SimpleChanges } from "@angular/core";
 
 @Component({
@@ -371,7 +371,7 @@ const AddComp = ({ baseNum, addNum }) => {
 
 To solve the derived value problem without recomputing the values manually, Angular introduces the concept of a "pipe" into the mix of things. The idea is that a pipe runs over an input (or series of inputs), just like React's `useMemo`.
 
-```typescript
+```angular-ts
 import { Pipe, PipeTransform } from "@angular/core";
 
 @Pipe({ name: "formatDate", standalone: true })
@@ -391,7 +391,7 @@ class FormatReadableDatePipe implements PipeTransform {
 
 You may then use these pipes in your components directly inside the template.
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-date",
 	standalone: true,
@@ -417,7 +417,7 @@ You may notice the similarities between pipes and functions. After all, pipes ar
 
 Let's add a second input to see if the `formatDate` pipe should return a readable date or not.
 
-```typescript
+```angular-ts
 @Pipe({ name: "formatDate", standalone: true })
 class FormatDatePipe implements PipeTransform {
 	// `dateFormat` is an optional argument. If left empty, will simply `formatDate`
@@ -431,7 +431,7 @@ class FormatDatePipe implements PipeTransform {
 
 Then, we can use it in our template while passing a second argument:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-date",
 	standalone: true,
@@ -457,7 +457,7 @@ Luckily, Angular's all-in-one methodology means that there's a slew of pipes tha
 
 To use the built-in pipes, we need to import them from `CommonModule` into the component. In this case, the pipe we're looking to use is called [`DatePipe`](https://angular.io/api/common/DatePipe). This provided date pipe is, expectedly, called `date` when used in the template and can be used like so:
 
-```typescript
+```angular-ts
 import { DatePipe } from "@angular/common";
 
 @Component({
@@ -544,7 +544,7 @@ const CountAndDoubleComp = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Pipe({ name: "doubleNum", standalone: true })
 class DoubleNumPipe implements PipeTransform {
 	transform(value: number): number {
@@ -679,7 +679,7 @@ function formatBytes(bytes) {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Pipe({ name: "formatBytes", standalone: true })
 class FormatBytesPipe implements PipeTransform {
 	kilobyte = 1024;

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/index.md
@@ -61,7 +61,7 @@ const App = () => {
 
 You set up a directive in Angular very similarly to how you might construct a component: using the `@Directive` decorator.
 
-```typescript
+```angular-ts
 import { Component, ElementRef, Directive } from "@angular/core";
 
 @Directive({
@@ -95,7 +95,7 @@ This isn't particularly useful, but demonstrates the most minimal version of wha
 
 It's frequently more helpful to get a reference to the element that the attribute is present on. To do this, we'll use Angular's [dependency injection](/posts/ffg-fundamentals-dependency-injection) to ask Angular for an `ElementRef` that's present within the framework's internals when you create a directive instance.
 
-```typescript
+```angular-ts
 @Directive({
 	selector: "[logElement]",
 	standalone: true,
@@ -110,7 +110,7 @@ But oh no! Our directive no longer uses the `constructor` function, which means 
 
 To fix this, we can extract our `inject` into a function that we can call from within our directive's class body:
 
-```typescript
+```angular-ts
 function findAndLogTheElement() {
 	const el = inject(ElementRef<any>);
 	// HTMLParagraphElement
@@ -216,7 +216,7 @@ const App = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 function injectElAndStyle() {
 	const el = inject(ElementRef<any>);
 	el.nativeElement.style.background = "red";
@@ -324,7 +324,7 @@ const App = () => {
 
 Angular uses the same `implements` implementation for classes to use lifecycle methods in directives as it does components.
 
-```typescript
+```angular-ts
 @Directive({
 	selector: "[focusElement]",
 	standalone: true,
@@ -417,7 +417,7 @@ However, one way that a directive's inputs differ from a component's is that you
 
 <!-- Editor's note: I am intentionally lying that you have to prefix the name. Read on. -->
 
-```typescript
+```angular-ts
 @Directive({
 	selector: "[styleBackground]",
 	standalone: true,
@@ -526,7 +526,7 @@ const App = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 class Color {
 	r: number;
 	g: number;
@@ -642,7 +642,7 @@ I have to come clean about something: when I said, "A directive's input must be 
 
 In reality, you can name an input anything you'd like, but then you need to have an empty attribute with the same name as the selector.
 
-```typescript
+```angular-ts
 @Directive({
 	selector: "[styleBackground]",
 	standalone: true,
@@ -839,7 +839,7 @@ the `ng-template`.
 
 However, because `ng-template` doesn't render anything on its own, we'll need to supply a parent to render the `ng-template`'s contents. We do this using the `ngTemplateOutlet` directive:
 
-```typescript
+```angular-ts
 import { NgTemplateOutlet } from "@angular/common";
 
 @Component({
@@ -900,7 +900,7 @@ To solve this, we can pass a "default" key called `$implicit` and bind it like s
 </ng-template>
 ```
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -924,7 +924,7 @@ class AppComponent {}
 
 While we've been using `inject` in directives to gain access to the directive's underlying HTML element, what happens if we bind a directive to an `ng-template`?
 
-```typescript
+```angular-ts
 @Directive({
 	selector: "[beOnTemplate]",
 	standalone: true,
@@ -954,7 +954,7 @@ Surprisingly, this `alert`s the `"I am alive!"` message despite nothing being sh
 
 Well, there's a hint if we try to access the underlying HTML element using `ElementRef`:
 
-```typescript
+```angular-ts
 @Directive({
 	selector: "[beOnTemplate]",
 	standalone: true,
@@ -994,7 +994,7 @@ Now that we know we can attach a template from a directive, let's go one step fu
 
 Here, we'll use dependency injection to get access to an `ng-template`'s `TemplateRef`:
 
-```typescript
+```angular-ts
 function injectTemplateAndLog() {
 	const template = inject(TemplateRef);
 	console.log(template);
@@ -1056,7 +1056,7 @@ To do this, Angular uses a compiler to create intelligent "template functions" w
 
 This means that:
 
-```typescript
+```angular-ts
 import { Component } from "@angular/core";
 @Component({
 	selector: "app-cmp",
@@ -1069,7 +1069,7 @@ class AppCmp {
 
 Might compile to something like:
 
-```typescript
+```angular-ts
 import { Component } from "@angular/core";
 import * as i0 from "@angular/core";
 class AppCmp {
@@ -1127,7 +1127,7 @@ When this compiler runs, it also creates a relationship between each component a
 
 This means that this code:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "list-comp",
 	standalone: true,
@@ -1167,7 +1167,7 @@ This isn't just theoretically helpful to learn, though; we're able to tell Angul
 
 Similarly, as a template is handled by an `EmbeddedView` in Angular's compiler, we can programmatically create an Embedded View using `ViewContainerRef.createEmbeddedView`:
 
-```typescript
+```angular-ts
 function injectAndRenderTemplate() {
 	const templToRender = inject(TemplateRef<any>);
 	const parentViewRef = inject(ViewContainerRef);
@@ -1209,7 +1209,7 @@ Now, we should be able to see the `p` tag rendering!
 
 Just as we could pass data to a template inside a component using `ngTemplateOutletContext`, we can do the same using a second argument of `createEmbeddedView`:
 
-```typescript
+```angular-ts
 function injectAndRenderTemplate() {
 	const templToRender = inject(TemplateRef<any>);
 	const parentViewRef = inject(ViewContainerRef);
@@ -1275,7 +1275,7 @@ Is functionally the same as this:
 
 Knowing this, we can take our previous code and convert it to a structural directive:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -1299,7 +1299,7 @@ class AppComponent {}
 
 Now that we have our foundation written out, we can finally build a simple `featureFlag` directive that renders nothing if a `flag` is false but renders the contents if a flag is `true`:
 
-```typescript
+```angular-ts
 const flags: Record<string, boolean> = {
 	addToCartButton: true,
 	purchaseThisItemButton: false,
@@ -1539,7 +1539,7 @@ However, to get this to work, we need to use [Angular CDK's DOMPortal](https://m
 
 We'll build out a custom PortalService that uses a `DomPortalOutlet` to enable this:
 
-```typescript
+```angular-ts
 @Injectable({
 	providedIn: "root",
 })
@@ -1560,7 +1560,7 @@ class PortalService {
 
 Then, we can bind to the `DomPortalOutput` by creating a `DOMPortal` like so:
 
-```typescript
+```angular-ts
 const viewRef = this.viewContainerRef.createEmbeddedView(this.templToRender);
 
 // We need to access the `div` itself to attach to a DomPortal; this is how you do that.
@@ -1578,7 +1578,7 @@ setTimeout(() => {
 
 Let's put it all together like so:
 
-```typescript
+```angular-ts
 @Directive({
 	selector: "[tooltip]",
 	standalone: true,

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/index.md
@@ -44,7 +44,7 @@ const File = ({ href, fileName, isSelected, onSelected }) => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-item",
 	standalone: true,
@@ -195,7 +195,7 @@ But the following examples **will not** render their contained values:
 
 ### Angular
 
-```typescript {2,7-8}
+```angular-ts {2,7-8}
 import { Component, Input } from "@angular/core";
 import { NgIf } from "@angular/common";
 
@@ -317,7 +317,7 @@ const FileList = () => {
 
 ### Angular
 
-```typescript {15,41}
+```angular-ts {15,41}
 @Component({
 	selector: "file-item",
 	standalone: true,
@@ -766,7 +766,7 @@ const FileList = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-list",
 	standalone: true,
@@ -941,7 +941,7 @@ We can then use the second argument inside the `map` to gain access to the index
 
 Just as how the previous `*ngIf` structural directive is used to conditionally render items, Angular uses a different structural directive to render a list of items: `*ngFor`.
 
-```typescript {1,6,9-17,32-48}
+```angular-ts {1,6,9-17,32-48}
 import { NgFor } from "@angular/common";
 
 @Component({
@@ -1151,7 +1151,7 @@ function getRandomWord() {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "word-list",
 	standalone: true,
@@ -1313,7 +1313,7 @@ Here, we're using the `key` property to tell React which `li` is related to whic
 
 While Angular doesn't have quite the same API for `key` as React and Vue, Angular instead uses a [`trackBy` method](https://angular.io/api/core/TrackByFunction) to figure out which item is which.
 
-```typescript {9,17-19}
+```angular-ts {9,17-19}
 @Component({
 	selector: "word-list",
 	standalone: true,
@@ -1522,7 +1522,7 @@ const FileList = () => {
 
 ## Angular
 
-```typescript {7,22-24,39}
+```angular-ts {7,22-24,39}
 @Component({
 	selector: "file-list",
 	standalone: true,
@@ -1690,7 +1690,7 @@ const FileList = () => {
 
 ## Angular
 
-```typescript {4,7,10,13,28,30-32}
+```angular-ts {4,7,10,13,28,30-32}
 @Component({
 	selector: "file-list",
 	standalone: true,
@@ -1845,7 +1845,7 @@ const Sidebar = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "expandable-dropdown",
 	standalone: true,
@@ -2039,7 +2039,7 @@ const Sidebar = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-sidebar",
 	standalone: true,
@@ -2185,7 +2185,7 @@ function objFromCategories(categories) {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-sidebar",
 	standalone: true,
@@ -2308,7 +2308,7 @@ const ExpandableDropdown = ({ name, expanded, onToggle }) => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "expandable-dropdown",
 	standalone: true,

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/index.md
@@ -86,7 +86,7 @@ function App() {
 
 # Angular
 
-```typescript
+```angular-ts
 /**
  * This code sample is inaccessible and generally not
  * production-grade. It's missing:
@@ -436,7 +436,7 @@ This is because `buttonRef.current` is set to `undefined` in the first render, a
 
 Using `ViewChild`, we can access an [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) that's within an Angular component's `template`:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "paragraph-tag",
 	standalone: true,
@@ -455,7 +455,7 @@ For example, the `#pTag` attribute assigns the template reference variable named
 
 Now that we have access to the underlying `<p>` element let's print it out inside a `ngOnInit`:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "paragraph-tag",
 	standalone: true,
@@ -479,7 +479,7 @@ class RenderParagraphComponent implements OnInit {
 
 Well, let's think about the following example:
 
-```typescript {6-8}
+```angular-ts {6-8}
 @Component({
 	selector: "paragraph-tag",
 	standalone: true,
@@ -511,7 +511,7 @@ To solve this, we can do one of two things:
 
 To tell Angular that there is no dynamic HTML, and it should immediately query for the elements, you can use the `{static: true}` property on `ViewChild`:
 
-```typescript {7}
+```angular-ts {7}
 @Component({
 	selector: "paragraph-tag",
 	standalone: true,
@@ -533,7 +533,7 @@ class RenderParagraphComponent implements OnInit {
 
 However, keep in mind that if you _do_ later add any dynamic HTML our element will be `undefined` once again:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "paragraph-tag",
 	standalone: true,
@@ -560,7 +560,7 @@ To solve this, we'll have to use a different lifecycle method than `ngOnInit`.
 
 While the values of a dynamic HTML may not be defined in `ngOnInit`, there is a different lifecycle method to be called when Angular has fully initialized all the child values of your dynamic HTML: `ngAfterViewInit`.
 
-```typescript
+```angular-ts
 import { AfterViewInit, Component, ElementRef, ViewChild } from "@angular/core";
 import { NgIf } from "@angular/common";
 
@@ -591,7 +591,7 @@ class RenderParagraphComponent implements AfterViewInit {
 
 Now that we know how to use `ViewChild`, we can add an `addEventListener` and `removeEventListener` to manually bind a `button`'s `click` event:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "paragraph-tag",
 	standalone: true,
@@ -743,7 +743,7 @@ Just as there is a `ViewChild` to gain access to a single underlying HTML elemen
 
 Using `ViewChildren`, we can access [template reference variables](https://crutchcorn-book.vercel.app/posts/content-reference#ng-templates) in order to `scrollIntoView` the first and last elements.
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -966,7 +966,7 @@ Additionally, we'll use `ViewChild` to track the `contextMenu` element and `.foc
 
 > We need to use a `setTimeout` in our `open` method to make sure the HTML element renders before our `focus` call.
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -1200,7 +1200,7 @@ function App() {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -1333,7 +1333,7 @@ function App() {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -1514,7 +1514,7 @@ function App() {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -1784,7 +1784,7 @@ function App() {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -2090,7 +2090,7 @@ function App() {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/index.md
@@ -48,7 +48,7 @@ const App = () => {
 
 # Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -141,7 +141,7 @@ const ErrorThrowingComponent = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "error-throwing",
 	standalone: true,
@@ -199,7 +199,7 @@ const EventErrorThrowingComponent = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "error-throwing",
 	standalone: true,
@@ -427,7 +427,7 @@ const App = () => {
 
 Despite errors thrown in a component's constructor preventing rendering:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -447,7 +447,7 @@ class AppComponent {
 
 Errors thrown in any of Angular's other lifecycle methods will not prevent a component from rendering:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -665,7 +665,7 @@ Angular uses its [dependency injection system](/posts/ffg-fundamentals-dependenc
 
 However, to provide the custom error handler service, you **must** provide it at the root of your application, meaning that you cannot simply provide it from your parent component.
 
-```typescript
+```angular-ts
 class MyErrorHandler implements ErrorHandler {
 	handleError(error: unknown) {
 		// Do something with the error
@@ -684,7 +684,7 @@ bootstrapApplication(AppComponent, {
 
 Now that we've set up our `ErrorHandler` instance, we can test that it works using a component that throws an error:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "child-comp",
 	standalone: true,
@@ -863,7 +863,7 @@ Because a custom error handler is implemented using an Angular service, we can u
 
 From there, it's as simple as storing a Boolean when an error _is_ thrown and using that Boolean to render out a fallback UI when `true`.
 
-```typescript
+```angular-ts
 import { Component, inject, ErrorHandler, OnInit } from "@angular/core";
 
 class MyErrorHandler implements ErrorHandler {
@@ -986,7 +986,7 @@ class ErrorBoundary extends Component {
 
 Rather than storing a Boolean when an error occurs, we can store [the error value itself](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) within an `error` object and display the underlying value when present.
 
-```typescript
+```angular-ts
 class MyErrorHandler implements ErrorHandler {
 	error: unknown = null;
 
@@ -1124,7 +1124,7 @@ Upon rendering the sidebar, we're greeted with [a JavaScript `ReferenceError`](h
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-sidebar",
 	standalone: true,
@@ -1321,7 +1321,7 @@ const Root = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 class MyErrorHandler implements ErrorHandler {
 	error: any = null;
 
@@ -1483,7 +1483,7 @@ class ErrorBoundary extends Component {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Pipe({ name: "errorHref", standalone: true })
 class ErrorHrefPipe implements PipeTransform {
 	transform(err: Error | null): string {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/index.md
@@ -160,7 +160,7 @@ React.createElement("div", null, aTag);
 
 ## Angular
 
-```typescript
+```angular-ts
 import { Component } from "@angular/core";
 
 @Component({
@@ -300,7 +300,7 @@ createRoot(document.getElementById("root")).render(<File />);
 
 ## Angular
 
-```typescript {2,15}
+```angular-ts {2,15}
 import { Component } from "@angular/core";
 import { bootstrapApplication } from "@angular/platform-browser";
 
@@ -391,7 +391,7 @@ const FileList = () => {
 
 ## Angular
 
-```typescript {12-22}
+```angular-ts {12-22}
 @Component({
 	selector: "file-item",
 	standalone: true,
@@ -494,7 +494,7 @@ const FileList = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-list",
 	standalone: true,
@@ -592,7 +592,7 @@ const FileList = () => {
 
 ## Angular
 
-```typescript {1-6,11,14,23,26}
+```angular-ts {1-6,11,14,23,26}
 @Component({
 	selector: "file-date",
 	standalone: true,
@@ -708,7 +708,7 @@ const FileDate = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-date",
 	standalone: true,
@@ -789,7 +789,7 @@ const FileDate = () => {
 
 ## Angular
 
-```typescript {7,9-16}
+```angular-ts {7,9-16}
 @Component({
 	selector: "file-date",
 	standalone: true,
@@ -878,7 +878,7 @@ const FileDate = () => {
 
 ### Angular
 
-```typescript {1,8,11-13}
+```angular-ts {1,8,11-13}
 import { Component, OnInit } from "@angular/core";
 
 @Component({
@@ -991,7 +991,7 @@ const FileDate = () => {
 
 ### Angular
 
-```typescript {4}
+```angular-ts {4}
 @Component({
 	selector: "file-date",
 	standalone: true,
@@ -1176,7 +1176,7 @@ While React takes a very explicit method of telling the framework when to re-ren
 
 All it takes in Angular to trigger a re-render is to update a variable's value:
 
-```typescript {11-17}
+```angular-ts {11-17}
 import { Component, OnInit } from "@angular/core";
 
 @Component({
@@ -1282,7 +1282,7 @@ const FileDate = () => {
 
 ### Angular
 
-```typescript {6}
+```angular-ts {6}
 import { Component, OnInit } from "@angular/core";
 
 @Component({
@@ -1380,7 +1380,7 @@ function dateSuffix(dayNumber) {
 
 ### Angular
 
-```typescript {6,10}
+```angular-ts {6,10}
 import { Component, OnInit } from "@angular/core";
 
 @Component({
@@ -1588,7 +1588,7 @@ const FileList = () => {
 
 ## Angular
 
-```typescript {1,14,23}
+```angular-ts {1,14,23}
 import { Input, Component } from "@angular/core";
 
 @Component({
@@ -1725,7 +1725,7 @@ const FileList = () => {
 
 ### Angular
 
-```typescript {12-13,22}
+```angular-ts {12-13,22}
 @Component({
 	selector: "file-item",
 	standalone: true,
@@ -1840,7 +1840,7 @@ const File = ({ href, fileName }) => {
 
 ### Angular
 
-```typescript {9,11-21,34,40}
+```angular-ts {9,11-21,34,40}
 import { Component, OnInit } from "@angular/core";
 
 @Component({
@@ -1969,7 +1969,7 @@ const GenericList = ({ inputArray }) => {
 
 ### Angular
 
-```typescript
+```angular-ts
 import { Component, OnInit } from "@angular/core";
 
 @Component({
@@ -2079,7 +2079,7 @@ There are three major things of note in this code sample:
 
 ### Angular
 
-```typescript {7-12,20-24}
+```angular-ts {7-12,20-24}
 @Component({
 	selector: "file-item",
 	standalone: true,
@@ -2257,7 +2257,7 @@ const FileList = () => {
 
 Angular provides us a simple `@Output` decorator that enables us to `emit()` events from a child component up to the parent. This is fairly similar to how we pass _in_ data using an `@Input` decorator.
 
-```typescript {9,26,38-43,65,67-73}
+```angular-ts {9,26,38-43,65,67-73}
 import { Component, Input, EventEmitter, Output } from "@angular/core";
 
 @Component({
@@ -2484,7 +2484,7 @@ createRoot(document.getElementById("root")).render(<Sidebar />);
 </html>
 ```
 
-```typescript
+```angular-ts
 import { Component } from "@angular/core";
 import { bootstrapApplication } from "@angular/platform-browser";
 @Component({
@@ -2560,7 +2560,7 @@ const Sidebar = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-sidebar",
 	standalone: true,
@@ -2635,7 +2635,7 @@ const Sidebar = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "expandable-dropdown",
 	standalone: true,
@@ -2765,7 +2765,7 @@ const Sidebar = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "expandable-dropdown",
 	standalone: true,
@@ -2941,7 +2941,7 @@ const Sidebar = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "expandable-dropdown",
 	standalone: true,
@@ -3119,7 +3119,7 @@ const ExpandableDropdown = ({ name, expanded, onToggle }) => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "expandable-dropdown",
 	standalone: true,

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/index.md
@@ -74,7 +74,7 @@ const Container = () => {
 
 # Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "list-item",
 	standalone: true,
@@ -216,7 +216,7 @@ const ToggleButtonList = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "toggle-button",
 	standalone: true,
@@ -362,7 +362,7 @@ const ToggleButtonList = () => {
 
 Angular has a special tag called `ng-content` that acts as a pass-through for all children's content passed to a component.
 
-```typescript
+```angular-ts
 @Component({
 	selector: "toggle-button",
 	standalone: true,
@@ -532,7 +532,7 @@ function RainbowExclamationMark() {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "rainbow-exclamation-mark",
 	standalone: true,
@@ -732,7 +732,7 @@ function App() {
 
 `ng-content` allows you to pass a `select` property to have specific children projected in dedicated locations. This `select` property takes [CSS selector query values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors). Knowing this, we can pass the attribute query for `header` by wrapping the attribute name in square brackets like so:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "dropdown-comp",
 	standalone: true,
@@ -968,7 +968,7 @@ const FileTable = () => {
 
 Angular is unlike the other frameworks covered in this book. For example, let's say we port the table components from the other frameworks one-to-one into Angular.
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-item",
 	standalone: true,
@@ -1090,7 +1090,7 @@ The reason our markup isn't correct is that we're creating non-default host elem
 
 When you use a `selector` in Angular to create an element, that selector stays in the DOM:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "list-item",
 	standalone: true,
@@ -1116,7 +1116,7 @@ At first, this might seem like a roadblock to implementing our `list-item` compo
 
 Combined, this might look something like this:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "tr[file-item]",
 	standalone: true,
@@ -1145,7 +1145,7 @@ Where `host` allows us to bind our typical event handlers and attributes to the 
 
 Knowing how `host` and `selector` can properly work together, let's finally build the Angular table that we wanted to from the start:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "tr[file-item]",
 	standalone: true,
@@ -1381,7 +1381,7 @@ const FileTable = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-table-container",
 	standalone: true,
@@ -1507,7 +1507,7 @@ const FileTable = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-table-container",
 	standalone: true,

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/index.md
@@ -57,7 +57,7 @@ const Modal = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "delete-modal",
 	standalone: true,
@@ -270,7 +270,7 @@ const FolderIcon = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -286,7 +286,7 @@ const FolderIcon = () => {
 class AppComponent {}
 ```
 
-```typescript
+```angular-ts
 @Component({
 	selector: "header-comp",
 	standalone: true,
@@ -307,7 +307,7 @@ class AppComponent {}
 class HeaderComponent {}
 ```
 
-```typescript
+```angular-ts
 @Component({
 	selector: "body-comp",
 	standalone: true,
@@ -326,7 +326,7 @@ class BodyComponent {
 }
 ```
 
-```typescript
+```angular-ts
 @Component({
 	selector: "footer-comp",
 	standalone: true,
@@ -335,7 +335,7 @@ class BodyComponent {
 class FooterComponent {}
 ```
 
-```typescript
+```angular-ts
 @Component({
 	selector: "folder-icon",
 	standalone: true,
@@ -351,7 +351,7 @@ class FooterComponent {}
 class FolderIconComponent {}
 ```
 
-```typescript
+```angular-ts
 @Component({
 	selector: "delete-icon",
 	standalone: true,
@@ -607,7 +607,7 @@ const Header = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "header-comp",
 	standalone: true,
@@ -781,7 +781,7 @@ npm i @angular/cdk
 
 From here, we can import components and utilities directly from the CDK.
 
-```typescript
+```angular-ts
 import { PortalModule, DomPortal } from "@angular/cdk/portal";
 
 @Component({
@@ -841,7 +841,7 @@ Because we're using a `div` to act as the parent element of the portal's content
 
 As such, we may want to use an `ng-template`, which does not render to the DOM in the first place:
 
-```typescript
+```angular-ts
 import { PortalModule, TemplatePortal } from "@angular/cdk/portal";
 
 @Component({
@@ -967,7 +967,7 @@ function App() {
 
 In Angular, we can use a basic service to share our instance of a `Portal` between multiple components, parent and child alike.
 
-```typescript
+```angular-ts
 import { Portal, PortalModule, TemplatePortal } from "@angular/cdk/portal";
 
 @Injectable({
@@ -1158,7 +1158,7 @@ To use a portal that attaches directly to `body` in Angular, we need to switch f
 
 We can reuse our existing global service to create one of these `DomPortalOutlet`s and attach and detach it in our `modal` component, like so:
 
-```typescript
+```angular-ts
 import { TemplatePortal, DomPortalOutlet } from "@angular/cdk/portal";
 
 @Injectable({
@@ -1411,7 +1411,7 @@ function App() {
 
 ### Angular
 
-```typescript {1-6,25,70,85,87-88,108-110,121-123}
+```angular-ts {1-6,25,70,85,87-88,108-110,121-123}
 @Injectable({
 	providedIn: "root",
 })

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/index.md
@@ -158,7 +158,7 @@ To share data setup between components in Angular, we'll create an instance of a
 
 Just as we covered [in the dependency injection chapter](/posts/ffg-fundamentals-dependency-injection#basic-values), we'll use `Injectable` to create a class that can be provided to a component instance.
 
-```typescript
+```angular-ts
 @Injectable()
 class WindowSize {
 	height = window.innerHeight;
@@ -301,7 +301,7 @@ Instead, we can use a per-component injectable that uses its own `constructor` a
 >
 > The reason `Injectable`s don't have `ngOnInit` is because that method means something very specific under-the-hood, pertaining to UI data binding. Because an `Injectable` can't UI data bind, it has no need for `ngOnInit` and instead the `constructor` takes the role of setting up side effects.
 
-```typescript
+```angular-ts
 @Injectable()
 class WindowSize implements OnDestroy {
 	height = 0;
@@ -469,7 +469,7 @@ Just as we can use dependency injection to provide an instance of our `WindowSiz
 
 First, though, we need to provide a way to add behavior to our `onResize` class:
 
-```typescript
+```angular-ts
 @Injectable()
 class WindowSize implements OnDestroy {
 	height = 0;
@@ -500,7 +500,7 @@ class WindowSize implements OnDestroy {
 
 Now that we have this ability to tap into the `resize` event handler let's write our own `IsMobile` class:
 
-```typescript
+```angular-ts
 @Injectable()
 class IsMobile {
 	isMobile = false;
@@ -518,7 +518,7 @@ class IsMobile {
 
 This allows us to have an `isMobile` field that we can access from our `AppComponent` class:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -672,7 +672,7 @@ This is because our `ViewChild` element reference isn't available until `AfterVi
 
 <!-- Editor's note: This is true even with {static: true} -->
 
-```typescript
+```angular-ts
 @Injectable()
 class CloseIfOutSideContext implements OnDestroy {
 	getCloseIfOutsideFunction = (
@@ -707,7 +707,7 @@ class CloseIfOutSideContext implements OnDestroy {
 
 Let's embed this service class in our `ContextMenu` component:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "context-menu",
 	standalone: true,
@@ -922,7 +922,7 @@ function App() {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Injectable()
 class BoundsContext implements OnDestroy {
 	bounds = {
@@ -955,7 +955,7 @@ class BoundsContext implements OnDestroy {
 
 We can then use this service in our `AppComponent`:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/index.md
@@ -168,7 +168,7 @@ const Comp = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "comp-comp",
 	standalone: true,
@@ -254,7 +254,7 @@ const Parent = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "child-comp",
 	standalone: true,
@@ -362,7 +362,7 @@ We mentioned earlier that there is another hook used to handle side effects: `us
 To execute code during an initial render of a component, Angular uses a method called `ngOnInit`.
 This function is specially named so that Angular can call it on your behalf during the "rendered" lifecycle event:
 
-```typescript
+```angular-ts
 import { Component, OnInit } from "@angular/core";
 
 @Component({
@@ -477,7 +477,7 @@ const WindowSize = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "window-size",
 	standalone: true,
@@ -561,7 +561,7 @@ const WindowSize = () => {
 
 ## Angular
 
-```typescript {14-23}
+```angular-ts {14-23}
 @Component({
 	selector: "window-size",
 	standalone: true,
@@ -669,7 +669,7 @@ const WindowSize = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "window-size",
 	standalone: true,
@@ -860,7 +860,7 @@ function prefixZero(number) {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "clock-comp",
 	standalone: true,
@@ -970,7 +970,7 @@ function App() {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -1115,7 +1115,7 @@ function App() {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "alarm-screen",
 	standalone: true,
@@ -1393,7 +1393,7 @@ When we add a mounted lifecycle to Angular, we:
 
 To add an unmounted lifecycle method to an Angular component, we do the same steps as above, but with `OnDestroy` instead:
 
-```typescript
+```angular-ts
 import { Component, OnDestroy } from "@angular/core";
 
 @Component({
@@ -1414,7 +1414,7 @@ class CleanupComponent implements OnDestroy {
 
 Let's apply this new lifecycle method to our code sample previously:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "alarm-screen",
 	standalone: true,
@@ -1669,7 +1669,7 @@ However, **this is not the same thing as emitting an event in Angular or Vue**. 
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-alert",
 	standalone: true,
@@ -1794,7 +1794,7 @@ const Comp = () => {
 
 ### Angular
 
-```typescript {7}
+```angular-ts {7}
 @Component({
 	standalone: true,
 	selector: "app-comp",
@@ -1839,7 +1839,7 @@ const App = () => {
 
 ### Angular
 
-```typescript {7-10}
+```angular-ts {7-10}
 @Component({
 	standalone: true,
 	imports: [CompComponent],
@@ -1931,7 +1931,7 @@ const App = () => {
 
 #### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-alert",
 	standalone: true,
@@ -2098,7 +2098,7 @@ const WindowSize = () => {
 
 ### Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "window-size",
 	standalone: true,
@@ -2428,7 +2428,7 @@ const App = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -2572,7 +2572,7 @@ _Today_, Angular does not include a method for tracking internal state changes. 
 
 Instead, we'll have to use a `setTitle` function that calls the variable mutation as well as sets the `document.title` as a side effect:
 
-```typescript
+```angular-ts
 @Component({
 	selector: "app-root",
 	standalone: true,
@@ -2971,7 +2971,7 @@ const TitleChanger = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "title-changer",
 	standalone: true,
@@ -3077,7 +3077,7 @@ const TitleChanger = () => {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "title-changer",
 	standalone: true,
@@ -3305,7 +3305,7 @@ To sidestep this detection from Zone.js in Angular, you can tell the framework t
 
 To do this, we need to use ["Dependency Injection"](/posts/ffg-fundamentals-dependency-injection) to access Angular's internal `NgZone` reference and use the `runOutsideAngular` method:
 
-```typescript {1,20-22,32-34}
+```angular-ts {1,20-22,32-34}
 import { Component, NgZone, OnDestroy, inject } from "@angular/core";
 
 @Component({
@@ -3483,7 +3483,7 @@ function DarkModeToggle() {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "dark-mode-toggle",
 	standalone: true,
@@ -3615,7 +3615,7 @@ function App() {
 
 ## Angular
 
-```typescript
+```angular-ts
 import { Component, ViewEncapsulation } from "@angular/core";
 
 @Component({
@@ -3766,7 +3766,7 @@ function DarkModeToggle() {
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "dark-mode-toggle",
 	standalone: true,
@@ -3961,7 +3961,7 @@ function App() {
 
 ## Angular
 
-```typescript {37,59}
+```angular-ts {37,59}
 @Component({
 	selector: "dark-mode-toggle",
 	standalone: true,

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/index.md
@@ -72,7 +72,7 @@ const FileList = () => {
 
 # Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-item",
 	standalone: true,
@@ -553,7 +553,7 @@ const ButtonBar = ({
 
 ## Angular
 
-```typescript
+```angular-ts
 @Component({
 	selector: "file-action-buttons",
 	standalone: true,
@@ -669,7 +669,7 @@ That's because when we used a `div` for our `FileActionButtons` component, it by
 
 ## Angular
 
-```typescript {5-9,11-17}
+```angular-ts {5-9,11-17}
 @Component({
 	selector: "file-action-buttons",
 	standalone: true,
@@ -695,7 +695,7 @@ class FileActionButtonsComponent {
 
 We can even simplify this by removing the `ng-container`, since Angular supports multiple elements at the root of the component template.
 
-```typescript {4-15}
+```angular-ts {4-15}
 @Component({
 	selector: "file-action-buttons",
 	standalone: true,


### PR DESCRIPTION
This PR moves away from `typescript` and towards `ts-angular` syntax highlighting for the template in Angular code samples for FFG