### PR TITLE
fix: styling for inline code blocks should wrap for epubs

### DIFF
--- a/build-scripts/epubs/epub.css
+++ b/build-scripts/epubs/epub.css
@@ -30,7 +30,10 @@ code .line::before {
 	opacity: 0.8;
 }
 
-pre.shiki code {
+/**
+ * Apply to code blocks, Shiki and non-Shiki alike
+ */
+pre code {
 	white-space: normal;
 }
 


### PR DESCRIPTION
Fixes:

![](https://github.com/unicorn-utterances/unicorn-utterances/assets/9100169/aece835a-8a95-4b12-809b-53fab773d490)
