### PR TITLE
Fix GitHub link on posts

### DIFF
--- a/src/views/blog-post/blog-post.astro
+++ b/src/views/blog-post/blog-post.astro
@@ -46,7 +46,7 @@ const {
 	Content: MarkdownInstance<any>["Content"];
 };
 
-const GHLink = `https://github.com/${siteMetadata.repoPath}/tree/main${siteMetadata.relativeToPosts}/${post.slug}/index.md`;
+const GHLink = `https://github.com/${siteMetadata.repoPath}/tree/main/content/${post.path}/index.md`;
 ---
 
 <script>


### PR DESCRIPTION
Fixes the issue in #1072, where you'd land on a 404 when clicking to view the post on GitHub.

The link was not updated from when the content directory was restructured. Now we can just use the post path to construct the url.

![Screen Recording 2024-04-15 at 9 41 24 AM](https://github.com/unicorn-utterances/unicorn-utterances/assets/14305123/ff46054c-0d49-4b88-b707-2af1cceeed29)
