### PR TITLE
Fix double backtick typo

### DIFF
--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/index.md
@@ -500,7 +500,7 @@ class RenderParagraphComponent implements OnInit {
 }
 ```
 
-Here, we're conditionally rendering our `p` tag using an `ngIf`. But see, under the hood, the `ngIf`` won't initialize the `<p>` tag until _after_ the `ngOnInit` lifecycle method is executed.
+Here, we're conditionally rendering our `p` tag using an `ngIf`. But see, under the hood, `ngIf` won't initialize the `<p>` tag until _after_ the `ngOnInit` lifecycle method is executed.
 
 To solve this, we can do one of two things:
 


### PR DESCRIPTION
Fix the double backtick typo and improve sentence flow (IMHO) by removing `the` before `ngIf`. 

![image](https://github.com/unicorn-utterances/unicorn-utterances/assets/14029543/d82a8c2b-ea05-4249-add9-adf215549f35)
