### PR TITLE
Fix layout shift & focus bug on search filter dropdowns

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -51,9 +51,9 @@ const ButtonWrapper = forwardRef<AllowedElements<AllowedTags> | null, ButtonProp
 			<Wrapper
 				{...props}
 				aria-label={props["aria-label"]}
+				data-focus-visible={isFocusVisible}
 				class={[
 					"button",
-					isFocusVisible ? "focusVisible" : "",
 					className,
 					variant,
 				]

--- a/src/components/pagination/pagination-popover.tsx
+++ b/src/components/pagination/pagination-popover.tsx
@@ -19,6 +19,7 @@ import {
 } from "react-aria";
 import { OverlayTriggerState, useOverlayTriggerState } from "react-stately";
 import { DOMProps } from "@react-types/shared";
+import { useReactAriaScrollGutterHack } from "src/hooks/useReactAriaScrollGutterHack";
 
 function PopupContents(
 	props: Pick<PaginationProps, "page" | "getPageHref" | "softNavigate"> & {
@@ -139,42 +140,13 @@ function PaginationPopover({
 	const { dialogProps, titleProps } = useDialog(overlayProps, dialogRef);
 	const { isFocusVisible } = useFocusVisible();
 
-	/**
-	 * bandaid solution for layout shift
-	 *
-	 * https://github.com/adobe/react-spectrum/issues/5470
-	 * https://github.com/adobe/react-spectrum/issues/1216
-	 * TODO: remove this padding-right whenever we have a better solution or react aria fixes the issue
-	 */
-	useLayoutEffect(() => {
-		const updateStyles = () => {
-			if (CSS.supports("scrollbar-gutter: stable")) {
-				document.documentElement.style.paddingRight = "0";
-			}
-		};
-
-		// immediately invoke to set the styles we want
-		updateStyles();
-
-		// Observe attribute changes to apply styles as needed
-		const mutationObserver = new MutationObserver(updateStyles);
-		mutationObserver.observe(document.documentElement, {
-			attributes: true,
-			attributeFilter: ["style"],
-			subtree: false,
-			attributeOldValue: false,
-		});
-
-		return () => {
-			// Clean up observer on component unmount
-			mutationObserver.disconnect();
-		};
-	}, []);
+	// bandaid solution for layout shift
+	useReactAriaScrollGutterHack();
 
 	return (
 		<Overlay>
 			<div {...underlayProps} className={style.underlay} />
-			
+
 			<div {...popoverProps} ref={popoverRef} className={style.popup}>
 				<svg
 					width="24"

--- a/src/components/select/select.module.scss
+++ b/src/components/select/select.module.scss
@@ -61,6 +61,7 @@
 .option {
 	background: unset;
 	border: unset;
+	outline: none;
 	display: flex;
 	gap: var(--popup_item_gap);
 	align-items: center;
@@ -68,10 +69,13 @@
 	min-height: var(--popup_item_min-height);
 	border-radius: var(--popup_item_corner-radius);
 	min-width: var(--popup_min-width);
+
+	@include transition(background-color);
 }
 
-.option:focus-visible {
+.option[data-focus-visible="true"] {
 	background-color: var(--popup_item_background-color_focused);
+	outline: var(--border-width_focus) solid var(--focus-outline_primary);
 }
 
 .option.selected {

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -11,6 +11,8 @@ import {
 	usePopover,
 	AriaPopoverProps,
 	useButton,
+	useFocusVisible,
+	useFocusRing,
 } from "react-aria";
 import { PropsWithChildren } from "preact/compat";
 import down from "src/icons/chevron_down.svg?raw";
@@ -19,6 +21,7 @@ import styles from "./select.module.scss";
 import checkmark from "src/icons/checkmark.svg?raw";
 import { useRef } from "preact/hooks";
 import { Node } from "@react-types/shared";
+import { useReactAriaScrollGutterHack } from "src/hooks/useReactAriaScrollGutterHack";
 
 export { Item, Section } from "react-stately";
 
@@ -40,6 +43,9 @@ function Popover({
 		},
 		state,
 	);
+
+	// bandaid solution for layout shift
+	useReactAriaScrollGutterHack();
 
 	return (
 		<Overlay>
@@ -78,6 +84,7 @@ export function SelectWithLabel<T extends object>({
 		state,
 		ref,
 	);
+	const { isFocusVisible, focusProps } = useFocusRing();
 
 	const { buttonProps } = useButton(triggerProps, ref);
 
@@ -107,8 +114,10 @@ export function SelectWithLabel<T extends object>({
 				tag="button"
 				type="button"
 				variant={"primary"}
+				isFocusVisible={isFocusVisible}
 				ref={ref}
 				{...buttonProps}
+				{...focusProps}
 				rightIcon={
 					<span
 						style={{
@@ -234,7 +243,7 @@ interface OptionProps {
 
 export function Option({ item, state }: OptionProps) {
 	const ref = useRef<HTMLLIElement>(null);
-	const { optionProps, isDisabled, isSelected, isFocused } = useOption(
+	const { optionProps, isDisabled, isSelected, isFocusVisible } = useOption(
 		{
 			key: item.key,
 		},
@@ -254,6 +263,7 @@ export function Option({ item, state }: OptionProps) {
 			{...optionProps}
 			ref={ref}
 			class={`${styles.option} ${isSelected ? styles.selected : ""}`}
+			data-focus-visible={isFocusVisible}
 		>
 			<span className={`text-style-button-regular ${styles.optionText}`}>
 				{item.rendered}

--- a/src/hooks/useReactAriaScrollGutterHack.ts
+++ b/src/hooks/useReactAriaScrollGutterHack.ts
@@ -1,0 +1,35 @@
+import { useLayoutEffect } from "preact/hooks";
+
+/**
+ * bandaid solution for layout shift
+ *
+ * https://github.com/adobe/react-spectrum/issues/5470
+ * https://github.com/adobe/react-spectrum/issues/1216
+ * TODO: remove this padding-right whenever we have a better solution or react aria fixes the issue
+ */
+export function useReactAriaScrollGutterHack() {
+	useLayoutEffect(() => {
+		const updateStyles = () => {
+			if (CSS.supports("scrollbar-gutter: stable")) {
+				document.documentElement.style.paddingRight = "0";
+			}
+		};
+
+		// immediately invoke to set the styles we want
+		updateStyles();
+
+		// Observe attribute changes to apply styles as needed
+		const mutationObserver = new MutationObserver(updateStyles);
+		mutationObserver.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ["style"],
+			subtree: false,
+			attributeOldValue: false,
+		});
+
+		return () => {
+			// Clean up observer on component unmount
+			mutationObserver.disconnect();
+		};
+	}, []);
+}

--- a/src/styles/button.scss
+++ b/src/styles/button.scss
@@ -90,6 +90,7 @@
 	border: none;
 	cursor: pointer;
 	box-sizing: border-box;
+	outline: none;
 
 	@include transition(color background-color);
 }
@@ -169,8 +170,8 @@
 		background-color: var(--btn_primary_background-color_emphasized_hovered);
 	}
 
-	&:focus-visible,
-	&.focusVisible {
+	&:focus-visible:not([data-focus-visible="false"]),
+	&[data-focus-visible="true"] {
 		outline: var(--btn_primary_focus-outline_width) solid var(--btn_primary_focus-oultine_color);
 		outline-offset: var(--btn_primary_focus-outline_gap);
 	}
@@ -188,8 +189,8 @@
 		background-color: var(--btn_secondary_background-color_emphasized_hovered);
 	}
 
-	&:focus-visible,
-	&.focusVisible {
+	&:focus-visible:not([data-focus-visible="false"]),
+	&[data-focus-visible="true"] {
 		outline: var(--btn_secondary_focus-outline_width) solid var(--btn_secondary_focus-oultine_color);
 		outline-offset: var(--btn_secondary_focus-outline_gap);
 	}
@@ -207,8 +208,8 @@
 		background-color: var(--btn_primary_background-color_default_hovered);
 	}
 
-	&:focus-visible,
-	&.focusVisible {
+	&:focus-visible:not([data-focus-visible="false"]),
+	&[data-focus-visible="true"] {
 		outline: var(--btn_primary_focus-outline_width) solid var(--btn_primary_focus-oultine_color);
 		outline-offset: var(--btn_primary_focus-outline_gap);
 	}
@@ -226,8 +227,8 @@
 		background-color: var(--btn_secondary_background-color_default_hovered);
 	}
 
-	&:focus-visible,
-	&.focusVisible {
+	&:focus-visible:not([data-focus-visible="false"]),
+	&[data-focus-visible="true"] {
 		outline: var(--btn_secondary_focus-outline_width) solid var(--btn_secondary_focus-oultine_color);
 		outline-offset: var(--btn_secondary_focus-outline_gap);
 	}


### PR DESCRIPTION
- Separates the scroll gutter hack into a `useReactAriaScrollGutterHack` hook
- Adds `useFocusRing()` to the `<Select>` component buttons and option elements to conditionally apply the focus styling