### PR TITLE
FFG Angular link updates

### DIFF
--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-accessing-children-challenge-115/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-accessing-children-challenge-115/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-accessing-children-challenge-115/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-accessing-children-challenge-115/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-adding-children-dynamically-114/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-adding-children-dynamically-114/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-adding-children-dynamically-114/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-adding-children-dynamically-114/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-children-in-loop-113/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-children-in-loop-113/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-children-in-loop-113/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-children-in-loop-113/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-contentchild-112/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-contentchild-112/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-contentchild-112/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-contentchild-112/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-counting-component-children-112/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-counting-component-children-112/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-counting-component-children-112/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-counting-component-children-112/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-pass-val-to-projected-content-114/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-pass-val-to-projected-content-114/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-pass-val-to-projected-content-114/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-pass-val-to-projected-content-114/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-why-ngaftercontentinit-112/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-why-ngaftercontentinit-112/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-why-ngaftercontentinit-112/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/ffg-fundamentals-angular-why-ngaftercontentinit-112/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-accessing-children/index.md
@@ -128,7 +128,7 @@ In [our "Dynamic HTML" chapter, we talked about how you're able to assign a "var
 <div #templVar></div>
 ```
 
-In our previous example, we used them to conditionally render content using `ngIf`, but these template tags aren't simply useful in `ngIf` usage. We can also use them in a myriad of programmatic queries, such as [`ContentChild`](https://angular.io/api/core/ContentChild).
+In our previous example, we used them to conditionally render content using `ngIf`, but these template tags aren't simply useful in `ngIf` usage. We can also use them in a myriad of programmatic queries, such as [`ContentChild`](https://angular.dev/api/core/ContentChild).
 
 `ContentChild` is a way to query the projected content within [`ng-content`](/posts/ffg-fundamentals-passing-children) from JavaScript.
 
@@ -171,7 +171,7 @@ class AppComponent {}
 <iframe data-frame-title="Angular ContentChild - StackBlitz" src="uu-code:./ffg-fundamentals-angular-contentchild-112?template=node&embed=1&file=src%2Fmain.ts"></iframe>
 <!-- ::end:no-ebook -->
 
-Here, we're querying for the template tag `childItem` within the project content by using [the `ContentChild` decorator](https://angular.io/api/core/ContentChild).
+Here, we're querying for the template tag `childItem` within the project content by using [the `ContentChild` decorator](https://angular.dev/api/core/ContentChild).
 
 `ContentChild` then returns [a TypeScript generic type](/posts/typescript-type-generics) of `ElementRef`.
 
@@ -217,7 +217,7 @@ This can be solved by either:
 
 While `ContentChild` is useful for querying against a single item being projected, what if we wanted to query against multiple items being projected?
 
-This is where [`ContentChildren`](https://angular.io/api/core/ContentChildren) comes into play:
+This is where [`ContentChildren`](https://angular.dev/api/core/ContentChildren) comes into play:
 
 ```angular-ts
 import {
@@ -264,7 +264,7 @@ class AppComponent {}
 <iframe data-frame-title="Angular Counting Component Children - StackBlitz" src="uu-code:./ffg-fundamentals-angular-counting-component-children-112?template=node&embed=1&file=src%2Fmain.ts"></iframe>
 <!-- ::end:no-ebook -->
 
-`ContentChildren` returns an array-like [`QueryList`](https://angular.io/api/core/QueryList) generic type. You can then access the properties of `children` inside of the template itself, like what we're doing with `children.length`.
+`ContentChildren` returns an array-like [`QueryList`](https://angular.dev/api/core/QueryList) generic type. You can then access the properties of `children` inside of the template itself, like what we're doing with `children.length`.
 
 ## Vue
 

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-alert-67/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-alert-67/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-alert-67/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-alert-67/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-challenge-69/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-challenge-69/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-challenge-69/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-challenge-69/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-intro-66/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-intro-66/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-intro-66/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-intro-66/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-log-67/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-log-67/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-log-67/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-comp-ref-log-67/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-focused-comp-ref-68/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-focused-comp-ref-68/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-focused-comp-ref-68/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-component-reference/ffg-fundamentals-angular-focused-comp-ref-68/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-app-wide-providers-88/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-app-wide-providers-88/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-app-wide-providers-88/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-app-wide-providers-88/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-change-val-after-inject-84/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-change-val-after-inject-84/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-change-val-after-inject-84/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-change-val-after-inject-84/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-change-val-from-child-85/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-change-val-from-child-85/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-change-val-from-child-85/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-change-val-from-child-85/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-data-consistency-91/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-data-consistency-91/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-data-consistency-91/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-data-consistency-91/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-data-variance-92/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-data-variance-92/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-data-variance-92/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-data-variance-92/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-default-vals-for-optional-87/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-default-vals-for-optional-87/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-default-vals-for-optional-87/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-default-vals-for-optional-87/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-basic-values-object-83/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-basic-values-object-83/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-basic-values-object-83/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-basic-values-object-83/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-basic-values-string-82/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-basic-values-string-82/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-basic-values-string-82/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-basic-values-string-82/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-challenge-93/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-challenge-93/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-challenge-93/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-challenge-93/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-injectable-83/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-injectable-83/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-injectable-83/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-di-injectable-83/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-finding-specific-vals-90/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-finding-specific-vals-90/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-finding-specific-vals-90/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-finding-specific-vals-90/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-optional-injected-vals-86/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-optional-injected-vals-86/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-optional-injected-vals-86/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-optional-injected-vals-86/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-optional-injected-vals-err-86/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-optional-injected-vals-err-86/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-optional-injected-vals-err-86/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-optional-injected-vals-err-86/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-overwriting-specificity-89/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-overwriting-specificity-89/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-overwriting-specificity-89/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/ffg-fundamentals-angular-overwriting-specificity-89/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dependency-injection/index.md
@@ -1308,7 +1308,7 @@ const App = () => {
 
 While other frameworks require you to explicitly provide your dependency-injected values at the root of your application, Angular does not.
 
-Remember when we used `@Injectable` to mark a class as an injectable class instance? Well, this decorator has a trick up its sleeve: [the `providedIn` property](https://angular.io/guide/providers#providedin-and-ngmodules).
+Remember when we used `@Injectable` to mark a class as an injectable class instance? Well, this decorator has a trick up its sleeve: [the `providedIn` property](https://angular.dev/guide/ngmodules/providers#providing-a-service).
 
 When you pass `{providedIn: 'root'}` to the `@Injectable` decorator, you no longer have to explicitly place the class inside a `providers` array; instead, Angular will simply provide this class to the root of your application.
 

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-built-in-pipes-47/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-built-in-pipes-47/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-built-in-pipes-47/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-built-in-pipes-47/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-computed-values-47/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-computed-values-47/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-computed-values-47/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-computed-values-47/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-derived-challenge-49/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-derived-challenge-49/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-derived-challenge-49/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-derived-challenge-49/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-multi-input-pipes-47/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-multi-input-pipes-47/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-multi-input-pipes-47/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-multi-input-pipes-47/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-non-prop-derived-48/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-non-prop-derived-48/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-non-prop-derived-48/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-non-prop-derived-48/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-prop-listening-46/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-prop-listening-46/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-prop-listening-46/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-prop-listening-46/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-refreshing-file-date-45/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-refreshing-file-date-45/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-refreshing-file-date-45/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/ffg-fundamentals-angular-refreshing-file-date-45/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-derived-values/index.md
@@ -455,7 +455,7 @@ class FileDateComponent {
 
 Luckily, Angular's all-in-one methodology means that there's a slew of pipes that the Angular team has written for us. One such pipe is actually a date formatting pipe. We can remove our own implementation in favor of one built right into Angular!
 
-To use the built-in pipes, we need to import them from `CommonModule` into the component. In this case, the pipe we're looking to use is called [`DatePipe`](https://angular.io/api/common/DatePipe). This provided date pipe is, expectedly, called `date` when used in the template and can be used like so:
+To use the built-in pipes, we need to import them from `CommonModule` into the component. In this case, the pipe we're looking to use is called [`DatePipe`](https://angular.dev/api/common/DatePipe). This provided date pipe is, expectedly, called `date` when used in the template and can be used like so:
 
 ```angular-ts
 import { DatePipe } from "@angular/common";

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-basic-directives-105/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-basic-directives-105/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-basic-directives-105/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-basic-directives-105/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-conditionally-rendered-ui-110/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-conditionally-rendered-ui-110/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-conditionally-rendered-ui-110/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-conditionally-rendered-ui-110/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-default-keys-in-context-110/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-default-keys-in-context-110/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-default-keys-in-context-110/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-default-keys-in-context-110/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directive-el-reference-104/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directive-el-reference-104/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directive-el-reference-104/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directive-el-reference-104/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directive-side-effects-106/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directive-side-effects-106/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directive-side-effects-106/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directive-side-effects-106/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directives-challenge-111/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directives-challenge-111/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directives-challenge-111/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directives-challenge-111/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directives-pass-js-data-108/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directives-pass-js-data-108/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directives-pass-js-data-108/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-directives-pass-js-data-108/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-ng-template-directive-110/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-ng-template-directive-110/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-ng-template-directive-110/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-ng-template-directive-110/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-ng-template-inject-el-110/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-ng-template-inject-el-110/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-ng-template-inject-el-110/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-ng-template-inject-el-110/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-data-to-template-110/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-data-to-template-110/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-data-to-template-110/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-data-to-template-110/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-directives-data-107/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-directives-data-107/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-directives-data-107/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-directives-data-107/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-multiple-values-109/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-multiple-values-109/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-multiple-values-109/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-multiple-values-109/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-template-data-no-div-110/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-template-data-no-div-110/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-template-data-no-div-110/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-pass-template-data-no-div-110/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-rendered-template-data-110/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-rendered-template-data-110/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-rendered-template-data-110/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-rendered-template-data-110/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-structural-directives-110/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-structural-directives-110/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-structural-directives-110/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-structural-directives-110/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-template-from-directive-110/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-template-from-directive-110/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-template-from-directive-110/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-template-from-directive-110/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-viewcontainer-template-110/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-viewcontainer-template-110/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-viewcontainer-template-110/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-viewcontainer-template-110/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-what-is-a-directive-104/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-what-is-a-directive-104/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-what-is-a-directive-104/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/ffg-fundamentals-angular-what-is-a-directive-104/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-directives/index.md
@@ -1031,7 +1031,7 @@ class AppComponent {}
 > Because we're expecting Angular to pass an `ng-template` reference to `ItemDirective`, if we use the `item` attribute on anything other than a template, we'll end up with the following error:
 >
 > ```
-> Error: NG0201: No provider for TemplateRef found. Find more at https://angular.io/errors/NG0201
+> Error: NG0201: No provider for TemplateRef found. Find more at https://angular.dev/errors/NG0201
 > ```
 
 Doing this, we'll see that we get the `TemplateRef` as expected in our console:
@@ -1119,7 +1119,7 @@ AppCmp.ɵcmp = i0.ɵɵdefineComponent({
 })();
 ```
 
-> This code sample is taken from [the "How the Angular Compiler Works" article written by the Angular team](https://blog.angular.io/how-the-angular-compiler-works-42111f9d2549).
+> This code sample is taken from [the "How the Angular Compiler Works" article written by the Angular team](https://blog.angular.dev/how-the-angular-compiler-works-42111f9d2549).
 >
 > I explain how this code gets ran in detail in [my "Angular Internals: How Reactivity Works with Zone.js" article](/posts/angular-internals-zonejs).
 
@@ -1163,7 +1163,7 @@ Might be seen by Angular as such:
 
 ### Using ViewContainer to Render a Template {#using-viewcontainer-to-render-a-template}
 
-This isn't just theoretically helpful to learn, though; we're able to tell Angular that we want to gain access to the underlying `ViewContainer` via a [`ViewContainerRef`](https://angular.io/api/core/ViewContainerRef).
+This isn't just theoretically helpful to learn, though; we're able to tell Angular that we want to gain access to the underlying `ViewContainer` via a [`ViewContainerRef`](https://angular.dev/api/core/ViewContainerRef).
 
 Similarly, as a template is handled by an `EmbeddedView` in Angular's compiler, we can programmatically create an Embedded View using `ViewContainerRef.createEmbeddedView`:
 

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-conditional-branches-19/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-conditional-branches-19/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-conditional-branches-19/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-conditional-branches-19/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-conditional-date-18/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-conditional-date-18/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-conditional-date-18/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-conditional-date-18/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-conditional-render-17/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-conditional-render-17/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-conditional-render-17/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-conditional-render-17/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-dynamic-challenge-25/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-dynamic-challenge-25/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-dynamic-challenge-25/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-dynamic-challenge-25/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-keyed-demo-22/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-keyed-demo-22/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-keyed-demo-22/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-keyed-demo-22/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-rendering-lists-20/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-rendering-lists-20/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-rendering-lists-20/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-rendering-lists-20/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-unkeyed-demo-21/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-unkeyed-demo-21/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-unkeyed-demo-21/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-unkeyed-demo-21/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-using-it-together-24/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-using-it-together-24/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-using-it-together-24/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/ffg-fundamentals-angular-using-it-together-24/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-dynamic-html/index.md
@@ -1311,7 +1311,7 @@ Here, we're using the `key` property to tell React which `li` is related to whic
 
 ### Angular
 
-While Angular doesn't have quite the same API for `key` as React and Vue, Angular instead uses a [`trackBy` method](https://angular.io/api/core/TrackByFunction) to figure out which item is which.
+While Angular doesn't have quite the same API for `key` as React and Vue, Angular instead uses a [`trackBy` method](https://angular.dev/api/core/TrackByFunction) to figure out which item is which.
 
 ```angular-ts {9,17-19}
 @Component({

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-add-event-listener-62/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-add-event-listener-62/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-add-event-listener-62/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-add-event-listener-62/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-after-view-init-62/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-after-view-init-62/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-after-view-init-62/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-after-view-init-62/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-element-ref-challenge-65/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-element-ref-challenge-65/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-element-ref-challenge-65/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-element-ref-challenge-65/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-intro-context-menu-61/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-intro-context-menu-61/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-intro-context-menu-61/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-intro-context-menu-61/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-multi-element-ref-63/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-multi-element-ref-63/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-multi-element-ref-63/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-multi-element-ref-63/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-real-world-usage-64/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-real-world-usage-64/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-real-world-usage-64/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-real-world-usage-64/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-static-62/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-static-62/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-static-62/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-static-62/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-view-child-62/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-view-child-62/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-view-child-62/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-element-reference/ffg-fundamentals-angular-view-child-62/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-displaying-the-error-80/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-displaying-the-error-80/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-displaying-the-error-80/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-displaying-the-error-80/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-error-challenge-81/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-error-challenge-81/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-error-challenge-81/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-error-challenge-81/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-error-in-constructor-76/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-error-in-constructor-76/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-error-in-constructor-76/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-error-in-constructor-76/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-error-intro-70/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-error-intro-70/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-error-intro-70/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-error-intro-70/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-errors-in-lifecycles-76/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-errors-in-lifecycles-76/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-errors-in-lifecycles-76/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-errors-in-lifecycles-76/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-event-error-72/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-event-error-72/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-event-error-72/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-event-error-72/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-fallback-ui-79/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-fallback-ui-79/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-fallback-ui-79/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-fallback-ui-79/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-logging-the-error-77/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-logging-the-error-77/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-logging-the-error-77/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-logging-the-error-77/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-render-error-71/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-render-error-71/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-render-error-71/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-error-handling/ffg-fundamentals-angular-render-error-71/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-attribute-binding-10/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-attribute-binding-10/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-attribute-binding-10/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-attribute-binding-10/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-component-hierarchy-4/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-component-hierarchy-4/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-component-hierarchy-4/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-component-hierarchy-4/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-component-reuse-3/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-component-reuse-3/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-component-reuse-3/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-component-reuse-3/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-display-8/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-display-8/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-display-8/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-display-8/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-event-binding-14/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-event-binding-14/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-event-binding-14/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-event-binding-14/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-extracted-logic-6/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-extracted-logic-6/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-extracted-logic-6/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-extracted-logic-6/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-inline-logic-5/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-inline-logic-5/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-inline-logic-5/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-inline-logic-5/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-intro-challenge-16/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-intro-challenge-16/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-intro-challenge-16/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-intro-challenge-16/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-live-display-9/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-live-display-9/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-live-display-9/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-live-display-9/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-multi-props-12/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-multi-props-12/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-multi-props-12/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-multi-props-12/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-object-props-13/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-object-props-13/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-object-props-13/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-object-props-13/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-outputs-15/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-outputs-15/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-outputs-15/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-outputs-15/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-parent-child-2/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-parent-child-2/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-parent-child-2/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-parent-child-2/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-props-11/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-props-11/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-props-11/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-props-11/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-rendering-1/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-rendering-1/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-rendering-1/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-rendering-1/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-side-effect-intro-7/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-side-effect-intro-7/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-side-effect-intro-7/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-intro-to-components/ffg-fundamentals-angular-side-effect-intro-7/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-broken-file-table-58/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-broken-file-table-58/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-broken-file-table-58/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-broken-file-table-58/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-file-table-58/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-file-table-58/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-file-table-58/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-file-table-58/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-file-table-container-59/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-file-table-container-59/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-file-table-container-59/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-file-table-container-59/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-named-children-57/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-named-children-57/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-named-children-57/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-named-children-57/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-no-passing-demo-54/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-no-passing-demo-54/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-no-passing-demo-54/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-no-passing-demo-54/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-passing-basic-children-55/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-passing-basic-children-55/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-passing-basic-children-55/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-passing-basic-children-55/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-passing-challenge-60/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-passing-challenge-60/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-passing-challenge-60/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-passing-challenge-60/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-use-with-other-features-56/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-use-with-other-features-56/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-use-with-other-features-56/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/ffg-fundamentals-angular-use-with-other-features-56/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-passing-children/index.md
@@ -406,7 +406,7 @@ class ToggleButtonListComponent {}
 <iframe data-frame-title="Angular Passing Basic Children - StackBlitz" src="uu-code:./ffg-fundamentals-angular-passing-basic-children-55?template=node&embed=1&file=src%2Fmain.ts"></iframe>
 <!-- ::end:no-ebook -->
 
-Because `ng-content` is built into [Angular's compiler](https://blog.angular.io/how-the-angular-compiler-works-42111f9d2549), we do not need to import anything into our component to use the feature.
+Because `ng-content` is built into [Angular's compiler](https://blog.angular.dev/how-the-angular-compiler-works-42111f9d2549), we do not need to import anything into our component to use the feature.
 
 ### Vue
 

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-app-wide-portals-96/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-app-wide-portals-96/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-app-wide-portals-96/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-app-wide-portals-96/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-buggy-dialog-94/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-buggy-dialog-94/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-buggy-dialog-94/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-buggy-dialog-94/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-html-wide-portals-97/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-html-wide-portals-97/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-html-wide-portals-97/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-html-wide-portals-97/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-local-ng-template-95/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-local-ng-template-95/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-local-ng-template-95/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-local-ng-template-95/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-local-portals-95/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-local-portals-95/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-local-portals-95/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-local-portals-95/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-portals-challenge-99/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-portals-challenge-99/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-portals-challenge-99/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-portals-challenge-99/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-portals-pre-challenge-98/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-portals-pre-challenge-98/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-portals-pre-challenge-98/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/ffg-fundamentals-angular-portals-pre-challenge-98/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-portals/index.md
@@ -919,7 +919,7 @@ This `cdkPortalOutlet` is where the captured HTML is then projected into.
 >
 > The reason for this occurring is quite complex (and out of scope), but you can read about it more with the following resources:
 >
-> - [Official Angular video explaining "Expression has changed"](https://angular.io/errors/NG0100)
+> - [Official Angular video explaining "Expression has changed"](https://angular.dev/errors/NG0100)
 > - [Everything you need to know about the `ExpressionChangedAfterItHasBeenCheckedError` error](https://indepth.dev/posts/1001/everything-you-need-to-know-about-the-expressionchangedafterithasbeencheckederror-error)
 > - [Angular Debugging "Expression has changed after it was checked": Simple Explanation (and Fix)](https://blog.angular-university.io/angular-debugging/)
 

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-preface/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-preface/index.md
@@ -65,9 +65,9 @@ While ecosystem size is great and all, it's nothing without a swath of tools at 
 
 Luckily, for all three frameworks alike, myriads of tools build upon their foundation.
 
-For example, do you want to add [Static Site Generation or Server Side Rendering](https://unicorn-utterances.com/posts/what-is-ssr-and-ssg) to your projects to enhance SEO? No problem: React has [Next.js](https://nextjs.org/) and [Gatsby](https://gatsbyjs.com/), Angular has [Angular Universal](https://angular.io/guide/universal) and [Analog](https://analogjs.org/), and Vue has [NuxtJS](https://nuxtjs.org/) and [VuePress](https://vuepress.vuejs.org/).
+For example, do you want to add [Static Site Generation or Server Side Rendering](https://unicorn-utterances.com/posts/what-is-ssr-and-ssg) to your projects to enhance SEO? No problem: React has [Next.js](https://nextjs.org/) and [Gatsby](https://gatsbyjs.com/), Angular has [Angular SSR](https://angular.dev/guide/ssr) and [Analog](https://analogjs.org/), and Vue has [NuxtJS](https://nuxtjs.org/) and [VuePress](https://vuepress.vuejs.org/).
 
-Want to add a router to add multiple pages to your apps? React has the ["React Router"](https://reactrouter.com/), [Angular has its built-in router](https://angular.io/guide/router), and Vue has the ["Vue Router"](https://router.vuejs.org/).
+Want to add a router to add multiple pages to your apps? React has the ["React Router"](https://reactrouter.com/), [Angular has its built-in router](https://angular.dev/guide/routing), and Vue has the ["Vue Router"](https://router.vuejs.org/).
 
 Do you want to add global state management, making sharing data across an entire app easier? React has [Redux](https://redux.js.org/), Angular has [NgRx](https://ngrx.io/), and Vue has [Vuex](https://vuex.vuejs.org/).
 
@@ -87,7 +87,7 @@ React is built by Meta and powers all of its major applications. Moreover, the c
 
 However, when most mention "React," they tend to talk about the React ecosystem at large. See, the core maintainers of React itself tend to remain focused on a small subsection of tooling. Instead, they rely on external groups, like [Remix](https://remix.run/) and [Vercel](https://vercel.com/), to provide libraries that are often integral to application development.
 
-On the other hand, Angular is fully funded and supported by Google. They build a substantial portion of their major websites on top of the framework and, as a result, have a vested interest in continuing and up-keeping development. Continuing the differences from React, the Angular core team maintains a slew of helper libraries that provide everything from an [HTTP call layer](https://angular.io/guide/http) to [form validation](https://angular.io/guide/forms-overview).
+On the other hand, Angular is fully funded and supported by Google. They build a substantial portion of their major websites on top of the framework and, as a result, have a vested interest in continuing and up-keeping development. Continuing the differences from React, the Angular core team maintains a slew of helper libraries that provide everything from an [HTTP call layer](https://angular.dev/guide/http) to [form validation](https://angular.dev/guide/forms).
 
 Vue is often seen as the odd one out when talking about funding. Vue's development is driven by an independent team crowd-funded by a diverse pool of groups and individuals. However, while it's unclear how much money they bring in, it is clear that there are significant-sized financial contributors involved, [such as Alibaba, Baidu, Xiaomi, and more](https://medium.com/the-vue-point/the-state-of-vue-1655e10a340a).
 
@@ -269,11 +269,11 @@ Despite the similarities in their names, these two are entirely distinct entitie
 
 Angular has two ways of defining component imports: modules and standalone components. **We'll be using Standalone components**.
 
-When Angular was first released, it launched with [the concept of NgModules](https://angular.io/guide/ngmodules). Very broadly, this was an API that allowed you to namespace a collection of related UI items (called components, more on that in the next chapter) into so-called "modules".
+When Angular was first released, it launched with [the concept of NgModules](https://angular.dev/guide/ngmodules). Very broadly, this was an API that allowed you to namespace a collection of related UI items (called components, more on that in the next chapter) into so-called "modules".
 
 While these modules worked, they were primarily dissimilar from alternatives in other related frameworks like React and Vue. Further, a common complaint against them is that they were overly complicated with minimal yield.
 
-[Starting with an experimental release in Angular 14](https://github.com/angular/angular/discussions/45554) (and [being marked as stable in Angular 15](https://blog.angular.io/angular-v15-is-now-available-df7be7f2f4c8)), Angular introduced the "standalone components" API. This was a more similar method of importing similar UI elements into one another and is what our book will be using.
+[Starting with an experimental release in Angular 14](https://github.com/angular/angular/discussions/45554) (and [being marked as stable in Angular 15](https://blog.angular.dev/angular-v15-is-now-available-df7be7f2f4c8)), Angular introduced the "standalone components" API. This was a more similar method of importing similar UI elements into one another and is what our book will be using.
 
 > Keep in mind that if you're working with an older Angular codebase, it's likely to still be using modules.
 
@@ -298,7 +298,7 @@ Similarly, Angular 15.1 introduced a method for using self-closing tags with com
 
 #### We Won't Be Learning "Signals" {#no-signals}
 
-[Early in 2023, the Angular team announced that they would be introducing a new method of programming in Angular called "Signals"](https://angular.io/guide/signals). To pull back the curtains a bit, this book began life in January 2022, and by the time the book had launched, parts of the signals API had not yet been introduced as a stable API within the Angular ecosystem.
+[Early in 2023, the Angular team announced that they would be introducing a new method of programming in Angular called "Signals"](https://angular.dev/guide/signals). To pull back the curtains a bit, this book began life in January 2022, and by the time the book had launched, parts of the signals API had not yet been introduced as a stable API within the Angular ecosystem.
 
 While I believe Signals are the way forward for the Angular community, delaying the book further and waiting for this API to stabilize was simply not viable. As such, **this book will not teach Angular signals** at this time.
 

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-composing-logic-102/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-composing-logic-102/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-composing-logic-102/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-composing-logic-102/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-shared-data-storage-100/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-shared-data-storage-100/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-shared-data-storage-100/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-shared-data-storage-100/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-shared-logic-challenge-103/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-shared-logic-challenge-103/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-shared-logic-challenge-103/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-shared-logic-challenge-103/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-sharing-side-effect-101/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-sharing-side-effect-101/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-sharing-side-effect-101/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/ffg-fundamentals-angular-sharing-side-effect-101/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-shared-component-logic/index.md
@@ -352,7 +352,7 @@ class AppComponent {
 <iframe data-frame-title="Angular Sharing Side Effect - StackBlitz" src="uu-code:./ffg-fundamentals-angular-sharing-side-effect-101?template=node&embed=1&file=src%2Fmain.ts"></iframe>
 <!-- ::end:no-ebook -->
 
-> This code isn't ideal; the Angular team knows this. This is why they're working on introducing a new method of side effect handling (and data storage) [called "Signals"](https://angular.io/guide/signals). At the time of writing, Signals are still in the experimental phase, but they're worth keeping an eye on.
+> This code isn't ideal; the Angular team knows this. This is why they're working on introducing a new method of side effect handling (and data storage) [called "Signals"](https://angular.dev/guide/signals). At the time of writing, Signals are still in the experimental phase, but they're worth keeping an eye on.
 
 > While this is the only method we'll be looking at in this book for writing this code, [Lars Gyrup Brink Nielsen showcased how we could improve this code using RxJS in another article on the Unicorn Utterances site.](/posts/angular-extend-class#The-Angular-way-to-fix-the-code)
 

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-alarm-33/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-alarm-33/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-alarm-33/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-alarm-33/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-clock-32/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-clock-32/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-clock-32/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-clock-32/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-event-bubbling-30/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-event-bubbling-30/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-event-bubbling-30/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-event-bubbling-30/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-window-size-28/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-window-size-28/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-window-size-28/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-broken-window-size-28/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-effects-challenge-44/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-effects-challenge-44/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-effects-challenge-44/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-effects-challenge-44/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-event-bubbling-31/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-event-bubbling-31/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-event-bubbling-31/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-event-bubbling-31/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-hidden-memory-leak-events-35/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-hidden-memory-leak-events-35/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-hidden-memory-leak-events-35/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-hidden-memory-leak-events-35/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-hidden-memory-leak-functions-36/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-hidden-memory-leak-functions-36/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-hidden-memory-leak-functions-36/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-hidden-memory-leak-functions-36/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-in-component-side-effects-39/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-in-component-side-effects-39/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-in-component-side-effects-39/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-in-component-side-effects-39/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-initial-render-demo-26/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-initial-render-demo-26/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-initial-render-demo-26/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-initial-render-demo-26/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-initial-render-on-init-27/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-initial-render-on-init-27/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-initial-render-on-init-27/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-initial-render-on-init-27/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-leaking-window-size-29/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-leaking-window-size-29/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-leaking-window-size-29/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-leaking-window-size-29/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-mutable-update-title-43/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-mutable-update-title-43/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-mutable-update-title-43/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-mutable-update-title-43/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-stateful-update-title-42/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-stateful-update-title-42/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-stateful-update-title-42/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-stateful-update-title-42/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-unmounting-34/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-unmounting-34/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-unmounting-34/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-unmounting-34/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-update-title-41/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-update-title-41/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-update-title-41/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/ffg-fundamentals-angular-update-title-41/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/index.md
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-side-effects/index.md
@@ -2576,7 +2576,7 @@ useEffect(() => {
 
 ## Angular
 
-_Today_, Angular does not include a method for tracking internal state changes. However, a future version of Angular will introduce the concept of ["Signals"](https://angular.io/guide/signals), which will allow us to watch changes made to a variable, regardless of where the state change comes from.
+_Today_, Angular does not include a method for tracking internal state changes. However, a future version of Angular will introduce the concept of ["Signals"](https://angular.dev/guide/signals), which will allow us to watch changes made to a variable, regardless of where the state change comes from.
 
 Instead, we'll have to use a `setTitle` function that calls the variable mutation as well as sets the `document.title` as a side effect:
 

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-stacked-transparent-52/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-stacked-transparent-52/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-stacked-transparent-52/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-stacked-transparent-52/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-transparent-challenge-53/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-transparent-challenge-53/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-transparent-challenge-53/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-transparent-challenge-53/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-transparent-files-after-51/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-transparent-files-after-51/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-transparent-files-after-51/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-transparent-files-after-51/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-transparent-files-before-50/tsconfig.app.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-transparent-files-before-50/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-transparent-files-before-50/tsconfig.json
+++ b/content/crutchcorn/collections/framework-field-guide-fundamentals/posts/ffg-fundamentals-transparent-elements/ffg-fundamentals-angular-transparent-files-before-50/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/collections/react-beyond-the-render/posts/what-is-reactivity/angular-reactivity/tsconfig.app.json
+++ b/content/crutchcorn/collections/react-beyond-the-render/posts/what-is-reactivity/angular-reactivity/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/collections/react-beyond-the-render/posts/what-is-reactivity/angular-reactivity/tsconfig.json
+++ b/content/crutchcorn/collections/react-beyond-the-render/posts/what-is-reactivity/angular-reactivity/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/alert-on-destroy/tsconfig.app.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/alert-on-destroy/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/alert-on-destroy/tsconfig.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/alert-on-destroy/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/do-nothing-directive/tsconfig.app.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/do-nothing-directive/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/do-nothing-directive/tsconfig.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/do-nothing-directive/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/listen-for-events-inject/tsconfig.app.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/listen-for-events-inject/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/listen-for-events-inject/tsconfig.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/listen-for-events-inject/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/listen-for-events/tsconfig.app.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/listen-for-events/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/listen-for-events/tsconfig.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/listen-for-events/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/log-element/tsconfig.app.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/log-element/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/log-element/tsconfig.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/log-element/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/red-directive/tsconfig.app.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/red-directive/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/red-directive/tsconfig.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/red-directive/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/red-div-component/tsconfig.app.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/red-div-component/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/red-div-component/tsconfig.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/red-div-component/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/red-dynamic-host-directive/tsconfig.app.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/red-dynamic-host-directive/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/red-dynamic-host-directive/tsconfig.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/red-dynamic-host-directive/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/red-host-directive/tsconfig.app.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/red-host-directive/tsconfig.app.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"extends": "./tsconfig.json",
 	"compilerOptions": {

--- a/content/crutchcorn/posts/angular-dynamic-host-usage/red-host-directive/tsconfig.json
+++ b/content/crutchcorn/posts/angular-dynamic-host-usage/red-host-directive/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
 	"compileOnSave": false,
 	"compilerOptions": {


### PR DESCRIPTION
This PR updates all of the links in FFG away from the deprecated angular.io domain and to the new angular.dev domain