### PR TITLE
Fix missing commas in word count on post card

### DIFF
--- a/src/components/post-card/post-card.tsx
+++ b/src/components/post-card/post-card.tsx
@@ -51,7 +51,7 @@ function PostCardMeta({ post, authors }: PostCardProps) {
 							•
 						</span>
 						<span className={`text-style-body-small ${style.wordCount}`}>
-							{post.wordCount} words
+							{post.wordCount.toLocaleString("en")} words
 						</span>
 					</span>
 				</p>


### PR DESCRIPTION
Fixes the word count being placed in post cards without `.toLocaleString()` (which adds the comma in its other locations)